### PR TITLE
fix: configure UV cache dependency glob for monorepo structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,22 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: |
+            vibetuner-py/**/*requirements*.txt
+            vibetuner-py/**/*requirements*.in
+            vibetuner-py/**/*constraints*.txt
+            vibetuner-py/**/*constraints*.in
+            vibetuner-py/**/pyproject.toml
+            vibetuner-py/**/uv.lock
+            vibetuner-py/**/*.py.lock
+            vibetuner-template/**/*requirements*.txt
+            vibetuner-template/**/*requirements*.in
+            vibetuner-template/**/*constraints*.txt
+            vibetuner-template/**/*constraints*.in
+            vibetuner-template/**/pyproject.toml
+            vibetuner-template/**/uv.lock
+            vibetuner-template/**/*.py.lock
 
       - name: Plan release
         id: plan
@@ -300,6 +316,22 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: |
+            vibetuner-py/**/*requirements*.txt
+            vibetuner-py/**/*requirements*.in
+            vibetuner-py/**/*constraints*.txt
+            vibetuner-py/**/*constraints*.in
+            vibetuner-py/**/pyproject.toml
+            vibetuner-py/**/uv.lock
+            vibetuner-py/**/*.py.lock
+            vibetuner-template/**/*requirements*.txt
+            vibetuner-template/**/*requirements*.in
+            vibetuner-template/**/*constraints*.txt
+            vibetuner-template/**/*constraints*.in
+            vibetuner-template/**/pyproject.toml
+            vibetuner-template/**/uv.lock
+            vibetuner-template/**/*.py.lock
 
       - name: Build package
         id: build
@@ -389,6 +421,22 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: |
+            vibetuner-py/**/*requirements*.txt
+            vibetuner-py/**/*requirements*.in
+            vibetuner-py/**/*constraints*.txt
+            vibetuner-py/**/*constraints*.in
+            vibetuner-py/**/pyproject.toml
+            vibetuner-py/**/uv.lock
+            vibetuner-py/**/*.py.lock
+            vibetuner-template/**/*requirements*.txt
+            vibetuner-template/**/*requirements*.in
+            vibetuner-template/**/*constraints*.txt
+            vibetuner-template/**/*constraints*.in
+            vibetuner-template/**/pyproject.toml
+            vibetuner-template/**/uv.lock
+            vibetuner-template/**/*.py.lock
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -436,6 +484,22 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: |
+            vibetuner-py/**/*requirements*.txt
+            vibetuner-py/**/*requirements*.in
+            vibetuner-py/**/*constraints*.txt
+            vibetuner-py/**/*constraints*.in
+            vibetuner-py/**/pyproject.toml
+            vibetuner-py/**/uv.lock
+            vibetuner-py/**/*.py.lock
+            vibetuner-template/**/*requirements*.txt
+            vibetuner-template/**/*requirements*.in
+            vibetuner-template/**/*constraints*.txt
+            vibetuner-template/**/*constraints*.in
+            vibetuner-template/**/pyproject.toml
+            vibetuner-template/**/uv.lock
+            vibetuner-template/**/*.py.lock
 
       - name: Publish to PyPI
         run: uv publish


### PR DESCRIPTION
## Summary
- Fix UV cache dependency glob patterns for monorepo structure
- Add explicit patterns for `vibetuner-py/` and `vibetuner-template/` subdirectories
- Resolves "No file matched to" cache warnings in GitHub Actions

## Problem
The `astral-sh/setup-uv@v7` action was using default cache patterns that expect Python files at the repository root, but our monorepo has them in subdirectories:
- `vibetuner-py/pyproject.toml`
- `vibetuner-py/uv.lock` 
- `vibetuner-template/pyproject.toml`
- `vibetuner-template/uv.lock`

This caused warnings like:
```
No file matched to [/home/runner/work/vibetuner/vibetuner/**/*requirements*.txt,/home/runner/work/vibetuner/vibetuner/**/pyproject.toml,...]. The cache will never get invalidated.
```

## Solution
Added explicit `cache-dependency-glob` patterns to all `setup-uv` steps in the release workflow:
- `vibetuner-py/**/*requirements*.txt`
- `vibetuner-py/**/pyproject.toml`
- `vibetuner-py/**/uv.lock`
- `vibetuner-template/**/*requirements*.txt`
- `vibetuner-template/**/pyproject.toml`
- `vibetuner-template/**/uv.lock`

## Impact
- ✅ Eliminates cache warnings in GitHub Actions
- ✅ Ensures proper cache invalidation when dependencies change
- ✅ Improves CI/CD performance with accurate caching
- ✅ No functional changes to build process

## Testing
- Workflow will now properly detect file changes in subdirectories
- Cache will be correctly invalidated when Python dependencies are updated
- Build process remains unchanged