### PR TITLE
chore: add gh issue create to allowed tools without approval

### DIFF
--- a/vibetuner-template/.claude/settings.json
+++ b/vibetuner-template/.claude/settings.json
@@ -5,6 +5,7 @@
       "Bash(curl:*)",
       "Bash(echo:*)",
       "Bash(find:*)",
+      "Bash(gh issue create:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr diff:*)",
       "Bash(gh pr list:*)",


### PR DESCRIPTION
## Summary
- Add `Bash(gh issue create:*)` to the `allowedToolsWithoutUserApproval` list in the vibetuner template settings
- This allows Claude Code to create GitHub issues without requiring user approval for each issue

## Test plan
- [x] Verified change is minimal and affects only the settings.json file
- [x] Pre-commit hooks passed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)