### PR TITLE
chore: add git switch to Claude Code allow list

### DIFF
--- a/vibetuner-template/.claude/settings.json
+++ b/vibetuner-template/.claude/settings.json
@@ -23,6 +23,7 @@
       "Bash(git pull:*)",
       "Bash(git push:*)",
       "Bash(git status:*)",
+      "Bash(git switch:*)",
       "Bash(git tag:*)",
       "Bash(grep:*)",
       "Bash(head:*)",


### PR DESCRIPTION
## Summary

- Add `Bash(git switch:*)` to the Claude Code allow list in template settings
- Enables Claude Code to use `git switch` command without requiring approval

## Context

The `git switch` command is a safer alternative to `git checkout` for switching branches, introduced in Git 2.23. Adding it to the allow list improves the developer experience when using Claude Code for git operations.

## Testing

- Verified the JSON syntax is valid
- Confirmed the addition maintains alphabetical ordering in the list