### PR TITLE
feat: add auto-port selection for local development

### DIFF
--- a/vibetuner-template/.justfiles/localdev.justfile
+++ b/vibetuner-template/.justfiles/localdev.justfile
@@ -14,6 +14,11 @@ dev: install-deps
 local-dev PORT="8000": install-deps
     @vibetuner run dev --port {{ PORT }}
 
+# Runs local dev with auto-assigned port (deterministic per project path)
+[group('Local Development')]
+local-dev-auto: install-deps
+    @vibetuner run dev --auto-port
+
 # Runs the task worker locally without Docker
 [group('Local Development')]
 worker-dev: install-deps


### PR DESCRIPTION
## Summary
- Add `--auto-port` flag to `vibetuner run dev` that computes a deterministic port (8001-8999) based on the project's absolute path
- Add URL printing when starting frontend server (localhost + localdev.alltuner.com URLs)
- Add `local-dev-auto` justfile recipe for convenience

## Test plan
- [ ] Run `just local-dev-auto` in a scaffolded project and verify port is in 8001-8999 range
- [ ] Run same command again, verify same port is used (deterministic)
- [ ] Run in different project directory, verify different port
- [ ] Verify both URLs are printed on startup
- [ ] Test `--port` and `--auto-port` together errors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)