### PR TITLE
feat: add Redis key namespacing by project and environment

### DIFF
--- a/vibetuner-py/src/vibetuner/services/redis.py
+++ b/vibetuner-py/src/vibetuner/services/redis.py
@@ -1,0 +1,306 @@
+# ABOUTME: Redis client wrapper that applies project/environment namespace prefixing
+# ABOUTME: Ensures all Redis keys are isolated by project and environment
+
+from typing import Any
+
+from redis.asyncio import Redis
+
+
+class NamespacedRedis:
+    """Redis client wrapper that automatically prefixes all keys with project namespace.
+
+    All keys are prefixed with "{project_slug}:{env}:" for dev or "{project_slug}:" for prod.
+    This ensures Redis key isolation when multiple projects or environments share the same
+    Redis instance.
+    """
+
+    def __init__(self, redis: Redis, prefix: str) -> None:
+        self._redis = redis
+        self._prefix = prefix
+
+    def _prefixed(self, key: str) -> str:
+        return f"{self._prefix}{key}"
+
+    def _prefixed_keys(self, keys: list[str]) -> list[str]:
+        return [self._prefixed(k) for k in keys]
+
+    # String operations
+
+    async def get(self, key: str) -> Any:
+        return await self._redis.get(self._prefixed(key))
+
+    async def set(
+        self,
+        key: str,
+        value: Any,
+        ex: int | None = None,
+        px: int | None = None,
+        nx: bool = False,
+        xx: bool = False,
+    ) -> Any:
+        return await self._redis.set(
+            self._prefixed(key), value, ex=ex, px=px, nx=nx, xx=xx
+        )
+
+    async def setex(self, key: str, seconds: int, value: Any) -> Any:
+        return await self._redis.setex(self._prefixed(key), seconds, value)
+
+    async def setnx(self, key: str, value: Any) -> bool:
+        return await self._redis.setnx(self._prefixed(key), value)
+
+    async def delete(self, *keys: str) -> int:
+        return await self._redis.delete(*self._prefixed_keys(list(keys)))
+
+    async def exists(self, *keys: str) -> int:
+        return await self._redis.exists(*self._prefixed_keys(list(keys)))
+
+    async def expire(self, key: str, seconds: int) -> bool:
+        return await self._redis.expire(self._prefixed(key), seconds)
+
+    async def ttl(self, key: str) -> int:
+        return await self._redis.ttl(self._prefixed(key))
+
+    async def incr(self, key: str) -> int:
+        return await self._redis.incr(self._prefixed(key))
+
+    async def decr(self, key: str) -> int:
+        return await self._redis.decr(self._prefixed(key))
+
+    async def incrby(self, key: str, amount: int) -> int:
+        return await self._redis.incrby(self._prefixed(key), amount)
+
+    # Hash operations
+
+    async def hget(self, name: str, key: str) -> Any:
+        return await self._redis.hget(self._prefixed(name), key)
+
+    async def hset(
+        self,
+        name: str,
+        key: str | None = None,
+        value: Any = None,
+        mapping: dict[str, Any] | None = None,
+    ) -> int:
+        return await self._redis.hset(
+            self._prefixed(name), key=key, value=value, mapping=mapping
+        )
+
+    async def hgetall(self, name: str) -> dict[str, Any]:
+        return await self._redis.hgetall(self._prefixed(name))
+
+    async def hdel(self, name: str, *keys: str) -> int:
+        return await self._redis.hdel(self._prefixed(name), *keys)
+
+    async def hexists(self, name: str, key: str) -> bool:
+        return await self._redis.hexists(self._prefixed(name), key)
+
+    async def hincrby(self, name: str, key: str, amount: int = 1) -> int:
+        return await self._redis.hincrby(self._prefixed(name), key, amount)
+
+    # List operations
+
+    async def lpush(self, name: str, *values: Any) -> int:
+        return await self._redis.lpush(self._prefixed(name), *values)
+
+    async def rpush(self, name: str, *values: Any) -> int:
+        return await self._redis.rpush(self._prefixed(name), *values)
+
+    async def lpop(self, name: str, count: int | None = None) -> Any:
+        return await self._redis.lpop(self._prefixed(name), count)
+
+    async def rpop(self, name: str, count: int | None = None) -> Any:
+        return await self._redis.rpop(self._prefixed(name), count)
+
+    async def lrange(self, name: str, start: int, end: int) -> list[Any]:
+        return await self._redis.lrange(self._prefixed(name), start, end)
+
+    async def llen(self, name: str) -> int:
+        return await self._redis.llen(self._prefixed(name))
+
+    # Set operations
+
+    async def sadd(self, name: str, *values: Any) -> int:
+        return await self._redis.sadd(self._prefixed(name), *values)
+
+    async def srem(self, name: str, *values: Any) -> int:
+        return await self._redis.srem(self._prefixed(name), *values)
+
+    async def smembers(self, name: str) -> set[Any]:
+        return await self._redis.smembers(self._prefixed(name))
+
+    async def sismember(self, name: str, value: Any) -> bool:
+        return await self._redis.sismember(self._prefixed(name), value)
+
+    async def scard(self, name: str) -> int:
+        return await self._redis.scard(self._prefixed(name))
+
+    # Sorted set operations
+
+    async def zadd(
+        self, name: str, mapping: dict[str, float], nx: bool = False, xx: bool = False
+    ) -> int:
+        return await self._redis.zadd(self._prefixed(name), mapping, nx=nx, xx=xx)
+
+    async def zrem(self, name: str, *values: Any) -> int:
+        return await self._redis.zrem(self._prefixed(name), *values)
+
+    async def zrange(
+        self, name: str, start: int, end: int, withscores: bool = False
+    ) -> list[Any]:
+        return await self._redis.zrange(
+            self._prefixed(name), start, end, withscores=withscores
+        )
+
+    async def zrangebyscore(
+        self,
+        name: str,
+        min_score: float,
+        max_score: float,
+        withscores: bool = False,
+    ) -> list[Any]:
+        return await self._redis.zrangebyscore(
+            self._prefixed(name), min_score, max_score, withscores=withscores
+        )
+
+    async def zscore(self, name: str, value: Any) -> float | None:
+        return await self._redis.zscore(self._prefixed(name), value)
+
+    async def zcard(self, name: str) -> int:
+        return await self._redis.zcard(self._prefixed(name))
+
+    # Key pattern operations (prefix is applied to pattern)
+
+    async def keys(self, pattern: str = "*") -> list[str]:
+        prefixed_pattern = self._prefixed(pattern)
+        keys = await self._redis.keys(prefixed_pattern)
+        prefix_len = len(self._prefix)
+        return [
+            k[prefix_len:] if isinstance(k, str) else k.decode()[prefix_len:]
+            for k in keys
+        ]
+
+    # Pipeline support
+
+    def pipeline(self, transaction: bool = True) -> "NamespacedPipeline":
+        return NamespacedPipeline(self._redis.pipeline(transaction), self._prefix)
+
+    # Access to underlying client for advanced operations
+
+    @property
+    def raw(self) -> Redis:
+        """Access the underlying Redis client for operations not covered by this wrapper."""
+        return self._redis
+
+    @property
+    def prefix(self) -> str:
+        """The prefix applied to all keys."""
+        return self._prefix
+
+
+class NamespacedPipeline:
+    """Pipeline wrapper that applies namespace prefix to all operations."""
+
+    def __init__(self, pipeline: Any, prefix: str) -> None:
+        self._pipeline = pipeline
+        self._prefix = prefix
+
+    def _prefixed(self, key: str) -> str:
+        return f"{self._prefix}{key}"
+
+    async def execute(self) -> list[Any]:
+        return await self._pipeline.execute()
+
+    # String operations
+
+    def get(self, key: str) -> "NamespacedPipeline":
+        self._pipeline.get(self._prefixed(key))
+        return self
+
+    def set(
+        self,
+        key: str,
+        value: Any,
+        ex: int | None = None,
+        px: int | None = None,
+    ) -> "NamespacedPipeline":
+        self._pipeline.set(self._prefixed(key), value, ex=ex, px=px)
+        return self
+
+    def delete(self, *keys: str) -> "NamespacedPipeline":
+        for key in keys:
+            self._pipeline.delete(self._prefixed(key))
+        return self
+
+    def incr(self, key: str) -> "NamespacedPipeline":
+        self._pipeline.incr(self._prefixed(key))
+        return self
+
+    def expire(self, key: str, seconds: int) -> "NamespacedPipeline":
+        self._pipeline.expire(self._prefixed(key), seconds)
+        return self
+
+    # Hash operations
+
+    def hset(
+        self,
+        name: str,
+        key: str | None = None,
+        value: Any = None,
+        mapping: dict[str, Any] | None = None,
+    ) -> "NamespacedPipeline":
+        self._pipeline.hset(self._prefixed(name), key=key, value=value, mapping=mapping)
+        return self
+
+    def hget(self, name: str, key: str) -> "NamespacedPipeline":
+        self._pipeline.hget(self._prefixed(name), key)
+        return self
+
+    def hgetall(self, name: str) -> "NamespacedPipeline":
+        self._pipeline.hgetall(self._prefixed(name))
+        return self
+
+    # List operations
+
+    def lpush(self, name: str, *values: Any) -> "NamespacedPipeline":
+        self._pipeline.lpush(self._prefixed(name), *values)
+        return self
+
+    def rpush(self, name: str, *values: Any) -> "NamespacedPipeline":
+        self._pipeline.rpush(self._prefixed(name), *values)
+        return self
+
+    # Set operations
+
+    def sadd(self, name: str, *values: Any) -> "NamespacedPipeline":
+        self._pipeline.sadd(self._prefixed(name), *values)
+        return self
+
+    def smembers(self, name: str) -> "NamespacedPipeline":
+        self._pipeline.smembers(self._prefixed(name))
+        return self
+
+    # Sorted set operations
+
+    def zadd(self, name: str, mapping: dict[str, float]) -> "NamespacedPipeline":
+        self._pipeline.zadd(self._prefixed(name), mapping)
+        return self
+
+    def zrange(
+        self, name: str, start: int, end: int, withscores: bool = False
+    ) -> "NamespacedPipeline":
+        self._pipeline.zrange(self._prefixed(name), start, end, withscores=withscores)
+        return self
+
+
+async def create_namespaced_redis(redis_url: str, prefix: str) -> NamespacedRedis:
+    """Create a namespaced Redis client.
+
+    Args:
+        redis_url: Redis connection URL
+        prefix: Key prefix (typically from settings.redis_key_prefix)
+
+    Returns:
+        NamespacedRedis client with automatic key prefixing
+    """
+    redis = Redis.from_url(redis_url, decode_responses=True)
+    return NamespacedRedis(redis, prefix)

--- a/vibetuner-py/src/vibetuner/tasks/worker.py
+++ b/vibetuner-py/src/vibetuner/tasks/worker.py
@@ -6,10 +6,6 @@ from vibetuner.tasks.lifespan import lifespan
 
 worker = Worker(
     redis_url=str(settings.redis_url),
-    queue_name=(
-        settings.project.project_slug
-        if not settings.debug
-        else f"debug-{settings.project.project_slug}"
-    ),
+    queue_name=settings.redis_key_prefix.rstrip(":"),
     lifespan=lifespan,
 )

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -1,0 +1,61 @@
+# ABOUTME: Unit tests for vibetuner.config module
+# ABOUTME: Tests environment configuration and redis_key_prefix computation
+# ruff: noqa: S101
+
+from unittest.mock import patch
+
+import pytest
+from vibetuner.config import CoreConfiguration, ProjectConfiguration
+
+
+class TestCoreConfigurationEnvironment:
+    """Test environment configuration in CoreConfiguration."""
+
+    def test_environment_default_is_dev(self):
+        """Test that environment defaults to 'dev'."""
+        with patch.dict("os.environ", {}, clear=True):
+            config = CoreConfiguration(project=ProjectConfiguration())
+            assert config.environment == "dev"
+
+    def test_environment_from_env_var(self):
+        """Test that environment can be set via ENVIRONMENT env var."""
+        with patch.dict("os.environ", {"ENVIRONMENT": "prod"}, clear=False):
+            config = CoreConfiguration(project=ProjectConfiguration())
+            assert config.environment == "prod"
+
+    def test_environment_validation(self):
+        """Test that environment only accepts 'dev' or 'prod'."""
+        with pytest.raises(ValueError):
+            CoreConfiguration(project=ProjectConfiguration(), environment="invalid")
+
+
+class TestRedisKeyPrefix:
+    """Test redis_key_prefix computed property."""
+
+    def test_redis_key_prefix_dev_environment(self):
+        """Test redis_key_prefix format for dev environment."""
+        project = ProjectConfiguration(project_slug="myproject")
+        config = CoreConfiguration(project=project, environment="dev")
+        assert config.redis_key_prefix == "myproject:dev:"
+
+    def test_redis_key_prefix_prod_environment(self):
+        """Test redis_key_prefix format for prod environment."""
+        project = ProjectConfiguration(project_slug="myproject")
+        config = CoreConfiguration(project=project, environment="prod")
+        assert config.redis_key_prefix == "myproject:"
+
+    def test_redis_key_prefix_with_different_slugs(self):
+        """Test redis_key_prefix with different project slugs."""
+        test_cases = [
+            ("simple", "dev", "simple:dev:"),
+            ("my_project", "dev", "my_project:dev:"),
+            ("app123", "prod", "app123:"),
+            ("test-app", "prod", "test-app:"),
+        ]
+
+        for slug, env, expected in test_cases:
+            project = ProjectConfiguration(project_slug=slug)
+            config = CoreConfiguration(project=project, environment=env)
+            assert config.redis_key_prefix == expected, (
+                f"Failed for slug={slug}, env={env}"
+            )

--- a/vibetuner-py/tests/unit/test_redis_service.py
+++ b/vibetuner-py/tests/unit/test_redis_service.py
@@ -1,0 +1,262 @@
+# ABOUTME: Unit tests for vibetuner.services.redis module
+# ABOUTME: Tests NamespacedRedis key prefixing functionality
+# ruff: noqa: S101
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from vibetuner.services.redis import NamespacedPipeline, NamespacedRedis
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock Redis client."""
+    redis = AsyncMock()
+    redis.pipeline = MagicMock(return_value=AsyncMock())
+    return redis
+
+
+@pytest.fixture
+def namespaced_redis(mock_redis):
+    """Create a NamespacedRedis instance with a test prefix."""
+    return NamespacedRedis(mock_redis, "testproject:dev:")
+
+
+class TestNamespacedRedisStringOperations:
+    """Test string operations with namespace prefixing."""
+
+    @pytest.mark.asyncio
+    async def test_get_prefixes_key(self, namespaced_redis, mock_redis):
+        """Test that get() prefixes the key."""
+        await namespaced_redis.get("mykey")
+        mock_redis.get.assert_called_once_with("testproject:dev:mykey")
+
+    @pytest.mark.asyncio
+    async def test_set_prefixes_key(self, namespaced_redis, mock_redis):
+        """Test that set() prefixes the key."""
+        await namespaced_redis.set("mykey", "myvalue", ex=60)
+        mock_redis.set.assert_called_once_with(
+            "testproject:dev:mykey", "myvalue", ex=60, px=None, nx=False, xx=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_setex_prefixes_key(self, namespaced_redis, mock_redis):
+        """Test that setex() prefixes the key."""
+        await namespaced_redis.setex("mykey", 3600, "myvalue")
+        mock_redis.setex.assert_called_once_with(
+            "testproject:dev:mykey", 3600, "myvalue"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_prefixes_keys(self, namespaced_redis, mock_redis):
+        """Test that delete() prefixes all keys."""
+        await namespaced_redis.delete("key1", "key2", "key3")
+        mock_redis.delete.assert_called_once_with(
+            "testproject:dev:key1", "testproject:dev:key2", "testproject:dev:key3"
+        )
+
+    @pytest.mark.asyncio
+    async def test_exists_prefixes_keys(self, namespaced_redis, mock_redis):
+        """Test that exists() prefixes all keys."""
+        await namespaced_redis.exists("key1", "key2")
+        mock_redis.exists.assert_called_once_with(
+            "testproject:dev:key1", "testproject:dev:key2"
+        )
+
+    @pytest.mark.asyncio
+    async def test_incr_prefixes_key(self, namespaced_redis, mock_redis):
+        """Test that incr() prefixes the key."""
+        await namespaced_redis.incr("counter")
+        mock_redis.incr.assert_called_once_with("testproject:dev:counter")
+
+
+class TestNamespacedRedisHashOperations:
+    """Test hash operations with namespace prefixing."""
+
+    @pytest.mark.asyncio
+    async def test_hget_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that hget() prefixes the hash name."""
+        await namespaced_redis.hget("myhash", "field")
+        mock_redis.hget.assert_called_once_with("testproject:dev:myhash", "field")
+
+    @pytest.mark.asyncio
+    async def test_hset_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that hset() prefixes the hash name."""
+        await namespaced_redis.hset("myhash", key="field", value="value")
+        mock_redis.hset.assert_called_once_with(
+            "testproject:dev:myhash", key="field", value="value", mapping=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_hgetall_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that hgetall() prefixes the hash name."""
+        await namespaced_redis.hgetall("myhash")
+        mock_redis.hgetall.assert_called_once_with("testproject:dev:myhash")
+
+
+class TestNamespacedRedisListOperations:
+    """Test list operations with namespace prefixing."""
+
+    @pytest.mark.asyncio
+    async def test_lpush_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that lpush() prefixes the list name."""
+        await namespaced_redis.lpush("mylist", "value1", "value2")
+        mock_redis.lpush.assert_called_once_with(
+            "testproject:dev:mylist", "value1", "value2"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rpush_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that rpush() prefixes the list name."""
+        await namespaced_redis.rpush("mylist", "value1")
+        mock_redis.rpush.assert_called_once_with("testproject:dev:mylist", "value1")
+
+    @pytest.mark.asyncio
+    async def test_lrange_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that lrange() prefixes the list name."""
+        await namespaced_redis.lrange("mylist", 0, -1)
+        mock_redis.lrange.assert_called_once_with("testproject:dev:mylist", 0, -1)
+
+
+class TestNamespacedRedisSetOperations:
+    """Test set operations with namespace prefixing."""
+
+    @pytest.mark.asyncio
+    async def test_sadd_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that sadd() prefixes the set name."""
+        await namespaced_redis.sadd("myset", "value1", "value2")
+        mock_redis.sadd.assert_called_once_with(
+            "testproject:dev:myset", "value1", "value2"
+        )
+
+    @pytest.mark.asyncio
+    async def test_smembers_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that smembers() prefixes the set name."""
+        await namespaced_redis.smembers("myset")
+        mock_redis.smembers.assert_called_once_with("testproject:dev:myset")
+
+
+class TestNamespacedRedisSortedSetOperations:
+    """Test sorted set operations with namespace prefixing."""
+
+    @pytest.mark.asyncio
+    async def test_zadd_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that zadd() prefixes the sorted set name."""
+        await namespaced_redis.zadd("myzset", {"member1": 1.0, "member2": 2.0})
+        mock_redis.zadd.assert_called_once_with(
+            "testproject:dev:myzset",
+            {"member1": 1.0, "member2": 2.0},
+            nx=False,
+            xx=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_zrange_prefixes_name(self, namespaced_redis, mock_redis):
+        """Test that zrange() prefixes the sorted set name."""
+        await namespaced_redis.zrange("myzset", 0, -1, withscores=True)
+        mock_redis.zrange.assert_called_once_with(
+            "testproject:dev:myzset", 0, -1, withscores=True
+        )
+
+
+class TestNamespacedRedisKeys:
+    """Test keys() operation with namespace handling."""
+
+    @pytest.mark.asyncio
+    async def test_keys_prefixes_pattern(self, namespaced_redis, mock_redis):
+        """Test that keys() prefixes the pattern."""
+        mock_redis.keys.return_value = [
+            "testproject:dev:user:1",
+            "testproject:dev:user:2",
+        ]
+        result = await namespaced_redis.keys("user:*")
+        mock_redis.keys.assert_called_once_with("testproject:dev:user:*")
+        assert result == ["user:1", "user:2"]
+
+    @pytest.mark.asyncio
+    async def test_keys_returns_unprefixed_keys(self, namespaced_redis, mock_redis):
+        """Test that keys() returns keys without the prefix."""
+        mock_redis.keys.return_value = [
+            "testproject:dev:cache:session:abc",
+            "testproject:dev:cache:session:def",
+        ]
+        result = await namespaced_redis.keys("cache:session:*")
+        assert result == ["cache:session:abc", "cache:session:def"]
+
+
+class TestNamespacedRedisProperties:
+    """Test NamespacedRedis properties."""
+
+    def test_raw_property_returns_underlying_client(self, namespaced_redis, mock_redis):
+        """Test that raw property returns the underlying Redis client."""
+        assert namespaced_redis.raw is mock_redis
+
+    def test_prefix_property_returns_prefix(self, namespaced_redis):
+        """Test that prefix property returns the configured prefix."""
+        assert namespaced_redis.prefix == "testproject:dev:"
+
+
+class TestNamespacedPipeline:
+    """Test NamespacedPipeline operations."""
+
+    @pytest.fixture
+    def mock_pipeline(self):
+        """Create a mock pipeline."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def namespaced_pipeline(self, mock_pipeline):
+        """Create a NamespacedPipeline instance."""
+        return NamespacedPipeline(mock_pipeline, "testproject:dev:")
+
+    def test_get_prefixes_key(self, namespaced_pipeline, mock_pipeline):
+        """Test that pipeline get() prefixes the key."""
+        namespaced_pipeline.get("mykey")
+        mock_pipeline.get.assert_called_once_with("testproject:dev:mykey")
+
+    def test_set_prefixes_key(self, namespaced_pipeline, mock_pipeline):
+        """Test that pipeline set() prefixes the key."""
+        namespaced_pipeline.set("mykey", "myvalue", ex=60)
+        mock_pipeline.set.assert_called_once_with(
+            "testproject:dev:mykey", "myvalue", ex=60, px=None
+        )
+
+    def test_methods_return_self_for_chaining(self, namespaced_pipeline):
+        """Test that pipeline methods return self for chaining."""
+        result = namespaced_pipeline.get("key1").set("key2", "value").incr("counter")
+        assert result is namespaced_pipeline
+
+    @pytest.mark.asyncio
+    async def test_execute_calls_underlying_pipeline(
+        self, namespaced_pipeline, mock_pipeline
+    ):
+        """Test that execute() calls the underlying pipeline."""
+        mock_pipeline.execute.return_value = ["result1", "result2"]
+        result = await namespaced_pipeline.execute()
+        mock_pipeline.execute.assert_called_once()
+        assert result == ["result1", "result2"]
+
+
+class TestDifferentPrefixes:
+    """Test NamespacedRedis with different prefix formats."""
+
+    @pytest.mark.asyncio
+    async def test_prod_prefix_format(self, mock_redis):
+        """Test with production prefix format (no env suffix)."""
+        redis = NamespacedRedis(mock_redis, "myproject:")
+        await redis.get("mykey")
+        mock_redis.get.assert_called_once_with("myproject:mykey")
+
+    @pytest.mark.asyncio
+    async def test_dev_prefix_format(self, mock_redis):
+        """Test with dev prefix format."""
+        redis = NamespacedRedis(mock_redis, "myproject:dev:")
+        await redis.get("mykey")
+        mock_redis.get.assert_called_once_with("myproject:dev:mykey")
+
+    @pytest.mark.asyncio
+    async def test_complex_key_names(self, mock_redis):
+        """Test with complex key names containing colons."""
+        redis = NamespacedRedis(mock_redis, "app:dev:")
+        await redis.get("cache:user:123:profile")
+        mock_redis.get.assert_called_once_with("app:dev:cache:user:123:profile")

--- a/vibetuner-template/.env.j2
+++ b/vibetuner-template/.env.j2
@@ -9,3 +9,4 @@ SESSION_KEY=ct-!secret-must-change-me
 
 # Application Configuration
 DEBUG=true
+ENVIRONMENT=dev


### PR DESCRIPTION
## Summary

- Add `environment` config field (`dev` | `prod`) to `CoreConfiguration`
- Add `redis_key_prefix` computed property that returns `{project_slug}:dev:` for dev or `{project_slug}:` for prod
- Create `NamespacedRedis` wrapper class for direct Redis usage with automatic key prefixing
- Update Streaq worker to use the new `redis_key_prefix` for queue naming
- Add `ENVIRONMENT=dev` to `.env.j2` template

### Resulting Redis Key Structure

**Streaq (background jobs):**
- Dev: `streaq:myproject:dev:queues:*`, `streaq:myproject:dev:task:*`
- Prod: `streaq:myproject:queues:*`, `streaq:myproject:task:*`

**Direct Redis (via NamespacedRedis):**
- Dev: `myproject:dev:cache:*`, `myproject:dev:session:*`
- Prod: `myproject:cache:*`, `myproject:session:*`

## Test plan

- [x] Unit tests for `CoreConfiguration.environment` validation
- [x] Unit tests for `redis_key_prefix` computation (6 tests)
- [x] Unit tests for `NamespacedRedis` wrapper (27 tests)
- [ ] Manual verification with scaffolded project

🤖 Generated with [Claude Code](https://claude.com/claude-code)