### PR TITLE
feat: add sdiff and sdiffstore to NamespacedRedis

### DIFF
--- a/vibetuner-py/src/vibetuner/services/redis.py
+++ b/vibetuner-py/src/vibetuner/services/redis.py
@@ -134,6 +134,14 @@ class NamespacedRedis:
     async def scard(self, name: str) -> int:
         return await self._redis.scard(self._prefixed(name))
 
+    async def sdiff(self, *keys: str) -> set[Any]:
+        return await self._redis.sdiff(*self._prefixed_keys(list(keys)))
+
+    async def sdiffstore(self, dest: str, *keys: str) -> int:
+        return await self._redis.sdiffstore(
+            self._prefixed(dest), *self._prefixed_keys(list(keys))
+        )
+
     # Sorted set operations
 
     async def zadd(

--- a/vibetuner-py/tests/unit/test_redis_service.py
+++ b/vibetuner-py/tests/unit/test_redis_service.py
@@ -135,6 +135,29 @@ class TestNamespacedRedisSetOperations:
         await namespaced_redis.smembers("myset")
         mock_redis.smembers.assert_called_once_with("testproject:dev:myset")
 
+    @pytest.mark.asyncio
+    async def test_sdiff_prefixes_all_keys(self, namespaced_redis, mock_redis):
+        """Test that sdiff() prefixes all set keys."""
+        mock_redis.sdiff.return_value = {"a", "b"}
+        result = await namespaced_redis.sdiff("set1", "set2", "set3")
+        mock_redis.sdiff.assert_called_once_with(
+            "testproject:dev:set1", "testproject:dev:set2", "testproject:dev:set3"
+        )
+        assert result == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_sdiffstore_prefixes_all_keys(self, namespaced_redis, mock_redis):
+        """Test that sdiffstore() prefixes destination and all source keys."""
+        mock_redis.sdiffstore.return_value = 2
+        result = await namespaced_redis.sdiffstore("dest", "set1", "set2", "set3")
+        mock_redis.sdiffstore.assert_called_once_with(
+            "testproject:dev:dest",
+            "testproject:dev:set1",
+            "testproject:dev:set2",
+            "testproject:dev:set3",
+        )
+        assert result == 2
+
 
 class TestNamespacedRedisSortedSetOperations:
     """Test sorted set operations with namespace prefixing."""


### PR DESCRIPTION
## Summary

- Add `sdiff(*keys)` method to `NamespacedRedis` that returns set difference with all keys prefixed
- Add `sdiffstore(dest, *keys)` method that stores the result into a prefixed destination key

## Use Case

Finding new URLs not in existing sets (per #569):

```python
new_urls = await redis.sdiff(
    "temp_new_urls",
    "existing_podcast_urls",
    "error:url_rss_parsing",
    "error:url_connection",
)
```

## Test plan

- [x] Unit tests verify all keys are properly prefixed for both methods
- [x] All 88 unit tests pass
- [x] Linting passes

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)