### PR TITLE
fix: remove cache-dependency-glob from publish-python job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -514,22 +514,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          cache-dependency-glob: |
-            vibetuner-py/**/*requirements*.txt
-            vibetuner-py/**/*requirements*.in
-            vibetuner-py/**/*constraints*.txt
-            vibetuner-py/**/*constraints*.in
-            vibetuner-py/**/pyproject.toml
-            vibetuner-py/**/uv.lock
-            vibetuner-py/**/*.py.lock
-            vibetuner-template/**/*requirements*.txt
-            vibetuner-template/**/*requirements*.in
-            vibetuner-template/**/*constraints*.txt
-            vibetuner-template/**/*constraints*.in
-            vibetuner-template/**/pyproject.toml
-            vibetuner-template/**/uv.lock
-            vibetuner-template/**/*.py.lock
 
       - name: Publish to PyPI
         run: uv publish


### PR DESCRIPTION
## Summary
- Remove unnecessary `cache-dependency-glob` configuration from the `publish-python` job
- This job only downloads and publishes pre-built artifacts, so dependency caching is not needed
- Fixes the warning about cache paths not matching any files

## Issue
The `publish-python` job was showing a warning:
```
No file matched to [cache paths]. The cache will never get invalidated.
```

This occurred because the job only downloads distribution artifacts but doesn't check out the repository source code, so the dependency files referenced in the cache configuration don't exist in this job's context.

## Solution
Removed the `cache-dependency-glob` configuration from the `publish-python` job since:
1. The job doesn't install or build anything that needs caching
2. It only publishes pre-built artifacts from the `build-python` job
3. The cache paths don't exist in this job's context

Other jobs (`build-python`, `plan-release`, `build-docs`) still retain their cache configuration as they actually need it.

## Testing
- The workflow will run without the cache warning
- Functionality remains unchanged - Python package publishing still works
- Other jobs continue to benefit from dependency caching