### PR TITLE
fix: run mise trust in new worktrees

### DIFF
--- a/vibetuner-template/.justfiles/worktrees.justfile
+++ b/vibetuner-template/.justfiles/worktrees.justfile
@@ -20,6 +20,9 @@ feature NAME:
         ln -sf "$(pwd)/.env" "$WORKTREE_DIR/.env"
     fi
 
+    # Trust mise configuration in the worktree
+    (cd "$WORKTREE_DIR" && mise trust)
+
     echo ""
     echo "Worktree created at: $WORKTREE_DIR"
     echo "Branch: $BRANCH_NAME"


### PR DESCRIPTION
## Summary
Run `mise trust` after creating a worktree to ensure the mise configuration is trusted in the new directory.

## Test plan
- [ ] Run `just feature test-feature` and verify `mise trust` is executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)