### PR TITLE
fix: remove component prefixes from release tags

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -10,11 +10,13 @@
     "vibetuner-py": {
       "release-type": "python",
       "package-name": "vibetuner",
+      "component": "",
       "changelog-section": "Python Package"
     },
     "vibetuner-js": {
       "release-type": "node",
       "package-name": "@alltuner/vibetuner",
+      "component": "",
       "changelog-section": "JavaScript Package"
     }
   }


### PR DESCRIPTION
## Summary
- Set empty component names for Python and JS packages in Release Please config
- Prevents vibetuner- prefix from appearing in release tags
- Tags will now be clean: v2.12.0 instead of vibetuner-v2.12.0

## Issue
Recent releases were creating tags with unwanted prefixes:
- vibetuner-v2.12.0 (incorrect)
- v2.12.0 (desired)

## Solution
By setting empty component names in the Release Please configuration:
- The root package controls the main version tag
- Sub-packages (Python/JS) dont create their own tags
- Clean, consistent tag naming

## Impact
- Future releases will have clean tag names
- No more vibetuner- prefix in tags
- Consistent with standard semantic versioning conventions