### PR TITLE
chore: remove direct sniffio dependency

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2793,7 +2793,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "2.36.4"
+version = "2.36.5"
 source = { directory = "vibetuner-py" }
 dependencies = [
     { name = "aioboto3" },
@@ -2816,7 +2816,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "redis", extra = ["hiredis"] },
     { name = "rich" },
-    { name = "sniffio" },
     { name = "sqlmodel" },
     { name = "sse-starlette" },
     { name = "starlette-babel" },
@@ -2883,7 +2882,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.7" },
     { name = "rumdl", marker = "extra == 'dev'", specifier = ">=0.0.186" },
     { name = "semver", marker = "extra == 'dev'", specifier = ">=3.0.4" },
-    { name = "sniffio", specifier = ">=1.3.1" },
     { name = "sqlmodel", specifier = ">=0.0.27" },
     { name = "sse-starlette", specifier = ">=3.0.3" },
     { name = "starlette-babel", specifier = ">=1.0.3" },
@@ -2901,7 +2899,7 @@ provides-extras = ["dev", "test"]
 
 [[package]]
 name = "vibetuner-scaffolding"
-version = "2.36.4"
+version = "2.36.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -41,10 +41,6 @@ dependencies = [
   "pyyaml>=6.0.3",
   "redis[hiredis]>=7.1.0",
   "rich>=14.2.0",
-  # FIXME: remove this dep once this is fixed
-  # https://github.com/litestar-org/litestar/issues/4505
-  # https://github.com/agronholm/anyio/pull/1021
-  "sniffio>=1.3.1",
   "sse-starlette>=3.0.3",
   "starlette-babel>=1.0.3",
   "starlette-htmx>=0.1.1",

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2834,7 +2834,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "2.36.4"
+version = "2.36.5"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -2857,7 +2857,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "redis", extra = ["hiredis"] },
     { name = "rich" },
-    { name = "sniffio" },
     { name = "sqlmodel" },
     { name = "sse-starlette" },
     { name = "starlette-babel" },
@@ -2928,7 +2927,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.7" },
     { name = "rumdl", marker = "extra == 'dev'", specifier = ">=0.0.186" },
     { name = "semver", marker = "extra == 'dev'", specifier = ">=3.0.4" },
-    { name = "sniffio", specifier = ">=1.3.1" },
     { name = "sqlmodel", specifier = ">=0.0.27" },
     { name = "sse-starlette", specifier = ">=3.0.3" },
     { name = "starlette-babel", specifier = ">=1.0.3" },


### PR DESCRIPTION
## Summary

- Remove direct `sniffio>=1.3.1` dependency from vibetuner-py
- asyncer now declares sniffio as a dependency (fastapi/asyncer#421 merged Dec 1, 2025)
- sniffio remains available transitively through asyncer

## Test plan

- [x] `uv sync` completes successfully
- [x] Lock files updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)