### PR TITLE
feat: add worktrees directory placeholder to template

### DIFF
--- a/vibetuner-template/.gitignore
+++ b/vibetuner-template/.gitignore
@@ -77,4 +77,5 @@ src/app/_version.py
 ############################################################
 # Git Worktrees
 ############################################################
-worktrees/
+worktrees/*
+!worktrees/.placeholder

--- a/vibetuner-template/worktrees/.placeholder
+++ b/vibetuner-template/worktrees/.placeholder
@@ -1,0 +1,2 @@
+# ABOUTME: Placeholder to ensure the worktrees directory exists in git
+# ABOUTME: Git worktrees are created here by `just feature-new`


### PR DESCRIPTION
## Summary

- Adds `worktrees/.placeholder` to the template so the directory exists from scaffolding
- Updates `.gitignore` to track the placeholder while ignoring worktree contents

This ensures scaffolded projects have the `worktrees/` directory ready for `just feature-new` without needing to create it on first use.

## Test plan

- [ ] Scaffold a new project and verify `worktrees/.placeholder` exists
- [ ] Run `just feature-new test-branch` and confirm it works without needing to create the directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)