### PR TITLE
fix(hooks): replace missing format-files.sh with just format

### DIFF
--- a/vibetuner-template/.claude/settings.json
+++ b/vibetuner-template/.claude/settings.json
@@ -102,7 +102,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/format-files.sh"
+            "command": "just format"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Replaced non-existent `.claude/hooks/format-files.sh` script reference with `just format` command
- The hook now uses the existing project formatter instead of a missing shell script

## Verification

- Confirmed `just format` command exists and works in the project
- Git diff shows only the command string was changed
- Pre-commit hooks passed successfully

Closes #500