### PR TITLE
fix: add uv setup to prepare-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Extract version and bump type
         id: version
         run: |


### PR DESCRIPTION
## Summary
- Add missing astral-sh/setup-uv@v7 action to prepare-release job
- Fixes 'uv: command not found' error during version synchronization
- Ensures uv commands are available for version updates across components

## Issue
The prepare-release job was using uv commands to sync versions across vibetuner-py, vibetuner-js, and vibetuner-template but hadn't set up the uv tool first, causing build failures.

## Fix
Added the uv setup step right after checkout, before any uv commands are executed. This matches the pattern used in other build jobs in the workflow.

## Result
Version synchronization will now work correctly during release preparation.