### PR TITLE
feat: improve worktree management with hash-based directories

### DIFF
--- a/vibetuner-template/.justfiles/worktrees.justfile
+++ b/vibetuner-template/.justfiles/worktrees.justfile
@@ -1,31 +1,80 @@
 # ABOUTME: Git worktree management commands
 # ABOUTME: Enables feature branch development in isolated worktrees
 
-# Start a new feature in a worktree
-feature NAME:
+# Helper to compute worktree directory from branch name
+_worktree-dir NAME:
+    @echo "worktrees/$(echo -n '{{NAME}}' | sha256sum | cut -c1-8)"
+
+# Create a new feature worktree
+[group('Features')]
+feature-new NAME:
     #!/usr/bin/env bash
     set -euo pipefail
-
-    WORKTREE_DIR="worktrees/{{NAME}}"
     BRANCH_NAME="{{NAME}}"
-
-    # Create worktrees directory if needed
+    HASH=$(echo -n "$BRANCH_NAME" | sha256sum | cut -c1-8)
+    WORKTREE_DIR="worktrees/$HASH"
     mkdir -p worktrees
-
-    # Create worktree from main
     git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" main
-
-    # Symlink .env if it exists
     if [[ -f .env ]]; then
         ln -sf "$(pwd)/.env" "$WORKTREE_DIR/.env"
     fi
-
-    # Trust mise configuration in the worktree
-    (cd "$WORKTREE_DIR" && mise trust)
-
+    command -v mise &> /dev/null && (cd "$WORKTREE_DIR" && mise trust) || true
     echo ""
     echo "Worktree created at: $WORKTREE_DIR"
     echo "Branch: $BRANCH_NAME"
     echo ""
     echo "To start working:"
     echo "  cd $WORKTREE_DIR"
+
+# Remove a feature worktree and delete branch (fails if unmerged)
+[group('Features')]
+feature-done NAME:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    BRANCH_NAME="{{NAME}}"
+    HASH=$(echo -n "$BRANCH_NAME" | sha256sum | cut -c1-8)
+    WORKTREE_DIR="worktrees/$HASH"
+    if [[ ! -d "$WORKTREE_DIR" ]]; then
+        echo "Error: Worktree not found at $WORKTREE_DIR"
+        exit 1
+    fi
+    git worktree remove "$WORKTREE_DIR"
+    git branch -d "$BRANCH_NAME"
+    echo "Removed worktree and branch: $BRANCH_NAME"
+
+# Force remove a feature worktree and delete branch (even if unmerged)
+[group('Features')]
+feature-drop NAME:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    BRANCH_NAME="{{NAME}}"
+    HASH=$(echo -n "$BRANCH_NAME" | sha256sum | cut -c1-8)
+    WORKTREE_DIR="worktrees/$HASH"
+    if [[ ! -d "$WORKTREE_DIR" ]]; then
+        echo "Error: Worktree not found at $WORKTREE_DIR"
+        exit 1
+    fi
+    git worktree remove --force "$WORKTREE_DIR"
+    git branch -D "$BRANCH_NAME"
+    echo "Force removed worktree and branch: $BRANCH_NAME"
+
+# List all feature worktrees
+[group('Features')]
+feature-list:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Feature worktrees:"
+    echo ""
+    git worktree list --porcelain | while read -r line; do
+        if [[ "$line" == worktree* ]]; then
+            path="${line#worktree }"
+            if [[ "$path" == *"/worktrees/"* ]]; then
+                read -r head_line
+                read -r branch_line
+                branch="${branch_line#branch refs/heads/}"
+                echo "  $branch"
+                echo "    → $path"
+                echo ""
+            fi
+        fi
+    done


### PR DESCRIPTION
## Summary
Add feature worktree commands using idiomatic just syntax:

```bash
just feature-new feat/add-auth     # Create worktree with hash-based directory
just feature-done feat/add-auth    # Remove worktree + branch (fails if unmerged)
just feature-drop feat/add-auth    # Force remove worktree + branch
just feature-list                  # List all feature worktrees
```

- Uses short hash (8 chars) of branch name for directory (avoids issues with slashes)
- All commands grouped under [Features]
- `done` uses `git branch -d` (safe, fails if unmerged)
- `drop` uses `git branch -D` (force delete even if unmerged)

## Test plan
- [ ] `just feature-new feat/test` creates worktree
- [ ] `just feature-list` shows the worktree
- [ ] `just feature-done feat/test` fails if branch is unmerged
- [ ] `just feature-drop feat/test` force removes even if unmerged

🤖 Generated with [Claude Code](https://claude.com/claude-code)