### PR TITLE
chore: remove unused ffmpeg dependency from Dockerfile

### DIFF
--- a/vibetuner-template/Dockerfile
+++ b/vibetuner-template/Dockerfile
@@ -112,9 +112,6 @@ FROM python:${PYTHON_VERSION}-slim AS runtime
 
 ARG ENVIRONMENT=development
 
-COPY --from=mwader/static-ffmpeg:7.1.1 /ffmpeg /usr/local/bin/
-COPY --from=mwader/static-ffmpeg:7.1.1 /ffprobe /usr/local/bin/
-
 WORKDIR /app
 
 # Copy Python virtual environment with all dependencies and project


### PR DESCRIPTION
## Summary

- Removed statically linked ffmpeg and ffprobe from vibetuner-template Dockerfile
- Investigation confirmed no code references to ffmpeg/ffprobe in the entire codebase
- No Python dependencies require ffmpeg (no pydub, moviepy, imageio, opencv, or pyav)
- Reduces final Docker image size by removing unnecessary ~100MB binaries

Closes #505