### PR TITLE
fix: add copy-core-templates stub for backwards compatibility

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/scaffold.py
+++ b/vibetuner-py/src/vibetuner/cli/scaffold.py
@@ -186,3 +186,9 @@ def update(
     except Exception as e:
         console.print(f"[red]Error updating project: {e}[/red]")
         raise typer.Exit(code=1) from None
+
+
+@scaffold_app.command(name="copy-core-templates", hidden=True)
+def copy_core_templates() -> None:
+    """Deprecated: This command is a no-op kept for backwards compatibility."""
+    console.print("[dim]This command is deprecated and does nothing.[/dim]")


### PR DESCRIPTION
## Summary
- Adds hidden `copy-core-templates` command that does nothing
- Prevents errors in old repos that still call this command in their justfiles

## Test plan
- [x] Verified `vibetuner scaffold copy-core-templates` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)