### PR TITLE
refactor: remove template backwards compatibility symlink

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,1 @@
-../template/.claude/settings.json
+../copier-template/.claude/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,8 @@ node_modules/
 # Template Specific
 ############################################################
 .git
-template/bun.lock
-template/uv.lock
+copier-template/bun.lock
+copier-template/uv.lock
 
 
 ############################################################

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,1 +1,1 @@
-template/.mise.toml
+copier-template/.mise.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,1 @@
-template/.pre-commit-config.yaml
+copier-template/.pre-commit-config.yaml

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,1 +1,1 @@
-template/.ruff.toml
+copier-template/.ruff.toml

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,1 +1,1 @@
-template/.rumdl.toml
+copier-template/.rumdl.toml

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,1 +1,1 @@
-template/.taplo.toml
+copier-template/.taplo.toml

--- a/copier-template/.claude/commands/help.md
+++ b/copier-template/.claude/commands/help.md
@@ -8,11 +8,11 @@ allowed-tools: Bash(ls:*), Bash(grep:*), Bash(cat:*)
 
 Here are all available Claude commands in this project:
 
-!ls -1 /Users/dpoblador/repos/scaffolding/template/.claude/commands/*.md | sed 's|.*/||; s|\.md$||' | sort
+!ls -1 /Users/dpoblador/repos/vibetuner/copier-template/.claude/commands/*.md | sed 's|.*/||; s|\.md$||' | sort
 
 Let me show you what each command does:
 
-!for file in /Users/dpoblador/repos/scaffolding/template/.claude/commands/*.md; do echo ""; echo "## /$(basename "$file" .md)"; grep "^description:" "$file" | sed 's/description: //'; done
+!for file in /Users/dpoblador/repos/vibetuner/copier-template/.claude/commands/*.md; do echo ""; echo "## /$(basename "$file" .md)"; grep "^description:" "$file" | sed 's/description: //'; done
 
 **Usage:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,6 @@ The Copier-based template that generates new projects:
 - Generates complete project structure
 - Updates existing projects
 **Command**: `uvx vibetuner scaffold new my-app`
-**Note**: A `template/` symlink exists for backwards compatibility.
 
 ### 2. Python Package (`vibetuner`)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,7 +24,6 @@ vibetuner/
 │   ├── src/vibetuner/     # → Symlink to vibetuner-py/src/vibetuner
 │   ├── src/app/           # User application space
 │   └── *.j2 files         # Jinja2 templates processed by Copier
-├── template/              # → Symlink to copier-template/ (backwards compat)
 ├── copier.yml             # Template configuration
 ├── justfile               # Development commands
 ├── docs/                  # MkDocs documentation
@@ -85,7 +84,6 @@ cd /tmp/my-test-project
 just dev  # Starts Docker development environment
 ```
 
-**Note**: Template files are in `copier-template/` directory. A `template/` symlink exists for backwards compatibility.
 For a catalog of template prompts and update flows, see the [Scaffolding Reference](scaffolding.md).
 
 ### Working on Documentation

--- a/template
+++ b/template
@@ -1,1 +1,0 @@
-copier-template


### PR DESCRIPTION
## Summary

- Removed `template -> copier-template` backwards compatibility symlink
- Updated all root-level config symlinks to point to `copier-template/`
- Updated `.claude/settings.json` symlink reference
- Updated documentation references in `docs/`
- Updated `.gitignore` to reference `copier-template/` paths
- Updated hardcoded paths in `.claude/commands/help.md`

## Test plan

- [x] Verified all symlinks are accessible and readable
- [x] Confirmed no remaining references to old `template/` path in code
- [x] All configuration files work correctly through new symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)