### PR TITLE
fix: resolve Release Please workflow issues and improve commit validation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -22,7 +23,7 @@ jobs:
       - name: Release Please
         uses: googleapis/release-please-action@v4
         with:
-          command: release-pr
+          skip-github-release: true
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/copier-template/.pre-commit-config.yaml
+++ b/copier-template/.pre-commit-config.yaml
@@ -34,3 +34,13 @@ repos:
     hooks:
       - id: taplo-format
         args: [--check]
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [
+          feat, fix, docs, style, refactor, perf, test, build, ci, chore,
+          --optional-scopes,
+          --strict
+        ]


### PR DESCRIPTION
## Summary
- Remove deprecated 'command' input from Release Please action and replace with 'skip-github-release: true'
- Add missing 'issues: write' permission for proper PR creation functionality
- Add conventional commit validation hook to prevent future parsing errors
- Clean up old releases (v2.6.1, v2.7.0, v2.7.1, v2.8.0, v2.8.1) causing version conflicts

## Changes Made
- Updated `.github/workflows/release-please.yml` to use current Release Please action syntax
- Added conventional commit validation to `copier-template/.pre-commit-config.yaml`
- Removed conflicting releases and tags to establish cleaner version baseline

## Impact
This resolves the Release Please workflow failures and ensures future commits follow conventional commit format, preventing automated release parsing errors.