### PR TITLE
fix: properly handle force flags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,10 +215,12 @@ jobs:
           echo "Detecting changes for release $VERSION"
           echo "Version type: major=$IS_MAJOR, minor=$IS_MINOR, patch=$IS_PATCH"
 
-          # Check for manual force flags
-          FORCE_PYTHON="${{ github.event.inputs.force-python }}"
-          FORCE_JS="${{ github.event.inputs.force-js }}"
-          FORCE_DOCS="${{ github.event.inputs.force-docs }}"
+          # Check for manual force flags (GitHub Actions booleans are "true"/"false")
+          FORCE_PYTHON="${{ github.event.inputs.force-python || 'false' }}"
+          FORCE_JS="${{ github.event.inputs.force-js || 'false' }}"
+          FORCE_DOCS="${{ github.event.inputs.force-docs || 'false' }}"
+
+          echo "🔍 Debug: Force flags: python=$FORCE_PYTHON, js=$FORCE_JS, docs=$FORCE_DOCS"
 
           # Get previous tag for change detection
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- Fix force-js, force-python, and force-docs flags not working in release workflow
- Add proper default values for workflow dispatch inputs
- Add debug output to troubleshoot force flag handling

Fixes #447

## Changes
- Add default values (`|| 'false'`) for workflow dispatch inputs to handle empty cases
- Add debug logging to show actual force flag values
- Ensure boolean comparisons work correctly with GitHub Actions input format

## Testing
- Test with `force-js: true` to verify JavaScript package publishes even without changes
- Test with `force-python: true` to verify Python package publishes even without changes
- Test with `force-docs: true` to verify documentation deploys even without changes