### PR TITLE
feat(allowlist): add gh issue view and gh issue edit commands

### DIFF
--- a/vibetuner-template/.claude/settings.json
+++ b/vibetuner-template/.claude/settings.json
@@ -6,6 +6,8 @@
       "Bash(echo:*)",
       "Bash(find:*)",
       "Bash(gh issue create:*)",
+      "Bash(gh issue edit:*)",
+      "Bash(gh issue view:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr diff:*)",
       "Bash(gh pr list:*)",


### PR DESCRIPTION
## Summary

- Added `Bash(gh issue view:*)` to Claude Code allowlist
- Added `Bash(gh issue edit:*)` to Claude Code allowlist
- Note: `just format` was already covered by the existing `Bash(just:*)` wildcard

## Verification

- Commands added in alphabetical order within the gh commands section
- Pre-commit hooks passed successfully
- Git diff shows clean two-line addition

Closes #502