### PR TITLE
fix: make version updates idempotent in build steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -146,7 +146,16 @@ jobs:
       - name: Update pyproject.toml version
         working-directory: vibetuner-py
         run: |
-          uv version "${{ needs.detect-changes.outputs.version }}"
+          TARGET_VERSION="${{ needs.detect-changes.outputs.version }}"
+          CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+
+          if [ "$CURRENT_VERSION" != "$TARGET_VERSION" ]; then
+            echo "Updating version from $CURRENT_VERSION to $TARGET_VERSION"
+            uv version "$TARGET_VERSION"
+          else
+            echo "Version already at $TARGET_VERSION, no update needed"
+          fi
+
           cat pyproject.toml
 
       - name: Build package
@@ -183,7 +192,16 @@ jobs:
       - name: Update package.json version
         working-directory: vibetuner-js
         run: |
-          bun pm version "${{ needs.detect-changes.outputs.version }}" --no-git-tag-version
+          TARGET_VERSION="${{ needs.detect-changes.outputs.version }}"
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+          if [ "$CURRENT_VERSION" != "$TARGET_VERSION" ]; then
+            echo "Updating version from $CURRENT_VERSION to $TARGET_VERSION"
+            bun pm version "$TARGET_VERSION" --no-git-tag-version
+          else
+            echo "Version already at $TARGET_VERSION, no update needed"
+          fi
+
           cat package.json
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Fixes the force publish workflow by making version updates idempotent. Previously, the workflow failed when trying to force publish a package that was already at the target version.

## Problem

When running the workflow_dispatch with force flags:
1. build-js failed with "Version not changed" error when package.json already had the target version
2. This caused publish-js to be skipped
3. The cross-dependency safety check also blocked publish-python from running

See failed run: https://github.com/alltuner/vibetuner/actions/runs/19133597258

## Solution

- Check current version in both pyproject.toml and package.json before updating
- Only call version update commands if the version actually needs to change
- Skip update with informative message if version is already correct

## Changes

- **Python build**: Check `pyproject.toml` version before calling `uv version`
- **JS build**: Check `package.json` version before calling `bun pm version`

## Test plan

- [ ] Run workflow_dispatch with force-js=true and version=2.14.0 (current version)
- [ ] Verify build-js succeeds without version update
- [ ] Verify publish-js runs and publishes package
- [ ] Test with a different version to ensure update still works when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)