### PR TITLE
fix(email): replace blocking boto3 with async aioboto3 in SESEmailService

### DIFF
--- a/vibetuner-py/src/vibetuner/services/email.py
+++ b/vibetuner-py/src/vibetuner/services/email.py
@@ -6,7 +6,7 @@ To extend email functionality, create wrapper services in the parent services di
 
 from typing import Literal
 
-import boto3
+import aioboto3
 
 from vibetuner.config import settings
 
@@ -17,11 +17,9 @@ SES_SERVICE_NAME: Literal["ses"] = "ses"
 class SESEmailService:
     def __init__(
         self,
-        ses_client=None,
         from_email: str | None = None,
     ) -> None:
-        self.ses_client = ses_client or boto3.client(
-            service_name=SES_SERVICE_NAME,
+        self.session = aioboto3.Session(
             region_name=settings.project.aws_default_region,
             aws_access_key_id=settings.aws_access_key_id.get_secret_value()
             if settings.aws_access_key_id
@@ -36,15 +34,16 @@ class SESEmailService:
         self, to_address: str, subject: str, html_body: str, text_body: str
     ):
         """Send email using Amazon SES"""
-        response = self.ses_client.send_email(
-            Source=self.from_email,
-            Destination={"ToAddresses": [to_address]},
-            Message={
-                "Subject": {"Data": subject, "Charset": "UTF-8"},
-                "Body": {
-                    "Html": {"Data": html_body, "Charset": "UTF-8"},
-                    "Text": {"Data": text_body, "Charset": "UTF-8"},
+        async with self.session.client(SES_SERVICE_NAME) as ses_client:
+            response = await ses_client.send_email(
+                Source=self.from_email,
+                Destination={"ToAddresses": [to_address]},
+                Message={
+                    "Subject": {"Data": subject, "Charset": "UTF-8"},
+                    "Body": {
+                        "Html": {"Data": html_body, "Charset": "UTF-8"},
+                        "Text": {"Data": text_body, "Charset": "UTF-8"},
+                    },
                 },
-            },
-        )
-        return response
+            )
+            return response


### PR DESCRIPTION
## Summary

- Replaced sync `boto3.client()` with async `aioboto3.Session()` in SESEmailService
- Changed `send_email()` to properly use async/await with context manager pattern
- Removed `ses_client` parameter from `__init__` (no longer needed with session-based approach)
- Now properly non-blocking during magic-link login spikes

## Technical Details

**Before:**
- Used `boto3.client()` which is synchronous
- `async def send_email()` called sync `ses_client.send_email()` directly
- Blocked FastAPI/Granian event loop during SES API calls

**After:**
- Uses `aioboto3.Session()` for async AWS operations
- `async with session.client('ses')` creates async context manager
- Properly awaits `await ses_client.send_email()`
- Non-blocking - event loop can handle other requests during SES calls

Closes #451