### PR TITLE
fix: add workflow_dispatch trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish vibetuner packages
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   # Detect what changed since last release


### PR DESCRIPTION
Add workflow_dispatch trigger to allow manual testing of the publish workflow when release events are not firing properly.