### PR TITLE
fix: enable publishing for release-please releases on push events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,7 +469,8 @@ jobs:
     if: |
       always() &&
       needs.build-python.result == 'success' &&
-      (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+      (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || 
+       (github.event_name == 'push' && needs.create-releases.outputs.releases_created == 'true'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -510,7 +511,8 @@ jobs:
     if: |
       always() &&
       needs.build-js.result == 'success' &&
-      (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+      (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || 
+       (github.event_name == 'push' && needs.create-releases.outputs.releases_created == 'true'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Fix publishing logic for release-please releases triggered by push events
- Add condition to publish-python and publish-js jobs for push events when releases are created
- Fixes issue where minor/major versions from release-please weren't publishing packages

## Problem
When release-please creates releases via push events (for minor/major versions), publish-python and publish-js jobs were being skipped because they only ran on:
- `github.event_name == 'release'` (manual GitHub releases)
- `github.event_name == 'workflow_dispatch'` (manual workflow triggers)

This caused packages to not be published for minor/major versions, even though releases were created.

## Solution
Added third condition to publishing jobs:
```yaml
(github.event_name == 'release' || github.event_name == 'workflow_dispatch' || 
 (github.event_name == 'push' && needs.create-releases.outputs.releases_created == 'true'))
```

This ensures publishing runs when:
1. Manual GitHub releases (`release` events)
2. Manual workflow dispatch (`workflow_dispatch` events)  
3. Push events that create releases via release-please (`push` events with `releases_created == 'true'`)

## Impact
- ✅ Minor/major versions will now publish packages correctly
- ✅ Maintains existing behavior for manual releases
- ✅ Maintains existing behavior for workflow_dispatch
- ✅ deploy-docs already had correct push condition

## Testing
- YAML syntax validated
- Logic covers all release scenarios
- No breaking changes to existing workflow