### PR TITLE
docs: add worktree management documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,21 @@ just type-check              # Type check Python with ty
 just update-frontend-templates  # Sync frontend templates and commit changes
 ```
 
+### Parallel Development
+
+Work on multiple features simultaneously using isolated worktrees:
+
+```bash
+just feature-new NAME        # Create isolated worktree with new branch from main
+just feature-list            # List all active feature worktrees
+just feature-done [NAME]     # Remove worktree and delete merged branch
+just feature-drop [NAME]     # Force remove worktree and delete branch (even if unmerged)
+just feature-rebase          # Sync current branch with origin/main
+```
+
+The `NAME` parameter for `feature-done` and `feature-drop` is optional. If omitted, the command
+auto-detects the current worktree. You can also pass a directory path instead of a branch name.
+
 ## Markdown Line Length
 
 This project enforces a **120 character line limit** for markdown files using `rumdl`.

--- a/vibetuner-docs/docs/cli-reference.md
+++ b/vibetuner-docs/docs/cli-reference.md
@@ -114,10 +114,25 @@ automatically when documents are inserted.
 
 Generated projects expose additional helpers in the scaffolded `justfile`:
 
+### Development
+
 - `just local-all` – Runs server + assets in parallel with auto-port (recommended for local dev)
 - `just local-all-with-worker` – Same as above but includes background worker (requires Redis)
 - `just local-dev` – Runs server only (use with `bun dev` in separate terminal)
 - `just worker-dev` – Runs background worker only
 - `just update-scaffolding` – Updates project to latest template
+
+### Parallel Development
+
+Work on multiple features simultaneously using isolated worktrees:
+
+- `just feature-new NAME` – Create isolated worktree with new branch from main
+- `just feature-list` – List all active feature worktrees
+- `just feature-done [NAME]` – Remove worktree and delete merged branch
+- `just feature-drop [NAME]` – Force remove worktree and delete branch (even if unmerged)
+- `just feature-rebase` – Rebase current branch on origin/main
+
+The `NAME` parameter for `feature-done` and `feature-drop` is optional. If omitted, the command
+auto-detects the current worktree. You can also pass a directory path instead of a branch name.
 
 Use `just --list` inside a generated project to see all available commands.

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -111,6 +111,83 @@ just deploy-latest HOST      # Deploy to remote host
 just update-scaffolding      # Update project to latest vibetuner template
 ```
 
+### Parallel Development
+
+```bash
+just feature-new NAME        # Create new feature worktree
+just feature-list            # List all feature worktrees
+just feature-done [NAME]     # Remove worktree + delete merged branch
+just feature-drop [NAME]     # Force remove worktree + delete branch
+just feature-rebase          # Sync current branch with origin/main
+```
+
+## Parallel Development with Worktrees
+
+Work on multiple features simultaneously using git worktrees. Each worktree is an isolated
+copy of the repository with its own branch, allowing true parallel development.
+
+### When to Use Worktrees
+
+| Approach | Use When |
+|----------|----------|
+| Worktrees (`feature-new`) | Working on multiple features, need clean isolation, instant context switching |
+| Simple branch (`git checkout`) | Single feature at a time, quick fixes, prefer simpler workflow |
+
+### Creating a Feature Worktree
+
+```bash
+just feature-new feat/user-dashboard
+# Creates worktrees/a1b2c3d4/ with branch feat/user-dashboard
+# Symlinks .env for shared configuration
+# Runs mise trust if available
+
+cd worktrees/a1b2c3d4
+# Work on your feature...
+```
+
+### Listing Feature Worktrees
+
+```bash
+just feature-list
+# Shows all active feature worktrees with their branches and paths
+```
+
+### Completing a Feature
+
+After your PR is merged, clean up the worktree and branch:
+
+```bash
+# Auto-detect from current directory (run from within the worktree)
+just feature-done
+
+# By branch name
+just feature-done feat/user-dashboard
+
+# By directory path
+just feature-done ./worktrees/a1b2c3d4
+```
+
+If you're inside the worktree when running `feature-done`, you'll be reminded to `cd` back to
+the main repository since the directory will be deleted.
+
+### Abandoning Unmerged Work
+
+Use `feature-drop` to force-remove a worktree even if the branch has unmerged changes:
+
+```bash
+just feature-drop feat/abandoned-idea
+```
+
+### Keeping Features Up to Date
+
+Rebase your feature branch on latest main:
+
+```bash
+cd worktrees/a1b2c3d4
+just feature-rebase
+# Fetches origin/main and rebases your branch on top
+```
+
 ## Common Tasks
 
 ### Adding New Routes

--- a/vibetuner-docs/docs/development.md
+++ b/vibetuner-docs/docs/development.md
@@ -137,19 +137,28 @@ Visit [localhost:8000](http://localhost:8000) to view the documentation site.
 
 ### Adding New Features
 
-1. **Create a feature branch**:
+1. **Create a feature branch** using one of two approaches:
 
 ```bash
+# Option A: Simple branch (single feature at a time)
 just start-branch feature-name
+
+# Option B: Worktree (parallel development, isolated environment)
+just feature-new feature-name
+cd worktrees/$(echo -n "feature-name" | sha256sum | cut -c1-8)
 ```
 
-1. **Make your changes** in the appropriate location:
+Use worktrees when working on multiple features simultaneously or when you need complete
+isolation. Use simple branches for quick fixes or when working on one thing at a time.
+
+2. **Make your changes** in the appropriate location:
 - Python framework code: `vibetuner-py/src/vibetuner/`
 - JavaScript dependencies: `vibetuner-js/package.json`
 - Template files: `vibetuner-template/`
 - Template configuration: `copier.yml`
 - Documentation: `docs/`
-1. **Test your changes**:
+
+3. **Test your changes**:
 
 ```bash
 just format           # Format and check code
@@ -157,14 +166,14 @@ just test-scaffold    # Test scaffolding
 just docs-build       # Test docs build
 ```
 
-1. **Commit your changes**:
+4. **Commit your changes**:
 
 ```bash
 git add .
 git commit -m "Add feature X"
 ```
 
-1. **Push and create PR**:
+5. **Push and create PR**:
 
 ```bash
 git push origin feature-name
@@ -372,6 +381,12 @@ just push-tags           # Push tags to trigger publish
 # Git workflow
 just start-branch NAME   # Create feature branch
 just pr                  # Create GitHub PR
+# Parallel development (worktrees)
+just feature-new NAME    # Create isolated feature worktree
+just feature-list        # List all feature worktrees
+just feature-done [NAME] # Remove worktree + delete merged branch
+just feature-drop [NAME] # Force remove worktree + delete branch
+just feature-rebase      # Sync current branch with origin/main
 # Testing generated projects
 cd /tmp/vibetuner-test
 just dev                 # Docker development

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -168,6 +168,21 @@ just deploy-latest HOST      # Deploy to remote host
 just update-scaffolding      # Update project to latest vibetuner template
 ```
 
+#### Parallel Development
+
+Work on multiple features simultaneously using isolated worktrees:
+
+```bash
+just feature-new NAME        # Create isolated worktree with new branch from main
+just feature-list            # List all active feature worktrees
+just feature-done [NAME]     # Remove worktree and delete merged branch
+just feature-drop [NAME]     # Force remove worktree and delete branch (even if unmerged)
+just feature-rebase          # Sync current branch with origin/main
+```
+
+The `NAME` parameter for `feature-done` and `feature-drop` is optional. If omitted, the command
+auto-detects the current worktree. You can also pass a directory path instead of a branch name.
+
 ## Architecture
 
 ### Directory Structure


### PR DESCRIPTION
Document the parallel development worktree commands added in v2.43.0-v2.46.0:
- feature-new, feature-done, feature-drop, feature-list, feature-rebase
- Flexible input handling (auto-detect, branch name, directory path)
- When to use worktrees vs simple branches

Updated files:
- development-guide.md: Full workflow guide with examples
- development.md: Added worktree option to "Adding New Features"
- cli-reference.md: Added commands to Related Commands section
- AGENTS.md (root + template): Added Parallel Development section