### PR TITLE
fix: convert relative links to absolute URLs in changelog docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,9 @@ This page contains the complete changelog for the Vibetuner project.
 
 ## 📋 Complete Changelog
 
-For the full changelog with all version history, release notes, and package-specific changes, see the **[main CHANGELOG.md](https://github.com/alltuner/vibetuner/blob/main/CHANGELOG.md)** file in the repository.
+For the full changelog with all version history, release notes, and package-specific changes,
+see the **[main CHANGELOG.md](https://github.com/alltuner/vibetuner/blob/main/CHANGELOG.md)**
+file in the repository.
 
 ## 🔄 How Updates Are Managed
 
@@ -28,7 +30,9 @@ Changes are automatically categorized by which packages were affected in each re
 
 ## 🤝 Contributing to Changelog
 
-When contributing to Vibetuner, please follow the [PR title guidelines](../CONTRIBUTING.md#pr-title-format-important) to ensure proper changelog generation.
+When contributing to Vibetuner, please follow the
+[PR title guidelines](https://github.com/alltuner/vibetuner/blob/main/CONTRIBUTING.md#pr-title-format-important)
+to ensure proper changelog generation.
 
 ### Quick Reference
 
@@ -57,8 +61,8 @@ refactor: improve code structure
 
 - **[Main Changelog](https://github.com/alltuner/vibetuner/blob/main/CHANGELOG.md)** – Complete version history
 - **[GitHub Releases](https://github.com/alltuner/vibetuner/releases)** – Release downloads and notes
-- **[Contributing Guidelines](../CONTRIBUTING.md)** – How to contribute
-- **[Agent Guidance](../AGENTS.md)** – Guidelines for AI assistants
+- **[Contributing Guidelines](https://github.com/alltuner/vibetuner/blob/main/CONTRIBUTING.md)** – How to contribute
+- **[Agent Guidance](https://github.com/alltuner/vibetuner/blob/main/AGENTS.md)** – Guidelines for AI assistants
 
 ---
 


### PR DESCRIPTION
## Summary
Fix mkdocs strict mode build failures by converting relative links to absolute GitHub URLs

## Problem
The docs workflow was failing with:
```
WARNING - Doc file 'changelog.md' contains a link '../CONTRIBUTING.md'
WARNING - Doc file 'changelog.md' contains a link '../AGENTS.md'
Aborted with 3 warnings in strict mode!
```

## Solution
- Replace relative links (`../CONTRIBUTING.md`, `../AGENTS.md`) with absolute GitHub URLs
- Fix MD013 line length violations by breaking long lines
- Keep `--strict` flag enabled for quality assurance

MkDocs cannot resolve links to files outside the docs directory, so absolute URLs are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)