### PR TITLE
chore: add git stash commands to Claude Code allowlist

### DIFF
--- a/vibetuner-template/.claude/settings.json
+++ b/vibetuner-template/.claude/settings.json
@@ -22,6 +22,8 @@
       "Bash(git log:*)",
       "Bash(git pull:*)",
       "Bash(git push:*)",
+      "Bash(git stash pop:*)",
+      "Bash(git stash push:*)",
       "Bash(git status:*)",
       "Bash(git tag:*)",
       "Bash(grep:*)",


### PR DESCRIPTION
## Summary

- Added `Bash(git stash pop:*)` to Claude Code allowlist
- Added `Bash(git stash push:*)` to Claude Code allowlist  
- Verified `gh pr create` is already present in the allowlist

## Changes

Updated `vibetuner-template/.claude/settings.json` to include git stash commands in the permissions allow list. These commands are useful for managing work-in-progress changes during branch switching workflows.

## Verification

- Commands added in alphabetical order with other git commands
- All pre-commit hooks passed
- `gh pr create` confirmed present on line 9

Closes #498