### PR TITLE
feat: add Release Please integration to vibetuner-template

### DIFF
--- a/vibetuner-template/.github/workflows/pr-title-check.yml
+++ b/vibetuner-template/.github/workflows/pr-title-check.yml
@@ -1,0 +1,41 @@
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Conventional commit types from your CLAUDE.md
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            style
+            test
+            perf
+            ci
+            build
+          # Require a colon after the type
+          requireScope: false
+          # Allow uppercase in subject (e.g., "API" is fine)
+          subjectPattern: ^.+$
+          # Custom error message
+          subjectPatternError: |
+            The subject must not be empty.
+          # Validate whole title format
+          validateSingleCommit: false
+          # Don't ignore merge commits
+          ignoreLabels: |
+            skip-changelog

--- a/vibetuner-template/.github/workflows/release.yml
+++ b/vibetuner-template/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Release Please
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .release-please-config.json

--- a/vibetuner-template/.release-please-config.json
+++ b/vibetuner-template/.release-please-config.json
@@ -1,0 +1,49 @@
+{
+  "packages": {
+    ".": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "simple",
+      "include-component-in-tag": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous Chores"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation Updates"
+        },
+        {
+          "type": "ci",
+          "section": "CI/CD Changes"
+        },
+        {
+          "type": "style",
+          "section": "Styling Changes"
+        },
+        {
+          "type": "build",
+          "section": "Build System"
+        }
+      ]
+    }
+  }
+}

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -2,6 +2,72 @@
 
 FastAPI + MongoDB + HTMX web application scaffolded from AllTuner's template.
 
+## PR Title Conventions for AI Assistants
+
+This project uses **Release Please** for automated changelog generation and versioning.
+When creating PRs, use **conventional commit format** for PR titles:
+
+### Required Format
+
+```text
+<type>[optional scope]: <description>
+```
+
+### Supported Types
+
+- `feat:` New features (triggers MINOR version)
+- `fix:` Bug fixes (triggers PATCH version)
+- `docs:` Documentation changes (triggers PATCH version)
+- `chore:` Maintenance, dependencies (triggers PATCH version)
+- `refactor:` Code refactoring (triggers PATCH version)
+- `style:` Formatting, linting (triggers PATCH version)
+- `test:` Test changes (triggers PATCH version)
+- `perf:` Performance improvements (triggers MINOR version)
+- `ci:` CI/CD changes (triggers PATCH version)
+- `build:` Build system changes (triggers PATCH version)
+
+### Breaking Changes
+
+Add `!` to indicate breaking changes (triggers MAJOR version):
+
+- `feat!: remove deprecated API`
+- `fix!: change database schema`
+
+### Examples
+
+```text
+feat: add OAuth authentication support
+fix: resolve Docker build failure
+docs: update installation guide
+chore: bump FastAPI dependency
+feat!: remove deprecated authentication system
+```
+
+### Why This Matters
+
+- PR titles become commit messages after squash
+- Every merged PR creates/updates a Release Please PR
+- Release happens when the Release Please PR is merged
+- Automatic changelog generation from PR titles
+- Professional release notes for users
+
+### Release Workflow
+
+1. Merge any PR → Release Please creates/updates a release PR
+2. Review the release PR (version bump + changelog)
+3. Merge the release PR when ready to release
+4. Release Please creates a GitHub release with a git tag
+5. The git tag is automatically picked up by `uv-dynamic-versioning` for builds
+
+### Versioning
+
+This project uses **git tags** for versioning:
+
+- Release Please manages git tags (e.g., `v1.2.3`)
+- `uv-dynamic-versioning` reads the git tag to set package version
+- No manual version file updates needed
+- Build system automatically uses the latest git tag
+
 ## Tech Stack
 
 **Backend**: FastAPI, MongoDB (Beanie ODM), Redis (optional)


### PR DESCRIPTION
## Summary

This PR integrates Release Please into the vibetuner-template, enabling automated changelog generation and GitHub releases for all scaffolded projects.

## Changes

- **`.release-please-config.json`**: Simplified Release Please configuration
  - Same changelog sections and version bump rules as root vibetuner
  - No `extra-files` (relies on git tags via `uv-dynamic-versioning`)
  - No `.release-please-manifest.json` (auto-detects from existing git tags)

- **`.github/workflows/release.yml`**: Minimal release workflow
  - Runs Release Please on push to main
  - Creates/updates Release Please PRs with changelog
  - Creates GitHub releases with git tags when merged
  - **No package publishing** (unlike root vibetuner)

- **`.github/workflows/pr-title-check.yml`**: PR title validation
  - Enforces conventional commit format
  - Same types as Release Please config

- **`AGENTS.md`**: Documentation updates
  - PR title conventions and examples
  - Release workflow explanation (5-step process)
  - Versioning approach with git tags + `uv-dynamic-versioning`

## Design Decisions

### No Manifest File
- Release Please auto-detects latest tag from git history
- ✅ Existing projects: Continue from current version
- ✅ New projects: Start clean (first commit determines version)

### Git Tags Only
- No manual version file updates
- `uv-dynamic-versioning` reads from git tags automatically
- Perfect integration with existing build system

### Minimal Workflow
- Only changelog + GitHub releases
- No PyPI/npm publishing (scaffolded projects manage their own)
- No docs deployment
- Clean separation from root vibetuner's monorepo workflow

## Testing

- Verified scaffolding command still works
- Pre-commit hooks pass
- Configuration mirrors root vibetuner's proven setup

## Impact

After merge, all new scaffolded projects will include:
- Automated changelog generation
- Professional release workflow
- PR title validation
- Git tag-based versioning