### PR TITLE
fix: add push tag trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: Publish vibetuner packages
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Add push tag trigger to catch releases created by release-please that may not trigger the release:published event properly.