### PR TITLE
fix: update PR title validation to support breaking changes and upgrade action

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR Title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         with:
           types: feat,fix,docs,chore,refactor,style,test,perf,ci,build
           requireScope: false
           validateSingleCommit: false
           validateSingleCommitMatchesPrTitle: false
-          headerPattern: '^(\w+)(\(.+\))?: .+$'
+          headerPattern: '^(\w+)(\(.+\))?!?: .+$'
           errorMessages:
             missingType: 'PR title must start with a conventional commit type (feat, fix, docs, chore, refactor, style, test, perf, ci, build)'
-            invalidFormat: 'PR title must follow format: type: description or type(scope): description'
+            invalidFormat: 'PR title must follow format: type: description, type!: description, or type(scope): description'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Update headerPattern to support breaking changes with '!' 
- Upgrade action from v5 to v6
- Update error message to include breaking change format

This fixes the PR title validation workflow to properly handle conventional commit breaking changes indicated by the `!` symbol before the colon.