### PR TITLE
fix: handle missing version in workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,14 @@ jobs:
               VERSION="${{ github.event.inputs.version }}"
               echo "Using manual version: $VERSION"
             else
-              VERSION=$(gh release view --json tagName --jq '.tagName' | sed 's/^v//')
-              echo "Using latest GitHub release version: $VERSION"
+              VERSION=$(gh release view --json tagName --jq '.tagName' | sed 's/^v//' 2>/dev/null || echo "")
+              if [ -n "$VERSION" ]; then
+                echo "Using latest GitHub release version: $VERSION"
+              else
+                echo "❌ No version provided and no GitHub releases found"
+                echo "Please provide a version when triggering workflow_dispatch"
+                exit 1
+              fi
             fi
           elif [ "${{ github.event_name }}" = "release" ]; then
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -219,6 +225,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.plan.outputs.version }}"
+          
+          # Validate version is set
+          if [ -z "$VERSION" ]; then
+            echo "❌ VERSION is not set, cannot sync versions"
+            exit 1
+          fi
+          
+          echo "🔄 Syncing all components to version: $VERSION"
           
           # Update Python packages
           for dir in vibetuner-py vibetuner-template; do


### PR DESCRIPTION
## Summary
- Add error handling for gh release view command when no releases exist
- Validate VERSION is set before attempting to sync versions  
- Provide clear error message when version is missing
- Prevent uv version command from failing with empty version

## Root Cause
When using workflow_dispatch without providing a version input:
1. gh release view fails if no releases exist
2. VERSION becomes empty string
3. uv version command fails with "expected version to start with a number"
4. Sync versions step exits with code 2

## Changes
- Add error handling to gh release view with fallback
- Check if VERSION is empty before sync versions step
- Provide helpful error message with instructions
- Exit early with clear error instead of cryptic uv error

## Impact
- ✅ Python force publishing now works with proper version validation
- ✅ JS and docs force publishing also protected by same validation
- ✅ Clear error messages guide users to provide version input
- ✅ Prevents downstream jobs from failing with confusing errors