### PR TITLE
docs: clarify lifespan execution stages with inline comments

### DIFF
--- a/vibetuner-template/src/app/frontend/lifespan.py
+++ b/vibetuner-template/src/app/frontend/lifespan.py
@@ -10,10 +10,11 @@ from vibetuner.logging import logger
 async def lifespan(app: FastAPI):
     logger.info(f"Starting {settings.project.project_name} frontend...")
 
-    # Add any startup tasks here
-
+    # Tasks here are run before anything is available (even before DB access)
     async with base_lifespan(app):
+        # Tasks here are run after DB is available
         yield
+        # Tasks here are run on shutdown before vibetuner teardown
         logger.info(f"Stopping {settings.project.project_name} frontend...")
 
     # Add any teardown tasks here


### PR DESCRIPTION
## Summary
- Add inline comments to template `lifespan.py` explaining when different lifecycle sections execute
- Before `base_lifespan`: runs before DB access is available
- Inside `async with` block: runs after DB is available
- After `yield`: runs on shutdown before vibetuner teardown

## Why
Developers need to understand where to place their custom startup/shutdown logic based on their dependencies (e.g., tasks requiring DB access should go inside the async with block).

## Test plan
- [x] Verified comments are accurate and helpful
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)