### PR TITLE
chore: update dependencies

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2697,7 +2697,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "2.27.1"
+version = "2.28.0"
 source = { directory = "vibetuner-py" }
 dependencies = [
     { name = "aioboto3" },
@@ -2797,7 +2797,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "vibetuner-scaffolding"
-version = "2.27.1"
+version = "2.28.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2691,7 +2691,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "2.27.1"
+version = "2.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@alltuner/vibetuner": "^2.27.0"
+    "@alltuner/vibetuner": "^2.28.0"
   },
   "dependencies": {},
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump version from 2.27.1 to 2.28.0 in lockfiles
- Update vibetuner dependency in template package.json

## Changes

- Updated `uv.lock` with new vibetuner and vibetuner-scaffolding versions
- Updated `vibetuner-py/uv.lock` with new vibetuner version
- Updated `vibetuner-template/package.json` to use ^2.28.0

## Testing

- Verified lockfiles are properly updated
- No functionality changes, version bump only