### PR TITLE
fix: use uvx with mkdocs-material for docs build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,7 +387,7 @@ jobs:
         id: build
         working-directory: vibetuner-docs
         run: |
-          uv run mkdocs build
+          uvx --with mkdocs-material mkdocs build --strict --site-dir site
           echo "Build completed successfully"
 
       - name: Add CNAME


### PR DESCRIPTION
## Summary
- Revert to original working approach using uvx --with mkdocs-material
- Fixes build-docs job failure in release workflow
- The uv run command fails because mkdocs dependencies are not installed

## Root Cause
The workflow was changed from `uvx --with mkdocs-material mkdocs build` to `uv run mkdocs build`,
but the mkdocs-material dependencies are not available in the uv environment.

## Changes
- Use `uvx --with mkdocs-material mkdocs build --strict --site-dir site`
- Maintains the same output directory structure as current workflow expects
- Restores the working approach from the original implementation

## Testing
- build-docs job should now succeed
- Documentation should build properly with mkdocs-material theme
- Release workflow should complete successfully