### PR TITLE
fix: add pull_request_target trigger and ignore Release Please PRs in title validation

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -3,6 +3,8 @@ name: PR Title Check
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   validate-title:
@@ -39,3 +41,4 @@ jobs:
           # Don't ignore merge commits
           ignoreLabels: |
             skip-changelog
+            autorelease: pending


### PR DESCRIPTION
## Summary
- Add pull_request_target trigger to PR title check workflow to catch Release Please PRs
- Add autorelease: pending label to ignore list to automatically skip validation for Release Please PRs
- This fixes the issue where Release Please PRs were stuck waiting for required validate-title check that never ran

## Technical Details
Release Please creates PRs through the GitHub API in a way that doesn't trigger standard pull_request events. The pull_request_target trigger runs in the context of the base branch and can catch these bot-created PRs. Since Release Please PRs already follow conventional commit format by design, we can safely ignore them for validation.

Fixes #366