### PR TITLE
fix: add GH_TOKEN to plan-release step for gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Plan release
         id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Get version
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
## Summary
- Add GH_TOKEN environment variable to Plan release step
- Fixes gh release view command failure in workflow_dispatch
- GitHub CLI requires token to access release information
- Prevents "No version provided and no GitHub releases found" error when releases exist

## Root Cause
The gh release view command was failing because:
1. GH_TOKEN was only available in "Sync versions" step
2. "Plan release" step runs gh CLI without token
3. Command fails with authentication error
4. Falls back to "no releases found" even when releases exist

## Changes
- Add GH_TOKEN: ${{ github.token }} to Plan release step env
- Allows gh CLI to authenticate and access release data
- Fixes version detection for workflow_dispatch without version input

## Impact
- ✅ workflow_dispatch without version now works properly
- ✅ gh CLI can access existing releases
- ✅ Version detection works as intended
- ✅ Prevents unnecessary failures when releases exist