### PR TITLE
fix: pin prek to 0.2.25 (0.2.26 missing arm64 wheel)

### DIFF
--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
   "gh-bin>=2.83.2",
   "granian[pname,reload]>=2.6.0",
   "just-bin>=1.46.0",
-  "prek>=0.2.25",
+  "prek==0.2.25",  # 0.2.26 missing macosx_arm64 wheel
   "pysemver>=0.5.0",
   "ruff>=0.14.10",
   "rumdl>=0.0.211",

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2839,7 +2839,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "2.41.0"
+version = "2.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -2919,7 +2919,7 @@ requires-dist = [
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "just-bin", marker = "extra == 'dev'", specifier = ">=1.46.0" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "prek", marker = "extra == 'dev'", specifier = ">=0.2.25" },
+    { name = "prek", marker = "extra == 'dev'", specifier = "==0.2.25" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.12.5" },
     { name = "pydantic-extra-types", extras = ["pycountry"], specifier = ">=2.11.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },


### PR DESCRIPTION
## Summary

- Pins prek to 0.2.25 because 0.2.26 is missing the macosx_arm64 wheel
- Breaks installation on Apple Silicon Macs

## Related

- Filed upstream issue: https://github.com/j178/prek/issues/1320

## Test plan

- [ ] `uv sync` works on Apple Silicon Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)