### PR TITLE
feat: optimize Docker build caching and parallelization

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -84,3 +84,5 @@ _tasks:
     when: "{{ _copier_operation == 'copy' }}"
   - command: [uv, run, prek, install]
     when: "{{ _copier_operation == 'copy' }}"
+  # Copy core templates for Docker build parallelization (runs on both copy and update)
+  - command: [uv, run, vibetuner, scaffold, copy-core-templates]

--- a/vibetuner-template/Dockerfile
+++ b/vibetuner-template/Dockerfile
@@ -7,8 +7,10 @@ ARG PYTHON_VERSION=3.13
 # ────────────────────────────────────────────────────────────────────────────────
 FROM python:${PYTHON_VERSION}-slim AS python-base
 
-RUN apt-get update && apt-get install -y --no-install-recommends git \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends git
 
 # Install UV package manager from official image
 COPY --from=ghcr.io/astral-sh/uv:0.9 /uv /uvx /bin/
@@ -27,16 +29,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
     uv sync --locked --no-install-project --no-group dev
-
-# Copy frontend templates from the venv into /core-frontend-templates
-RUN set -e; \
-    FRONTEND_DIR="$(find .venv -type d -path '*site-packages/vibetuner/templates/frontend' -print -quit)"; \
-    if [ -z "$FRONTEND_DIR" ]; then \
-    echo "ERROR: vibetuner frontend templates directory not found" >&2; \
-    exit 1; \
-    fi; \
-    mkdir -p /core-frontend-templates; \
-    cp -a "$FRONTEND_DIR/." /core-frontend-templates/
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Stage 2: Install Project with Version Information
@@ -94,8 +86,10 @@ RUN --mount=type=cache,id=bun,target=/root/.bun/install/cache \
 # ────────────────────────────────────────────────────────────────────────────────
 FROM frontend-deps AS frontend-build
 
-COPY /templates/frontend/ templates/frontend/
-COPY --from=python-base /core-frontend-templates/ core-frontend-templates/
+# Copy templates for Tailwind CSS class scanning
+# core-templates/ contains vibetuner framework templates, copied at scaffold time
+COPY templates/frontend/ templates/frontend/
+COPY core-templates/ core-templates/
 
 # Build production assets with Bun
 RUN --mount=type=cache,id=bun,target=/root/.bun/install/cache \
@@ -115,35 +109,34 @@ ARG ENVIRONMENT=dev
 WORKDIR /app
 
 # Copy Python virtual environment with all dependencies and project
-COPY --from=python-versioning --chown=app:app /app/.venv/ .venv/
+COPY --link --from=python-versioning /app/.venv/ .venv/
 
 # Copy static assets and markdown content (not full frontend source)
-COPY --chown=app:app assets/statics/ assets/statics/
-COPY --chown=app:app templates/markdown/ templates/markdown/
+COPY assets/statics/ assets/statics/
+COPY templates/markdown/ templates/markdown/
 
 # Copy compiled localization files (smaller than source .po files)
-COPY --from=locales --chown=app:app --parents /app/locales/*/LC_MESSAGES/messages.mo /
+COPY --link --from=locales --parents /app/locales/*/LC_MESSAGES/messages.mo /
 
 # Copy template files
-COPY --chown=app:app templates/frontend templates/frontend/
-COPY --chown=app:app templates/email templates/email/
+COPY templates/frontend templates/frontend/
+COPY templates/email templates/email/
 
 # Copy built frontend assets (CSS and JS bundles)
-COPY --from=frontend-build --chown=app:app /app/assets/statics/css/bundle.css assets/statics/css/bundle.css
-COPY --from=frontend-build --chown=app:app /app/assets/statics/js/bundle.js assets/statics/js/bundle.js
+COPY --link --from=frontend-build /app/assets/statics/css/bundle.css assets/statics/css/bundle.css
+COPY --link --from=frontend-build /app/assets/statics/js/bundle.js assets/statics/js/bundle.js
 
 # Copy application source code
-COPY --chown=app:app src/ src/
+COPY src/ src/
 
 # Copy version files from the versioning stage
-COPY --from=python-versioning --chown=app:app --parents /app/src/app/_version.py /
+COPY --link --from=python-versioning --parents /app/src/app/_version.py /
 
 # Copy configuration file
-COPY --chown=app:app .copier-answers.yml ./
+COPY .copier-answers.yml ./
 
-# Copy and make startup script executable
-COPY start.sh /start.sh
-RUN chmod +x /start.sh
+# Copy startup script with executable permissions (--chmod eliminates separate RUN layer)
+COPY --chmod=755 start.sh /start.sh
 
 # Configure environment for Python application
 ENV PATH="/app/.venv/bin:$PATH" \

--- a/vibetuner-template/config.css
+++ b/vibetuner-template/config.css
@@ -1,8 +1,8 @@
 /* Start of File: do not remove this comment and don't add anything above */
 /* Do not change anything between this comment and the next comment */
 @import "tailwindcss";
-/* Include the package supplied jinja templates when building bundles */
-@source "templates/core";
+/* Include the vibetuner core templates when building bundles */
+@source "core-templates";
 @plugin "daisyui" {
   // Remove this once this is fixed
   // https://github.com/saadeghi/daisyui/issues/3882

--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -4,8 +4,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "link-templates": "uv run vibetuner scaffold link templates/core",
-    "dev:css": "bun link-templates && bun tailwindcss -w -i config.css -o assets/statics/css/bundle.css",
+    "dev:css": "bun tailwindcss -w -i config.css -o assets/statics/css/bundle.css",
     "dev:js": "bun build config.js --watch --outdir=assets/statics/js --entry-naming=\"bundle.[ext]\" --sourcemap",
     "dev": "concurrently 'bun dev:css' 'bun dev:js'",
     "build-prod:css": "bun tailwindcss -i config.css --minify -o assets/statics/css/bundle.css",


### PR DESCRIPTION
## Summary

- Implements multiple Docker build optimizations for faster builds
- Bundles core templates at scaffold time for frontend build parallelization
- Removes obsolete `scaffold link` command and `link-templates` script

## Changes

### Dockerfile Optimizations (#582)

1. **APT cache mount** - Caches apt packages across builds
2. **COPY --chmod=755** - Eliminates separate RUN layer for start.sh
3. **COPY --link** - Better layer deduplication for `--from` references

### Fix --chown=app:app (#583)

Removed `--chown=app:app` which referenced a non-existent user. This:
- Was silently doing nothing (files owned by root anyway)
- Prevented using `COPY --link` optimization

### Bundle templates at scaffold time (#584)

**Before:** Frontend build blocked by Python dependency installation
```
python-base (25s) → extract templates → frontend-build (1s)
```

**After:** Frontend and Python builds run in parallel
```
frontend-deps (2s) → frontend-build (1s) ─┐
                                          ├→ runtime
python-base (25s) → python-versioning ────┘
```

#### How it works:
- `vibetuner scaffold copy-core-templates` command copies templates from the installed package
- Copier task runs this automatically on both `scaffold new` and `scaffold update`
- Docker just COPYs from build context - no extraction needed

### Breaking Changes

- Removed `vibetuner scaffold link` command (replaced by `copy-core-templates`)
- Removed `link-templates` script from package.json
- Projects need `core-templates/` directory (created automatically on scaffold update)

## Test plan

- [ ] Scaffold a new project and verify `core-templates/` is created
- [ ] Run `bun dev` and verify Tailwind finds all classes
- [ ] Build Docker image and verify it works
- [ ] Run `just update-scaffolding` on existing project and verify templates are copied

Fixes #582, fixes #583, fixes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)