### PR TITLE
fix: configure Release Please to update Python package versions

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -15,7 +15,16 @@
         {"type": "chore", "section": "Miscellaneous Chores"}
       ],
       "extra-files": [
-        "vibetuner-py/pyproject.toml",
+        {
+          "type": "toml",
+          "path": "vibetuner-py/pyproject.toml",
+          "jsonpath": "$.project.version"
+        },
+        {
+          "type": "toml",
+          "path": "vibetuner-template/pyproject.toml",
+          "jsonpath": "$.project.version"
+        },
         "vibetuner-js/package.json"
       ]
     }


### PR DESCRIPTION
## Summary

- Fixed Release Please configuration to properly update Python package versions in `pyproject.toml` files
- Added explicit TOML type and jsonpath configuration for both `vibetuner-py` and `vibetuner-template`
- Included missing `vibetuner-template/pyproject.toml` in extra-files configuration

## Problem

Release Please was only updating `vibetuner-js/package.json` (currently at 2.17.1) but not the Python packages (stuck at 2.16.2). Investigation revealed:

1. The "simple" release-type only handles `version.txt` and `CHANGELOG.md` by default
2. The GenericToml updater requires explicit `jsonpath` configuration to locate version fields
3. JSON files have better default handling, which is why `package.json` was working
4. `vibetuner-template/pyproject.toml` was completely missing from extra-files

## Solution

Updated `.release-please-config.json` to use explicit TOML configuration:

```json
"extra-files": [
  {
    "type": "toml",
    "path": "vibetuner-py/pyproject.toml",
    "jsonpath": "$.project.version"
  },
  {
    "type": "toml",
    "path": "vibetuner-template/pyproject.toml",
    "jsonpath": "$.project.version"
  },
  "vibetuner-js/package.json"
]
```

## Test plan

- [ ] Merge this PR
- [ ] Wait for Release Please to create/update a release PR
- [ ] Verify the release PR updates versions in all three files:
  - `vibetuner-py/pyproject.toml`
  - `vibetuner-template/pyproject.toml`
  - `vibetuner-js/package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)