### PR TITLE
fix(docker): use python directly in healthcheck

### DIFF
--- a/vibetuner-template/compose.prod.yml
+++ b/vibetuner-template/compose.prod.yml
@@ -37,8 +37,6 @@ services:
       test:
         [
           "CMD",
-          "uv",
-          "run",
           "python",
           "-c",
           "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/ping')",


### PR DESCRIPTION
## Summary

- Remove `uv run` from healthcheck command in `compose.prod.yml`
- Use `python` directly since it's available in the runtime image PATH via `.venv/bin`

The production runtime image does not include `uv`, causing the healthcheck to fail with:
```
exec: "uv": executable file not found in $PATH
```

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)