### PR TITLE
fix: restore npm trusted publishing for JS package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,6 +428,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Download JS artifacts
@@ -436,13 +437,18 @@ jobs:
           name: js-dist
           path: ./
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup Node.js (for npm CLI)
+        uses: actions/setup-node@v6
+        with:
+          node-version: "latest"
 
-      - name: Publish to npm
-        run: bun pm publish --access public
+      - name: Publish to npm with trusted publishing
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+        run: |
+          TARBALL=$(ls alltuner-vibetuner-*.tgz)
+          echo "Publishing $TARBALL with trusted publishing"
+          npm publish "./$TARBALL" --access public
 
   # Deploy documentation
   deploy-docs:


### PR DESCRIPTION
## Summary
- Replace bun pm publish with npm publish for trusted publishing support
- Use NPM_CONFIG_PROVENANCE: true for provenance attestation
- Publish specific tarball file instead of from source directory
- Restore id-token: write permission for trusted publishing

## Root Cause
Bun doesn't support npm trusted publishing, which requires:
- npm CLI (not bun)
- NPM_CONFIG_PROVENANCE: true
- id-token: write permission
- Publishing specific .tgz file

## Changes
- Use npm publish with trusted publishing configuration
- Publish alltuner-vibetuner-*.tgz tarball file
- Setup Node.js instead of Bun for publish job
- Remove NPM_TOKEN secret (not needed for trusted publishing)

## Benefits
- ✅ Trusted publishing with provenance attestation
- ✅ No need for NPM_TOKEN secret management
- ✅ More secure publishing workflow
- ✅ Matches npm's recommended trusted publishing approach