### PR TITLE
fix: allow CLI to run outside project directory

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -1,6 +1,5 @@
 # ABOUTME: Run commands for starting the application in different modes
 # ABOUTME: Supports dev/prod modes for frontend and worker services
-import os
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -131,7 +130,6 @@ def dev(
     ),
 ) -> None:
     """Run in development mode with hot reload (frontend or worker)."""
-    os.environ["DEBUG"] = "1"
     _run_service("dev", service, host, port, workers_count)
 
 
@@ -149,5 +147,4 @@ def prod(
     ),
 ) -> None:
     """Run in production mode (frontend or worker)."""
-    os.environ["ENVIRONMENT"] = "prod"
     _run_service("prod", service, host, port, workers_count)


### PR DESCRIPTION
## Summary

- Defer config loading in CLI so commands like `vibetuner --help` and `vibetuner scaffold` work outside a project directory
- Refactor `dev` and `prod` commands to reduce code duplication
- Remove dead `os.environ` assignments that had no effect (settings already loaded at import time)

## Problem

Running `uvx vibetuner` outside a project directory crashed with:

```
RuntimeError: Project root not detected. Cannot load project configuration.
```

This happened because `cli/run.py` imported `settings` at module level, which triggered config loading that requires `.copier-answers.yml`.

## Solution

Move the `settings` import from module level into the command functions that actually need it. This follows the same pattern already used in `cli/db.py`.

Also extracted common logic from `dev()` and `prod()` into helper functions (`_run_worker`, `_run_frontend`, `_run_service`) to reduce duplication.

## Test plan

- [ ] `uvx vibetuner --help` works outside project directory
- [ ] `uvx vibetuner scaffold new /tmp/test --defaults` works outside project directory
- [ ] `vibetuner run dev` still works inside a project

🤖 Generated with [Claude Code](https://claude.com/claude-code)