### PR TITLE
feat: dynamic vibetuner templates for Tailwind CSS scanning

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -71,11 +71,7 @@ enable_watchtower:
   when: "{{ fqdn }}"
 
 _tasks:
-  # uv sync must run first so vibetuner is available for copy-core-templates
   - command: [uv, sync]
-    when: "{{ _copier_operation == 'copy' }}"
-  # Copy core templates BEFORE git-init so they're included in initial commit
-  - command: [uv, run, vibetuner, scaffold, copy-core-templates]
     when: "{{ _copier_operation == 'copy' }}"
   - command: [just, git-init, "{{ project_slug }}"]
     when: "{{ _copier_operation == 'copy' }}"
@@ -83,6 +79,3 @@ _tasks:
     when: "{{ _copier_operation == 'copy' }}"
   - command: [uv, run, prek, install]
     when: "{{ _copier_operation == 'copy' }}"
-  # Also run on update to keep core-templates in sync
-  - command: [uv, run, vibetuner, scaffold, copy-core-templates]
-    when: "{{ _copier_operation == 'update' }}"

--- a/vibetuner-py/src/vibetuner/cli/scaffold.py
+++ b/vibetuner-py/src/vibetuner/cli/scaffold.py
@@ -1,6 +1,5 @@
 # ABOUTME: Scaffolding commands for creating new projects from the vibetuner template
 # ABOUTME: Uses Copier to generate FastAPI+MongoDB+HTMX projects with interactive prompts
-import shutil
 from pathlib import Path
 from typing import Annotated
 
@@ -8,26 +7,8 @@ import copier
 import typer
 from rich.console import Console
 
-from vibetuner.paths import package_templates
-
 
 console = Console()
-
-
-def _copy_core_templates(destination: Path) -> None:
-    """Copy vibetuner core templates to the project's core-templates directory.
-
-    This enables Docker builds to run frontend builds in parallel with Python
-    dependency installation by having templates available in the build context.
-    """
-    source = package_templates / "frontend"
-    dest = destination / "core-templates"
-
-    if dest.exists():
-        shutil.rmtree(dest)
-
-    shutil.copytree(source, dest)
-    console.print("[dim]Copied core templates to core-templates/[/dim]")
 
 
 scaffold_app = typer.Typer(
@@ -205,35 +186,3 @@ def update(
     except Exception as e:
         console.print(f"[red]Error updating project: {e}[/red]")
         raise typer.Exit(code=1) from None
-
-
-@scaffold_app.command(name="copy-core-templates")
-def copy_core_templates(
-    destination: Annotated[
-        Path | None,
-        typer.Argument(
-            help="Path to the project directory (defaults to current directory)",
-        ),
-    ] = None,
-) -> None:
-    """Copy vibetuner core templates to the project's core-templates directory.
-
-    This command copies templates from the installed vibetuner package to enable
-    Docker builds to run frontend builds in parallel with Python dependency
-    installation.
-
-    This is automatically run by copier during scaffold new/update, but can be
-    run manually if needed.
-
-    Examples:
-
-        # Copy templates to current directory
-        vibetuner scaffold copy-core-templates
-
-        # Copy templates to specific project
-        vibetuner scaffold copy-core-templates /path/to/project
-    """
-    if destination is None:
-        destination = Path.cwd()
-
-    _copy_core_templates(destination)

--- a/vibetuner-template/.gitignore
+++ b/vibetuner-template/.gitignore
@@ -32,9 +32,9 @@ node_modules/
 
 
 ############################################################
-# Core templates
+# Vibetuner templates (dynamically linked/copied)
 ############################################################
-/templates/core
+.core-templates
 
 
 ############################################################

--- a/vibetuner-template/Dockerfile
+++ b/vibetuner-template/Dockerfile
@@ -47,12 +47,13 @@ COPY src/ src/
 ARG VERSION=0.0.0
 ENV UV_DYNAMIC_VERSIONING_BYPASS=$VERSION
 
-# Install project in editable mode and clean up test/doc files
+# Install project in editable mode, copy vibetuner templates, and clean up test/doc files
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
     uv sync --locked --no-group dev && \
+    cp -r $(.venv/bin/python -c "import vibetuner; print(vibetuner.__path__[0])")/templates/frontend .core-templates && \
     find .venv -type d -name 'tests' -exec rm -rf {} + 2>/dev/null || true && \
     find .venv -type f \( -name '*.md' -o -name '*.rst' -o -name '*.txt' \) ! -path '*/METADATA' -delete 2>/dev/null || true
 
@@ -89,9 +90,8 @@ RUN --mount=type=cache,id=bun,target=/root/.bun/install/cache \
 FROM frontend-deps AS frontend-build
 
 # Copy templates for Tailwind CSS class scanning
-# core-templates/ contains vibetuner framework templates, copied at scaffold time
 COPY templates/frontend/ templates/frontend/
-COPY core-templates/ core-templates/
+COPY --from=python-app /app/.core-templates/ .core-templates/
 
 # Build production assets with Bun
 RUN --mount=type=cache,id=bun,target=/root/.bun/install/cache \

--- a/vibetuner-template/config.css
+++ b/vibetuner-template/config.css
@@ -1,8 +1,9 @@
 /* Start of File: do not remove this comment and don't add anything above */
 /* Do not change anything between this comment and the next comment */
-@import "tailwindcss";
-/* Include the vibetuner core templates when building bundles */
-@source "core-templates";
+@import "tailwindcss" source(none);
+@source "templates";
+@source "assets/statics/js";
+@source ".core-templates";
 @plugin "daisyui" {
   // Remove this once this is fixed
   // https://github.com/saadeghi/daisyui/issues/3882

--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -4,10 +4,11 @@
   },
   "dependencies": {},
   "scripts": {
-    "dev:css": "bun tailwindcss -w -i config.css -o assets/statics/css/bundle.css",
+    "setup-tw-sources": "[ -d .core-templates ] && [ ! -L .core-templates ] || (rm -rf .core-templates && ln -s $(uv run python -c \"import vibetuner; print(vibetuner.__path__[0])\")/templates/frontend .core-templates)",
+    "dev:css": "bun run setup-tw-sources && bun tailwindcss -w -i config.css -o assets/statics/css/bundle.css",
     "dev:js": "bun build config.js --watch --outdir=assets/statics/js --entry-naming=\"bundle.[ext]\" --sourcemap",
     "dev": "concurrently 'bun dev:css' 'bun dev:js'",
-    "build-prod:css": "bun tailwindcss -i config.css --minify -o assets/statics/css/bundle.css",
+    "build-prod:css": "bun run setup-tw-sources && bun tailwindcss -i config.css --minify -o assets/statics/css/bundle.css",
     "build-prod:js": "bun build config.js --minify --outdir=assets/statics/js --entry-naming=\"bundle.[ext]\"",
     "build-prod": "concurrently 'bun build-prod:css' 'bun build-prod:js'"
   }


### PR DESCRIPTION
## Summary

- Remove static `core-templates/` scaffolding in favor of dynamic template linking
- Add `setup-tw-sources` script that creates symlinks to installed vibetuner templates
- Update Dockerfile to copy templates from python-app stage during builds
- Use `source(none)` in config.css for restricted Tailwind scanning

## Details

Templates are now dynamically linked from the installed vibetuner package for local
development, and copied from the Python stage during Docker builds. This ensures:

1. **Always up-to-date**: Local dev uses templates from the installed vibetuner version
2. **No git duplication**: `.core-templates` is gitignored, not tracked
3. **CI/CD works**: Docker build copies templates from the Python stage
4. **Faster Tailwind builds**: Explicit `@source` directives restrict scanning scope

## Migration for Existing Projects

1. Remove `core-templates/` from git: `git rm -r --cached core-templates/`
2. Add `.core-templates` to `.gitignore`
3. Delete the local `core-templates/` directory
4. Update `package.json` with `setup-tw-sources` script
5. Update `config.css` to use `source(none)` and explicit `@source` directives
6. Update `Dockerfile` to copy templates from python-app stage

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)