### PR TITLE
feat: implement conditional builds for package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,69 @@ on:
     types: [published]
 
 jobs:
+  # Detect what changed since last release
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      python-changed: ${{ steps.changes.outputs.python }}
+      js-changed: ${{ steps.changes.outputs.js }}
+      version: ${{ steps.version.outputs.version }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for git diff
+
+      - name: Extract version from release
+        id: version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo "Release version: $TAG"
+
+      - name: Detect changes
+        id: changes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Detecting changes for release $VERSION"
+          
+          # Get previous tag
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          
+          if [ -n "$PREV_TAG" ]; then
+            echo "Comparing $PREV_TAG..$VERSION"
+            
+            # Check Python changes
+            if git diff --name-only $PREV_TAG..HEAD | grep -q "^vibetuner-py/"; then
+              echo "python=true" >> $GITHUB_OUTPUT
+              echo "✅ Python package changed"
+            else
+              echo "python=false" >> $GITHUB_OUTPUT
+              echo "❌ Python package unchanged"
+            fi
+            
+            # Check JS changes  
+            if git diff --name-only $PREV_TAG..HEAD | grep -q "^vibetuner-js/"; then
+              echo "js=true" >> $GITHUB_OUTPUT
+              echo "✅ JavaScript package changed"
+            else
+              echo "js=false" >> $GITHUB_OUTPUT
+              echo "❌ JavaScript package unchanged"
+            fi
+          else
+            # First release - build both
+            echo "First release detected - building both packages"
+            echo "python=true" >> $GITHUB_OUTPUT
+            echo "js=true" >> $GITHUB_OUTPUT
+          fi
+
+  # Conditional Python build
   build-python:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.python-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,17 +79,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Extract version from release
-        id: version
-        run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          echo "version=$TAG" >> $GITHUB_OUTPUT
-          echo "Building Python package version: $TAG"
-
       - name: Update pyproject.toml version
         working-directory: vibetuner-py
         run: |
-          uv version "${{ steps.version.outputs.version }}"
+          uv version "${{ needs.detect-changes.outputs.version }}"
           cat pyproject.toml
 
       - name: Build package
@@ -44,7 +99,10 @@ jobs:
           name: python-dist
           path: vibetuner-py/dist/
 
+  # Conditional JavaScript build
   build-js:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.js-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,17 +116,10 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Extract version from release
-        id: version
-        run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          echo "version=$TAG" >> $GITHUB_OUTPUT
-          echo "Building JS package version: $TAG"
-
       - name: Update package.json version
         working-directory: vibetuner-js
         run: |
-          bun pm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+          bun pm version "${{ needs.detect-changes.outputs.version }}" --no-git-tag-version
           cat package.json
 
       - name: Install dependencies
@@ -85,9 +136,15 @@ jobs:
           name: js-dist
           path: vibetuner-js/*.tgz
 
+  # Conditional Python publish (blocks if any build fails)
   publish-python:
+    needs: [detect-changes, build-python, build-js]
+    if: |
+      always() && 
+      needs.detect-changes.outputs.python-changed == 'true' &&
+      (needs.build-python.result == 'success' || needs.build-python.result == 'skipped') &&
+      (needs.build-js.result != 'failure')
     runs-on: ubuntu-latest
-    needs: [build-python, build-js]
     permissions:
       contents: read
       id-token: write
@@ -107,9 +164,15 @@ jobs:
       - name: Publish to PyPI
         run: uv publish
 
+  # Conditional JavaScript publish (blocks if any build fails)
   publish-js:
+    needs: [detect-changes, build-python, build-js]
+    if: |
+      always() && 
+      needs.detect-changes.outputs.js-changed == 'true' &&
+      (needs.build-js.result == 'success' || needs.build-js.result == 'skipped') &&
+      (needs.build-python.result != 'failure')
     runs-on: ubuntu-latest
-    needs: [build-python, build-js]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

This PR implements smart conditional builds for the package publishing workflow, addressing the inefficiency of building both packages on every release.

### Changes Made

- **Change Detection**: Added a `detect-changes` job that compares the current release tag with the previous one to determine which packages have actual changes
- **Conditional Builds**: Python and JavaScript packages now only build when their respective directories (`vibetuner-py/` or `vibetuner-js/`) contain changes
- **Safety Net Maintained**: The workflow still blocks publishing if any build fails, preserving the existing safety mechanism
- **Version Gaps**: Packages will naturally have version gaps when they don't change between releases
- **First Release Support**: Handles the edge case of the first release (no previous tag) by building both packages

### Technical Details

- Uses `git diff --name-only` to detect file changes between release tags
- Implements proper job dependencies with `needs:` and `if:` conditions
- Maintains all existing functionality while adding efficiency
- Preserves trusted publishing configurations for both PyPI and npm

### Benefits

✅ **Faster releases**: Only build changed packages  
✅ **Cost efficiency**: Less CI/CD runtime  
✅ **Natural versioning**: Package versions reflect actual changes  
✅ **Maintains safety**: Still blocks releases if any build fails  

### Testing

The workflow has been designed to handle:
- First releases (builds both packages)
- Single package changes (builds only changed package)
- Both packages changed (builds both)
- No package changes (shouldn't occur on release
- Build failures (blocks publishing appropriately)

This change creates a more efficient release process while maintaining all existing safety mechanisms.
EOF
)