### PR TITLE
feat: add markdown formatting support with rumdl

### DIFF
--- a/vibetuner-template/.justfiles/formatting.justfile
+++ b/vibetuner-template/.justfiles/formatting.justfile
@@ -18,6 +18,11 @@ format-jinja:
 format-yaml:
     @uvx --from dprint-py dprint fmt --plugins https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm
 
+# Format Markdown files with rumdl
+[group('Code quality: formatting')]
+format-md:
+    @rumdl fmt
+
 # Format all code
 [group('Code quality: formatting')]
-format: format-py format-toml format-jinja
+format: format-py format-toml format-jinja format-md


### PR DESCRIPTION
## Summary
- Add `format-md` recipe to formatting.justfile using `rumdl fmt`
- Include markdown formatting in the main `format` recipe
- Enables consistent markdown formatting across the template

## Changes
- Added `format-md` recipe that uses `rumdl fmt` command
- Updated `format` recipe to include `format-md` dependency