### PR TITLE
fix: include chore commits in changelog

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -11,7 +11,8 @@
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},
         {"type": "refactor", "section": "Code Refactoring"},
-        {"type": "perf", "section": "Performance Improvements"}
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "chore", "section": "Miscellaneous Chores"}
       ],
       "extra-files": [
         "vibetuner-py/pyproject.toml",


### PR DESCRIPTION
## Summary

Added `chore` commit type to Release Please changelog configuration.

**Changes:**
- Added `chore` type to `changelog-sections` in `.release-please-config.json`
- Chore commits will now appear under "Miscellaneous Chores" section in release notes

This ensures maintenance tasks like dependency updates are documented in releases.

## Test plan

- [x] Configuration follows Release Please JSON schema
- [x] After merge, Release Please should include chore commits in PR #376

## Context

Previously, chore commits (like PR #374 "chore(deps): update JavaScript and Python dependencies" and PR #375 "chore: add permissions") were excluded from release notes. This change makes them visible to users so they can see what maintenance work was done.

Common chore commits include:
- Dependency updates
- CI/CD configuration changes
- Repository maintenance
- Build system updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)