### PR TITLE
fix: include refactor and perf commits in changelog

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,6 +7,12 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "always-bump-patch": true,
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "perf", "section": "Performance Improvements"}
+      ],
       "extra-files": [
         "vibetuner-py/pyproject.toml",
         "vibetuner-js/package.json"


### PR DESCRIPTION
## Summary

Updated Release Please configuration to include `refactor` and `perf` commit types in changelog generation.

**Changes:**
- Added `changelog-sections` to `.release-please-config.json`
- `refactor:` commits now appear under "Code Refactoring" section
- `perf:` commits now appear under "Performance Improvements" section

This fixes the issue where PR #377 (refactor: remove template backwards compatibility symlink) was not included in the Release Please PR #376.

## Test plan

- [x] Configuration follows Release Please JSON schema
- [x] After merge, Release Please should update PR #376 to include refactor commits

## Context

By default, Release Please only includes `feat` and `fix` commits in changelogs. This change explicitly configures which commit types should appear, ensuring refactoring and performance improvements are documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)