### PR TITLE
fix: improve release workflow with Bun setup and proper version commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,15 +215,37 @@ jobs:
           VERSION="${{ steps.plan.outputs.version }}"
           
           # Update Python version
-          sed -i.bak "s/^version = .*/version = \"$VERSION\"/" vibetuner-py/pyproject.toml
+          cd vibetuner-py
+          CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          if [ "$CURRENT_VERSION" != "$VERSION" ]; then
+            echo "Updating vibetuner-py from $CURRENT_VERSION to $VERSION"
+            uv version "$VERSION"
+          else
+            echo "vibetuner-py already at version $VERSION"
+          fi
+          cd ..
           
           # Update JS version
           cd vibetuner-js
-          bun version $VERSION
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          if [ "$CURRENT_VERSION" != "$VERSION" ]; then
+            echo "Updating vibetuner-js from $CURRENT_VERSION to $VERSION"
+            bun pm version "$VERSION" --no-git-tag-version
+          else
+            echo "vibetuner-js already at version $VERSION"
+          fi
           cd ..
           
           # Update template version
-          sed -i.bak "s/^version = .*/version = \"$VERSION\"/" vibetuner-template/pyproject.toml
+          cd vibetuner-template
+          CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          if [ "$CURRENT_VERSION" != "$VERSION" ]; then
+            echo "Updating vibetuner-template from $CURRENT_VERSION to $VERSION"
+            uv version "$VERSION"
+          else
+            echo "vibetuner-template already at version $VERSION"
+          fi
+          cd ..
           
           echo "Updated all components to version $VERSION"
 


### PR DESCRIPTION
## Summary
- Add Bun setup to plan-release job before Sync versions step
- Replace sed commands with proper package management tools (uv version, bun pm version)
- Add version checks to avoid unnecessary updates and provide better logging
- Follow package management best practices instead of manual file manipulation

## Changes
- Add Bun setup action to plan-release job
- Use `uv version "$VERSION"` for Python packages (vibetuner-py, vibetuner-template)
- Use `bun pm version "$VERSION" --no-git-tag-version` for JavaScript package (vibetuner-js)
- Add conditional version checks to only update when versions differ
- Improve logging to show when updates are made vs skipped

## Root Cause
1. plan-release job was trying to run `bun version` but didn't have Bun installed
2. Original workflow used sed commands instead of proper package management tools

## Testing
- plan-release job should now succeed with Bun available
- version-files artifact should be created with proper version updates
- build jobs should be able to download version files
- Full release workflow should complete successfully