### PR TITLE
minor

### DIFF
--- a/template/src/vibetuner/frontend/oauth.py
+++ b/template/src/vibetuner/frontend/oauth.py
@@ -21,6 +21,7 @@ _PROVIDERS: dict[str, OauthProviderModel] = {}
 def register_oauth_provider(name: str, provider: OauthProviderModel) -> None:
     _PROVIDERS[name] = provider
     PROVIDER_IDENTIFIERS[name] = provider.identifier
+    _oauth_config.update(**provider.config)
     register_kwargs = {"client_kwargs": provider.client_kwargs, **provider.params}
     oauth.register(name, overwrite=True, **register_kwargs)
 
@@ -54,8 +55,12 @@ class Config:
     def get(self, key, default=None):
         return self._data.get(key, default)
 
+    def update(self, **kwargs):
+        self._data.update(kwargs)
 
-oauth = OAuth(Config())
+
+_oauth_config = Config()
+oauth = OAuth(_oauth_config)
 
 PROVIDER_IDENTIFIERS: dict[str, str] = {}
 


### PR DESCRIPTION
- ─────┬──────────────────────────────────────────────────────────────────────────      │ STDIN      │ Size: - ─────┼──────────────────────────────────────────────────────────────────────────    1 │ fix: propagate OAuth credentials to client registration    2 │    3 │ OAuth provider credentials (client_id/secret) were being discarded during    4 │ registration, causing authorize_redirect/authorize_access_token to fail at    5 │ runtime. Now properly merging provider.config into OAuth Config instance.    6 │    7 │ 🤖 Generated with [Claude Code](https://claude.com/claude-code)    8 │    9 │ Co-Authored-By: Claude <noreply@anthropic.com> ─────┴──────────────────────────────────────────────────────────────────────────