### PR TITLE
fix: add PAT fallback for Release Please due to org policy restrictions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,6 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           skip-github-release: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Add RELEASE_PLEASE_TOKEN fallback to enable Personal Access Token usage
- Required due to organization-level policies restricting GitHub Actions PR creation
- Maintains backward compatibility with GITHUB_TOKEN

## Context
Release Please is currently failing because:
1. Repository is owned by an organization with restrictive policies
2. "Allow GitHub Actions to create and approve pull requests" is grayed out due to org policy
3. GITHUB_TOKEN cannot create PRs under these restrictions

## Solution
This change adds support for a Personal Access Token (PAT) that can bypass the organization restrictions.

## Setup Instructions
To fix Release Please:

1. **Create a Personal Access Token:**
   - Go to https://github.com/settings/tokens
   - Click "Generate new token (classic)"
   - Select `repo` scope (full repository access)
   - Generate and copy the token

2. **Add as Repository Secret:**
   - Go to https://github.com/alltuner/vibetuner/settings/secrets/actions
   - Click "New repository secret"
   - Name: `RELEASE_PLEASE_TOKEN`
   - Value: paste the PAT from step 1

3. **Test the Workflow:**
   - The Release Please workflow will automatically use the PAT
   - No further configuration needed

## Changes Made
- Updated Release Please workflow to prioritize `RELEASE_PLEASE_TOKEN` over `GITHUB_TOKEN`
- This allows the workflow to create PRs despite organization restrictions