### PR TITLE
chore(template): add frontend-design skill to permissions whitelist

### DIFF
--- a/vibetuner-template/.claude/settings.json
+++ b/vibetuner-template/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "permissions": {
     "allow": [
+      "Skill(frontend-design:frontend-design)",
       "Bash(cat:*)",
       "Bash(curl:*)",
       "Bash(docker images:*)",


### PR DESCRIPTION
## Summary

- Adds the `frontend-design:frontend-design` skill to the Claude Code permissions whitelist in the vibetuner template
- This allows scaffolded projects to use the frontend-design skill without requiring manual permission approval

## Test plan

- [ ] Scaffold a new project and verify the skill is present in `.claude/settings.json`
- [ ] Verify the frontend-design skill can be invoked without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)