### PR TITLE
fix: correct documentation deployment logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,16 +189,22 @@ jobs:
             echo "✅ Building JavaScript (first release)"
           fi
           
-          # Documentation (always build for releases)
+          # Documentation (build for releases and workflow dispatch)
           if [ "$FORCE_DOCS" = "true" ]; then
             DOCS_NEEDED="true"
             echo "🔧 Force building documentation"
           elif [ "${{ github.event_name }}" = "release" ]; then
             DOCS_NEEDED="true"
             echo "✅ Building documentation (GitHub release)"
-          else
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            DOCS_NEEDED="true"
+            echo "✅ Building documentation (release-please release)"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             DOCS_NEEDED="true"
             echo "✅ Building documentation (workflow dispatch)"
+          else
+            DOCS_NEEDED="false"
+            echo "❌ Not building documentation"
           fi
           
           echo "python-needed=$PYTHON_NEEDED" >> $GITHUB_OUTPUT
@@ -456,7 +462,7 @@ jobs:
     if: |
       always() &&
       needs.build-docs.result == 'success' &&
-      github.event_name == 'release'
+      (github.event_name == 'release' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
## Summary
- Fix plan-release docs condition to handle all trigger events properly
- Add explicit push event handling for release-please releases  
- Update deploy-docs condition to match build-docs triggers
- Ensure docs are deployed for push, release, and workflow_dispatch events

## Root Cause
The workflow had inconsistent logic:
- build-docs would run for push events (release-please releases)
- deploy-docs would only run for 'release' events
- This caused docs to be built but never deployed for push events

## Changes
- Add explicit push event handling in plan-release docs logic
- Update deploy-docs condition to include push and workflow_dispatch events
- Ensure consistent behavior between build and deploy jobs
- Add proper logging for each event type

## Testing
- Docs should now deploy for release-please releases (push events)
- Docs should deploy for GitHub releases (release events)  
- Docs should deploy for workflow dispatch (with force-docs flag)
- Prevents unnecessary docs builds for other event types