### PR TITLE
feat: enable automatic GitHub releases on PR merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Release Please
         uses: googleapis/release-please-action@v4
         with:
-          skip-github-release: true
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Remove skip-github-release: true from Release Please workflow
- Merging release PRs will now automatically create GitHub releases
- Enables end-to-end automated release process

## Context
Previously, Release Please was only creating release PRs but not actual GitHub releases. This meant:
- Manual step required to create releases after merging PRs
- Publish workflow (which triggers on release: published) wouldnt run automatically

## Changes Made
- Removed skip-github-release: true setting
- Now when a release PR is merged:
  1. Release Please creates the GitHub release/tag automatically
  2. Publish workflow triggers automatically
  3. Packages get published to PyPI and npm

## Impact
This enables a fully automated release workflow:
1. Merge release PR → GitHub release created → Packages published
2. No manual intervention required
3. Faster release cycle