### PR TITLE
Improve dark mode link readability

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -52,13 +52,26 @@
   color: #7a2f45;
 }
 
-/* Custom link colors for dark mode - lighter for better readability */
+/* Custom link colors for dark mode - use white-smoke for readability */
 [data-md-color-scheme="slate"] .md-content a {
-  color: #e89bb3;
+  color: var(--white-smoke);
 }
 
 [data-md-color-scheme="slate"] .md-content a:hover {
-  color: #f5b6ca;
+  color: var(--taupe-gray);
+}
+
+/* Sidebar navigation links in dark mode */
+[data-md-color-scheme="slate"] .md-nav__link {
+  color: var(--white-smoke);
+}
+
+[data-md-color-scheme="slate"] .md-nav__link:hover {
+  color: var(--taupe-gray);
+}
+
+[data-md-color-scheme="slate"] .md-nav__link--active {
+  color: var(--white-smoke);
 }
 
 /* Custom header logo sizing */


### PR DESCRIPTION
## Summary
- Use white-smoke color for all links in dark mode for better readability
- Apply consistent styling to content links, navigation links, and active states
- Maintain wine color for links in light mode

## Test plan
- [ ] Verify links are visible and readable in dark mode
- [ ] Confirm light mode links remain unchanged (wine color)
- [ ] Test hover states in both color schemes
- [ ] Check navigation sidebar links in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)