### PR TITLE
fix: add workflow_call trigger to make release.yml reusable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,24 @@ on:
         description: 'Version to publish (e.g., 1.2.3). Leave empty to use latest release.'
         required: false
         type: string
+  workflow_call:
+    inputs:
+      force-python:
+        description: 'Force publish Python package'
+        type: boolean
+        default: false
+      force-js:
+        description: 'Force publish JS package'
+        type: boolean
+        default: false
+      force-docs:
+        description: 'Force publish documentation'
+        type: boolean
+        default: false
+      version:
+        description: 'Version to publish (e.g., 1.2.3). Leave empty to use latest release.'
+        required: false
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add missing `workflow_call` trigger to release.yml workflow
- Fixes error: "workflow is not reusable as it is missing a `on.workflow_call` trigger"
- Allows release-please.yml to properly call the release workflow using `uses` syntax

## Issue
The CI refactor introduced a reusable workflow pattern where release-please.yml calls release.yml, but the workflow_call trigger was missing, causing the workflow to fail.

## Fix
Added `workflow_call` trigger with the same inputs as `workflow_dispatch` for consistency, ensuring the workflow can be called both manually and by other workflows.