### PR TITLE
feat: add manual workflow dispatch for force publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,9 +46,9 @@ jobs:
               VERSION="${{ github.event.inputs.version }}"
               echo "Using manual version: $VERSION"
             else
-              # Get latest release tag
-              VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
-              echo "Using latest release version: $VERSION"
+              # Get latest GitHub release (not just tag)
+              VERSION=$(gh release view --json tagName --jq '.tagName' | sed 's/^v//')
+              echo "Using latest GitHub release version: $VERSION"
             fi
           else
             # Release event
@@ -57,6 +57,8 @@ jobs:
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Final version: $VERSION"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Detect changes
         id: changes


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to publish.yml workflow
- Allow manual publishing with force flags to bypass change detection
- Support manual version input or automatic latest GitHub release detection

## Changes

- Added `workflow_dispatch` trigger with three inputs:
  - `force-python`: Force publish Python package regardless of changes
  - `force-js`: Force publish JS package regardless of changes  
  - `version`: Optional version to publish (defaults to latest GitHub release)
- Updated version extraction to handle manual triggers and use GitHub release API
- Modified change detection to respect force flags when set

## Use Cases

This enables:
1. Republishing packages after registry issues
2. Force publishing when change detection is incorrect
3. Manual publishing of specific versions
4. Publishing latest release without triggering a new release event

## Test plan

- [ ] Verify workflow appears in Actions tab with "Run workflow" button
- [ ] Test manual trigger with force-python enabled
- [ ] Test manual trigger with force-js enabled
- [ ] Test manual trigger with custom version
- [ ] Test manual trigger without version (should use latest release)
- [ ] Verify normal release-triggered workflow still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)