### PR TITLE
fix: detect merge conflicts when updating scaffolding

### DIFF
--- a/vibetuner-template/.justfiles/scaffolding.justfile
+++ b/vibetuner-template/.justfiles/scaffolding.justfile
@@ -5,10 +5,31 @@ import 'deps.justfile'
 update-scaffolding:
     @echo "Updating project scaffolding..."
     @copier update -A --trust
-    @bun install
-    @uv sync --all-extras
-    @echo "Project scaffolding updated."
-    @echo "Please review the changes and commit."
+    
+    # Check package.json and conditionally install
+    @if [ -f package.json ]; then \
+        if grep -q "<<<<<<<\|=======\|>>>>>>>" package.json; then \
+            echo "⚠️  Conflicts detected in package.json - skipping bun install"; \
+            echo "Please resolve conflicts manually and run: bun install"; \
+        else \
+            echo "✅ No conflicts in package.json - running bun install"; \
+            bun install; \
+        fi \
+    fi
+    
+    # Check pyproject.toml and conditionally sync
+    @if [ -f pyproject.toml ]; then \
+        if grep -q "<<<<<<<\|=======\|>>>>>>>" pyproject.toml; then \
+            echo "⚠️  Conflicts detected in pyproject.toml - skipping uv sync"; \
+            echo "Please resolve conflicts manually and run: uv sync --all-extras"; \
+        else \
+            echo "✅ No conflicts in pyproject.toml - running uv sync"; \
+            uv sync --all-extras; \
+        fi \
+    fi
+    
+    @echo "Project scaffolding update completed."
+    @echo "Please review the changes and resolve any conflicts before committing."
 
 # Initialize git repo
 [group('initialization')]


### PR DESCRIPTION
## Summary
- Add conflict detection to `update-scaffolding` command
- Skip `bun install` when package.json has merge conflicts  
- Skip `uv sync` when pyproject.toml has merge conflicts
- Provide clear guidance for manual conflict resolution
- Prevent installation failures during scaffolding updates

## Changes
- Modified `vibetuner-template/.justfiles/scaffolding.justfile` to check for conflict markers before running install commands
- Added conditional logic to only run installs when no conflicts are detected
- Improved user feedback with status messages and next steps