### PR TITLE
deps: remove need for uv-bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -427,14 +427,14 @@ wheels = [
 
 [[package]]
 name = "botocore-stubs"
-version = "1.42.24"
+version = "1.42.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-awscrt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/61/5715ec25b3dcb2a08133811f6a18a9ca9be54567452ab3e92cadcaec746e/botocore_stubs-1.42.24.tar.gz", hash = "sha256:f5fbe240267b27036b1217a304de34bf2bf993087e049a300d17d6f52d77988b", size = 42415, upload-time = "2026-01-07T21:27:03.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/66/f2308aa4b6e7f24ddc788bec0c26c85f03540ae4cbc07299e915f3e47da4/botocore_stubs-1.42.26.tar.gz", hash = "sha256:5b0946681d46ce8acb0a3b8494bdf76d34bc26276f0b7baedcf88a6cf1dd798b", size = 42398, upload-time = "2026-01-12T21:28:07.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/6b/cffb62a7872ba32e08c22c9c918a4d5d1d39ed6d74195bf50a3ae75a22f3/botocore_stubs-1.42.24-py3-none-any.whl", hash = "sha256:025999e68f419472cc8dfb7bcc2964fa0a06b447f43e7fc309012ff4c665b3db", size = 66762, upload-time = "2026-01-07T21:27:02.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/47/bee86341e7294c6c977ea1da6cf2ec86dc6129adcf87af30ed1cac8d02de/botocore_stubs-1.42.26-py3-none-any.whl", hash = "sha256:548380a16d31234255c00a4a4a15a5c8cdad360ba1af6dac5202111ec258155c", size = 66762, upload-time = "2026-01-12T21:28:05.555Z" },
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "coredis"
-version = "5.4.0"
+version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout" },
@@ -590,29 +590,29 @@ dependencies = [
     { name = "pympler" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/e3/faa06bf9d7df34a94d2c49e00bf1d8def45c52c05b8ff6b8793b03db750c/coredis-5.4.0.tar.gz", hash = "sha256:042ce1205b5c8996a3523eabbea0ab1edc3dec5b8aa1cdfe237a9e96a2d631cb", size = 2661497, upload-time = "2025-12-18T01:29:34.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/0a/d3ea5b6ef3f68da3e33e524be122a3d70c4a11de9b643bdb82f5cfd9f663/coredis-5.5.0.tar.gz", hash = "sha256:2b2f67e73a68bf4dc4d0d77b86ec7e03e75543f824f2f2bb076779ee9295bf65", size = 2661588, upload-time = "2026-01-13T02:09:54.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/a9/9f5fcd4aa067a8ae35df3b29f781682a49e34deb43611cc64440af997ab0/coredis-5.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cb98fa8f40006983201736f2d9f449c60b54b5d1d18672be092873b0bb12cc94", size = 358811, upload-time = "2025-12-18T01:29:03.042Z" },
-    { url = "https://files.pythonhosted.org/packages/69/c1/f6efa096e49a3f0d17a71b433bdb28302c1db81e15a12bbac9eddb5ee0d9/coredis-5.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7792129c5ce01c98731aea66e97ecd112dd0244e6d02f3164c30b5b778a1e52a", size = 353083, upload-time = "2025-12-18T01:29:04.473Z" },
-    { url = "https://files.pythonhosted.org/packages/95/fb/78c1b0cc5730919045a73dd3eea7bd97b9b78dd393a4185dc78474e5e046/coredis-5.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e5b771572ff20b7dd881b8d716b90e733e0d3951045a80e37fb62ab5b9e8cc", size = 369874, upload-time = "2025-12-18T01:29:05.978Z" },
-    { url = "https://files.pythonhosted.org/packages/37/ad/f8bc5faa2a3d33593a84db7ef3c777e91969d286d0d52566da34678b8c72/coredis-5.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4256d9337b5dd4e14f8212e92e8789683b7b5eacf60cc0c1d5427c27bb8b595", size = 373692, upload-time = "2025-12-18T01:29:07.566Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/0b/36d3da6d20f5775adf19d322901d21344e91836262ddf763f84e3a32a7a4/coredis-5.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bef2b5a675be39f944e10c2aef0af19f0ce4818076aad6219022042524ea9dfd", size = 362198, upload-time = "2025-12-18T01:29:09.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/df/79f2278e0d4b5987dacdb976aa9da91e3f77d0998430f59350cd487d6e9e/coredis-5.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eaba0f30ee4d94fbf6b573f77ba6a2924dc6fca3cf20c45549785bdce6e6d4ac", size = 356877, upload-time = "2025-12-18T01:29:10.763Z" },
-    { url = "https://files.pythonhosted.org/packages/35/4f/9da793fe4d89a2510d7851ed9447d051ecd378a4ad32832b1579aae74305/coredis-5.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:837558b7a184cadfa064df2efcd08f92ffa2285ac8ddc513f98e223539b400ec", size = 370697, upload-time = "2025-12-18T01:29:12.289Z" },
-    { url = "https://files.pythonhosted.org/packages/97/fa/fb69cc2ab272159f64fbe6247454229e24fe3716ac8c9b184d45d2b3be3c/coredis-5.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a81eef183c6a6e580a5f11dbb36b0a1814505222e0ac6926b1910d4a03ae0163", size = 375402, upload-time = "2025-12-18T01:29:14.43Z" },
-    { url = "https://files.pythonhosted.org/packages/19/7c/8d6dafe76f2ad5ab091c20d66e6d6996104f589c8ecccb9c93728c1b7526/coredis-5.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:836348e02390197cdec990affc1d2a553170acbeedd9fb1f52ec40a7f68bea72", size = 362082, upload-time = "2025-12-18T01:29:15.679Z" },
-    { url = "https://files.pythonhosted.org/packages/25/70/2c86aeb64209f693199737554cf7a822b978bee62c4abea9ec20b15ff6df/coredis-5.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e97cca00295501110bc127c9d10febeffd55e29d3fadcde14ae99006a0d58dda", size = 356718, upload-time = "2025-12-18T01:29:17.163Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/97/d5e98bfae0b87e970699dc7a71a84db11f7b56e908221f642f25ac2d632f/coredis-5.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f86fee3b9c80a7db5841de82efc88854113a54d651a02541a32b8aaad2708cb9", size = 370449, upload-time = "2025-12-18T01:29:18.329Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/cf/5adf38d1c2825982fa2e0f5535cea39d497af65f785e0570add4186b7afa/coredis-5.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5fee3f9bdba5aa8a283d5745c3c9ade74c934bf27d3776e1843087be632a6b8", size = 374996, upload-time = "2025-12-18T01:29:19.484Z" },
-    { url = "https://files.pythonhosted.org/packages/49/4c/6c4f02561b7c36768f9025a84149095bc517f44e1c0cd9fff57bf91ceaaf/coredis-5.4.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4fd6ccf307755957bd0918b98b5202354e34b78686a810dd89d753a7727eb887", size = 361578, upload-time = "2025-12-18T01:29:20.974Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/79/23b0106ec45cfa7f8f6276967969224ad57d8e32d98c532882e97c0faf61/coredis-5.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ff0aa5463eaf17b46954698dc52975ee54a05abec309238616dc52e36134770f", size = 356440, upload-time = "2025-12-18T01:29:22.507Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c8/5319d802006decd629fc94c1aa7aa23ab753f179cfd563e1aa98d217e6a3/coredis-5.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12db7610b62d1011472bd60e82d0cdcbee20820d6e5c0830f3075c1a87073bc7", size = 371743, upload-time = "2025-12-18T01:29:23.667Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/33/584c5abd578f95eea094768ea791b14d48e64d56a8600ae4901f4df08180/coredis-5.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ab0f26b5ef0f3732469a84e157625d820a5633e3c55f7f2a8feb12c0f71c6d9", size = 374660, upload-time = "2025-12-18T01:29:25.224Z" },
-    { url = "https://files.pythonhosted.org/packages/54/1f/fbe87ce4dcc3e4355f80e9fe22d28c03b1faabb2508a9ba087f430b6e810/coredis-5.4.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1ccb5b0af5202f1602426be08b168744f78bf2c343c15b81f5771427e5efd5ee", size = 371528, upload-time = "2025-12-18T01:29:27.13Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/56/ddef4e9f19f336a706397fbbd9372465db0713ec439f9330d7cc9aa43b8a/coredis-5.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb4d804408b766fe06c793f400b27aeb56e52e7922e35da5358ae9bcf61b89d5", size = 367031, upload-time = "2025-12-18T01:29:28.435Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/53/170128955eebad9b545b1d89902353da1feb5539c8d52dff808221923e13/coredis-5.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:687893ac70ededf8c4b6fc5ae8bff5024a8b156246d96fbddc509934da4a244c", size = 384998, upload-time = "2025-12-18T01:29:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/af/d7/ca9c1971fd65757d276773bde0bec7b7ee2c46eed54975e7c7845573545c/coredis-5.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6b4ee4a09a932f806c9e5073113b8e925a79e977ab809090ed45a3881bb524f", size = 387105, upload-time = "2025-12-18T01:29:31.225Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/da/e8746cc3522ee8a8f1376ce7ed286e50d600d1098eaa67b0a6abd28d2939/coredis-5.4.0-py3-none-any.whl", hash = "sha256:67ad5eb4d0040c635eeb8442a0549adf5699ae6392b0a36a0c1ffe38173cc150", size = 239328, upload-time = "2025-12-18T01:29:32.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f2/ffe60a056f38790c8d63eb0d955fef0bcbb3ccda14a87f19f2da5ff6d88a/coredis-5.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:03ecc3f778c68c89baa2212101884ecf57bc7dfd37ea695f763e21498950215b", size = 358855, upload-time = "2026-01-13T02:09:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/20/76/9df15bd9e47c2d64072029589878b947fb3e0723b61a291ad28d46a1e275/coredis-5.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a697dbf51fae77a4343a854aec5d0336ada878926158779ae9cd4f1cbc3de476", size = 353127, upload-time = "2026-01-13T02:09:17.335Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0c/428badadc3608317ae98f3a5d945c90571b34792932d38f5be728f610b9c/coredis-5.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ceab39e99f73cba34247f1002e782bafbd866f8613f0c31cbd72726a8880967", size = 369917, upload-time = "2026-01-13T02:09:19.53Z" },
+    { url = "https://files.pythonhosted.org/packages/10/14/eadd589c1b0592ffcb9596f9ff8335d9dba4a12097eea940cbc2b3a842f8/coredis-5.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ac63f9fea1d063e132e620e07d6a5f389e5b3b2b9b24c3a9af4f13519a53c0a", size = 373737, upload-time = "2026-01-13T02:09:21.393Z" },
+    { url = "https://files.pythonhosted.org/packages/be/dd/0b8e1e460f0d119f8b488ff7f3ae7b4358c235a55b59342beda7a4efb590/coredis-5.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2633f8541be906b33a74d35421ae4a77ed1e2c8bf368a0f5a4e20f716942c999", size = 362241, upload-time = "2026-01-13T02:09:24.645Z" },
+    { url = "https://files.pythonhosted.org/packages/09/97/caf8eb164b38f9c24dc95278c43a17d069575a48e8866f85f465eae13fd3/coredis-5.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5230ec0faf8e8f72c5f8a7134faeeff7b484851f645d5fcf2ef86231c596bc08", size = 356920, upload-time = "2026-01-13T02:09:26.356Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bd/ae7d1e2f8de54651b845384cb716643516b6c2b92341cbbd83dc8ed92540/coredis-5.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9b7ab83947934616b5328f0d17a9f66541acf90c5996f3f5afba4f842821667", size = 370740, upload-time = "2026-01-13T02:09:28.157Z" },
+    { url = "https://files.pythonhosted.org/packages/43/96/c199e932763daa275bbd2de810024242ab3c82b51a5e2344de77686435a0/coredis-5.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4a64805df31adaddb78eba078555b578819fc1d618dcf4ce1073de580258928", size = 375445, upload-time = "2026-01-13T02:09:29.709Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/70/53b1592b8995aff3f1a0f09f37dcefa76958cbb11c4c7840a129ea9d0af4/coredis-5.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:746ddc5fd7adb214f8e19dfdaf0061f7a44386f47d8ca055b75190736f3b04ac", size = 362126, upload-time = "2026-01-13T02:09:31.375Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f1/ccc8a20245e3932140aaaa25c75c215526f8b0461b22a70ff676de6ce303/coredis-5.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b524af3ab8e8677405a1fcf556382d9e81176db47937393076745b8d375fe88a", size = 356762, upload-time = "2026-01-13T02:09:33.035Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/16/8cee7e24efdf07a8b84f039e977088bf553a47298089cd9308ea31d9952f/coredis-5.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c885664a6c23c3d298c7f0343ae3730e24d39994266628824d106d0c53acfd7", size = 370493, upload-time = "2026-01-13T02:09:34.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/4d/63b2276156f5be164c9f8e71b30cdc2f9740982ac799eafb8b26cdfa524c/coredis-5.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28c4ac22a984e72ce3d4b251baa18064216b65905ac4bab690da1735c0675f9d", size = 375039, upload-time = "2026-01-13T02:09:35.976Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8f/357623526e9bbe64cc8e4e85ba7aa397599a64fd436dc08051b3d4c78f0f/coredis-5.5.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:049553088dc62bae4a27bcdcdb6cda927ce133888775984674113b6c17c2a7e1", size = 361621, upload-time = "2026-01-13T02:09:38.205Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/f857affb57137953436be1c6bec63c1eef41ba3737d1abb8eda4050dfd1d/coredis-5.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2057cd7f4eb81bcf4b437bf089c7e6f986c33ae3f05d4d5c5745444691e98079", size = 356483, upload-time = "2026-01-13T02:09:40.149Z" },
+    { url = "https://files.pythonhosted.org/packages/17/4a/931652d868b05a9d5594ffa8171a8457f4fda6fcf5b0b33f0f57fb9b252b/coredis-5.5.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ee6eb78e02b2ea199516b707c986db75161d32c59f31c05f4fb580b9e5bf942", size = 371786, upload-time = "2026-01-13T02:09:41.929Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/84/d6fc2f31e85d3a59f42e0269e04a2710fe64a9e77d10390885931cf95a16/coredis-5.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b381d203ea88dc190ee801cc281c9ba318dba1e9f903099eca65c1c52b264ea", size = 374703, upload-time = "2026-01-13T02:09:44.27Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b6/2a4852bc205bfca840d77220397eb89009436522e29d79cf172fb72ff74d/coredis-5.5.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9f2cc301b4b8e97b0a5426f36860abadd3c63a771f8c53841a9f39090e9e888e", size = 371574, upload-time = "2026-01-13T02:09:45.724Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ba/9dee968fd890be36a5c30f68a9db36e556c3235284801db75645d62d4d1f/coredis-5.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1e5c24a61274f2bc22f7ffcf21f9b08d68a175a278d90365a086d54bd1d23ff2", size = 367077, upload-time = "2026-01-13T02:09:47.487Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/8b/90de03592a9cbac62e5fda7384e9e1541695a11f46a2ae7bc57e03a91283/coredis-5.5.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7015c8af852e3fd66fe628c77e18d809227e9114f8eef91993a005fc7a578e9d", size = 385041, upload-time = "2026-01-13T02:09:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/12938772928a77cf80101c3d80ee2cc8f2fa2dff5948e5d3034c6e932b30/coredis-5.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c93b1eec9b33645cd3b61e5dc8f3a4edff911c379556c838d2d1a9a1fc8df2c8", size = 387149, upload-time = "2026-01-13T02:09:50.729Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/cd/46b3fc3b7bb9d1085a28a36be4b1bfd747366b68649d3bb054f6a3912893/coredis-5.5.0-py3-none-any.whl", hash = "sha256:6bc06cc94ef38a7e12a11b9a83755a19875b99a41656889e716323ac912bb51b", size = 239370, upload-time = "2026-01-13T02:09:52.585Z" },
 ]
 
 [[package]]
@@ -1586,11 +1586,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.0.2"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/b9/6eb731b52f132181a9144bbe77ff82117f6b2d2fbfba49aaab2c014c4760/pathspec-1.0.2.tar.gz", hash = "sha256:fa32b1eb775ed9ba8d599b22c5f906dc098113989da2c00bf8b210078ca7fb92", size = 130502, upload-time = "2026-01-08T04:33:27.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/bb8e495d5262bfec41ab5cb18f522f1012933347fb5d9e62452d446baca2/pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d", size = 130841, upload-time = "2026-01-09T15:46:46.009Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/6b/14fc9049d78435fd29e82846c777bd7ed9c470013dc8d0260fff3ff1c11e/pathspec-1.0.2-py3-none-any.whl", hash = "sha256:62f8558917908d237d399b9b338ef455a814801a4688bc41074b25feefd93472", size = 54844, upload-time = "2026-01-08T04:33:26.4Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c", size = 55021, upload-time = "2026-01-09T15:46:44.652Z" },
 ]
 
 [[package]]
@@ -2248,17 +2248,17 @@ wheels = [
 
 [[package]]
 name = "rumdl"
-version = "0.0.212"
+version = "0.0.215"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/4f/9aef550622afd24c031f87d74ceb3f9e44d04ba9d51b1d1ec67c75a46557/rumdl-0.0.212.tar.gz", hash = "sha256:a2a05d579426e320dd18cfcc29a0c2d7ad07978003f0d3f140796e2c12becd00", size = 1535171, upload-time = "2026-01-07T18:57:51.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/b0/22a78a2d5cdd9ce1756b92975309df4e99735369ffb028f138f35f24c1b9/rumdl-0.0.215.tar.gz", hash = "sha256:81d8e5eceea13703f08fc80f489115262f11b3fbff86de3d4e011b0bdabdf676", size = 1557071, upload-time = "2026-01-12T14:57:01.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/69/59216572ae4deba446fc3bb76e8bdb75d8b085b2a64ba16e37ca90f09363/rumdl-0.0.212-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1b42094831d42a8a3598e0a0a98d5f8aa44102050efa26f545f6caa867d13924", size = 3104871, upload-time = "2026-01-07T18:57:46.374Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/0c/ff7b43bee654a437a5c8282b4318f6d4ece25ea96132d5cc3727fdbff398/rumdl-0.0.212-py3-none-macosx_11_0_arm64.whl", hash = "sha256:75811ca1b5476869b44bdd2d9c98ba27cae12519b7fc38ae945d863fc2dda459", size = 2984946, upload-time = "2026-01-07T18:57:41.67Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/88/944c3289cfa76cb4a4b30a1e2b21d5a7a55bcf93706234f707498cbf8059/rumdl-0.0.212-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:4f793addc60adab4dfac090f909f79cef17679e5ba9d00bec77d5e2121534697", size = 3345895, upload-time = "2026-01-07T18:57:43.72Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/a1/c55fc8b4bdb674baad148dc21fbb408152d414c1854c6bdd4ffb556d0b05/rumdl-0.0.212-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2417267ff85dcdf5add7bbcd712d43ae2a3f4b0be94dc2824cc42e713a0e91e2", size = 3376832, upload-time = "2026-01-07T18:57:49.196Z" },
-    { url = "https://files.pythonhosted.org/packages/06/22/55d7a5a7314d83905d29196a3110b415af55a9e881c9687b698bbc90219c/rumdl-0.0.212-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a686e7ef45094f7c6ae720a001338eaad80b468eb9537fa5628489d416e1340", size = 3337025, upload-time = "2026-01-07T18:57:44.877Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/dc/8071688a7a346b30843f6152b69c77e6485fdedbc70169c612b518880ee5/rumdl-0.0.212-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:90802904aab83d903cf2493f2ad7147c2ac306434356d131a22361d4b0ac944b", size = 3367276, upload-time = "2026-01-07T18:57:50.366Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a7/17926fec1c339d2d5e67e96a371e306dd367f32a2905dec1587b68841655/rumdl-0.0.212-py3-none-win_amd64.whl", hash = "sha256:ecbe63bac0a214b4de76b28fea403ab9f045915b578024879a9c3a76e712e715", size = 3190205, upload-time = "2026-01-07T18:57:47.645Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/5c567b85bd26d6a32e8dcc5b6183a5cf42dbcd33c2eaad12df587130d4a8/rumdl-0.0.215-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5ec4ee6314371bc5a87736e0b8d176e5fd26812379e2e5de503ad1deb3060d2f", size = 3118519, upload-time = "2026-01-12T14:56:56.39Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a2/fecae1b5e7e128e4aef1699a1d4a78a6e4defb598967a36a47cba8f2283c/rumdl-0.0.215-py3-none-macosx_11_0_arm64.whl", hash = "sha256:10b1341e62015b8cea36f7d77ce1fd739d752828ad90f786a8b685db8feaa160", size = 2995043, upload-time = "2026-01-12T14:56:52.352Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2f/ae47ad816bc9c80dba965f5dd9d78f591fa331f1cd177ad1157a174d26a6/rumdl-0.0.215-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:3208788df4633526a92ca42822eaf66f9e5c047757b7daddb05b80eda157a53c", size = 3360504, upload-time = "2026-01-12T14:56:53.948Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2f/55eeef66c71d4d755e41d447665dd6618c047c91e19b40e35d93c496c139/rumdl-0.0.215-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c2d47999cb64a2e77a1b1416e1b3987a5d496d0bc28c6a69b7a4d6e8bc3ab290", size = 3391266, upload-time = "2026-01-12T14:56:58.95Z" },
+    { url = "https://files.pythonhosted.org/packages/53/50/fb0629fa3de91226a858c6ff53a14a65a61b19443f7c0f7a13e87c1dcb75/rumdl-0.0.215-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f93068d5c9fd4cc2749fae114209fde15a3e61efc4abcdf4f2522d9288144665", size = 3350914, upload-time = "2026-01-12T14:56:55.2Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8f/7baec997f07b5e10cb621d344552c0197384a8072bbbe97b2515240ae4fd/rumdl-0.0.215-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3d501a8b52bed28016e95f400c173d8c0b3ed04eb48c4183deb2df95cee600e1", size = 3382144, upload-time = "2026-01-12T14:57:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/db/46927ac23de51ecb9b81175457820fce3ae943970cc545efd21f743161b7/rumdl-0.0.215-py3-none-win_amd64.whl", hash = "sha256:92cd295d9b867face415efee33bbf222a321db3e166471b66d36c1f62523eec4", size = 3202791, upload-time = "2026-01-12T14:56:57.786Z" },
 ]
 
 [[package]]
@@ -2647,11 +2647,11 @@ wheels = [
 
 [[package]]
 name = "types-awscrt"
-version = "0.30.0"
+version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/1f/febd2df22e24f77b759db0dd9ecdd7f07f055e6a4dbbb699c5eb34b617ef/types_awscrt-0.30.0.tar.gz", hash = "sha256:362fd8f5eaebcfcd922cb9fd8274fb375df550319f78031ee3779eac0b9ecc79", size = 17761, upload-time = "2025-12-12T01:55:59.626Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/9f/9be587f2243ea7837ad83aad248ff4d8f9a880ac5a84544e9661e5840a22/types_awscrt-0.31.0.tar.gz", hash = "sha256:aa8b42148af0847be14e2b8ea3637a3518ffab038f8d3be7083950f3ce87d3ff", size = 17817, upload-time = "2026-01-12T06:42:37.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/5f/15999051fca2949a67562c3f80fae2dd5d3404a3f97b326b614533843281/types_awscrt-0.30.0-py3-none-any.whl", hash = "sha256:8204126e01a00eaa4a746e7a0076538ca0e4e3f52408adec0ab9b471bb0bb64b", size = 42392, upload-time = "2025-12-12T01:55:58.194Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/8d/87ac494b5165e7650b2bc92ee3325c1339a47323489beeda32dffc9a1334/types_awscrt-0.31.0-py3-none-any.whl", hash = "sha256:009cfe5b9af8c75e8304243490e20a5229e7a56203f1d41481f5522233453f51", size = 42509, upload-time = "2026-01-12T06:42:36.187Z" },
 ]
 
 [[package]]
@@ -2700,15 +2700,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "uv-bump"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/16/0b9f89d10df58d6376130ee98fd0ee679726b9ce2f5de6585cb3fd48c19d/uv_bump-0.4.0.tar.gz", hash = "sha256:ee230c26287d4ef93e72f8068e52bf00a23d95bcdc59cd93cd3098fad4baaca9", size = 5257, upload-time = "2025-12-13T09:08:21.859Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/a1/865ba99e107a79e58ab4b802845ffe2dda6b8f121aae4ad7223856c94603/uv_bump-0.4.0-py3-none-any.whl", hash = "sha256:312de0d83007bf359c8efe420f2d2f58595fb1dba8934cfd1747cb649e5305c6", size = 6579, upload-time = "2025-12-13T09:08:20.856Z" },
 ]
 
 [[package]]
@@ -2775,7 +2766,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "2.46.4"
+version = "2.46.5"
 source = { directory = "vibetuner-py" }
 dependencies = [
     { name = "aioboto3" },
@@ -2820,7 +2811,6 @@ dev = [
     { name = "types-aioboto3", extra = ["s3", "ses"] },
     { name = "types-authlib" },
     { name = "types-pyyaml" },
-    { name = "uv-bump" },
 ]
 
 [package.metadata]
@@ -2865,13 +2855,12 @@ requires-dist = [
     { name = "types-aioboto3", extras = ["s3", "ses"], marker = "extra == 'dev'", specifier = ">=15.5.0" },
     { name = "types-authlib", marker = "extra == 'dev'", specifier = ">=1.6.6.20251220" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },
-    { name = "uv-bump", marker = "extra == 'dev'", specifier = ">=0.4.0" },
 ]
 provides-extras = ["dev", "test"]
 
 [[package]]
 name = "vibetuner-scaffolding"
-version = "2.46.4"
+version = "2.46.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -2982,44 +2971,61 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "15.0.1"
+version = "16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
-    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
-    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
-    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
-    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
-    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
-    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
-    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
-    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
-    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
-    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]

--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -75,7 +75,6 @@ dev = [
   "types-aioboto3[s3,ses]>=15.5.0",
   "types-authlib>=1.6.6.20251220",
   "types-pyyaml>=6.0.12.20250915",
-  "uv-bump>=0.4.0",
 ]
 test = [
   # Testing dependencies

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -427,14 +427,14 @@ wheels = [
 
 [[package]]
 name = "botocore-stubs"
-version = "1.42.24"
+version = "1.42.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-awscrt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/61/5715ec25b3dcb2a08133811f6a18a9ca9be54567452ab3e92cadcaec746e/botocore_stubs-1.42.24.tar.gz", hash = "sha256:f5fbe240267b27036b1217a304de34bf2bf993087e049a300d17d6f52d77988b", size = 42415, upload-time = "2026-01-07T21:27:03.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/66/f2308aa4b6e7f24ddc788bec0c26c85f03540ae4cbc07299e915f3e47da4/botocore_stubs-1.42.26.tar.gz", hash = "sha256:5b0946681d46ce8acb0a3b8494bdf76d34bc26276f0b7baedcf88a6cf1dd798b", size = 42398, upload-time = "2026-01-12T21:28:07.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/6b/cffb62a7872ba32e08c22c9c918a4d5d1d39ed6d74195bf50a3ae75a22f3/botocore_stubs-1.42.24-py3-none-any.whl", hash = "sha256:025999e68f419472cc8dfb7bcc2964fa0a06b447f43e7fc309012ff4c665b3db", size = 66762, upload-time = "2026-01-07T21:27:02.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/47/bee86341e7294c6c977ea1da6cf2ec86dc6129adcf87af30ed1cac8d02de/botocore_stubs-1.42.26-py3-none-any.whl", hash = "sha256:548380a16d31234255c00a4a4a15a5c8cdad360ba1af6dac5202111ec258155c", size = 66762, upload-time = "2026-01-12T21:28:05.555Z" },
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "coredis"
-version = "5.4.0"
+version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout" },
@@ -590,29 +590,29 @@ dependencies = [
     { name = "pympler" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/e3/faa06bf9d7df34a94d2c49e00bf1d8def45c52c05b8ff6b8793b03db750c/coredis-5.4.0.tar.gz", hash = "sha256:042ce1205b5c8996a3523eabbea0ab1edc3dec5b8aa1cdfe237a9e96a2d631cb", size = 2661497, upload-time = "2025-12-18T01:29:34.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/0a/d3ea5b6ef3f68da3e33e524be122a3d70c4a11de9b643bdb82f5cfd9f663/coredis-5.5.0.tar.gz", hash = "sha256:2b2f67e73a68bf4dc4d0d77b86ec7e03e75543f824f2f2bb076779ee9295bf65", size = 2661588, upload-time = "2026-01-13T02:09:54.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/a9/9f5fcd4aa067a8ae35df3b29f781682a49e34deb43611cc64440af997ab0/coredis-5.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cb98fa8f40006983201736f2d9f449c60b54b5d1d18672be092873b0bb12cc94", size = 358811, upload-time = "2025-12-18T01:29:03.042Z" },
-    { url = "https://files.pythonhosted.org/packages/69/c1/f6efa096e49a3f0d17a71b433bdb28302c1db81e15a12bbac9eddb5ee0d9/coredis-5.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7792129c5ce01c98731aea66e97ecd112dd0244e6d02f3164c30b5b778a1e52a", size = 353083, upload-time = "2025-12-18T01:29:04.473Z" },
-    { url = "https://files.pythonhosted.org/packages/95/fb/78c1b0cc5730919045a73dd3eea7bd97b9b78dd393a4185dc78474e5e046/coredis-5.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e5b771572ff20b7dd881b8d716b90e733e0d3951045a80e37fb62ab5b9e8cc", size = 369874, upload-time = "2025-12-18T01:29:05.978Z" },
-    { url = "https://files.pythonhosted.org/packages/37/ad/f8bc5faa2a3d33593a84db7ef3c777e91969d286d0d52566da34678b8c72/coredis-5.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4256d9337b5dd4e14f8212e92e8789683b7b5eacf60cc0c1d5427c27bb8b595", size = 373692, upload-time = "2025-12-18T01:29:07.566Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/0b/36d3da6d20f5775adf19d322901d21344e91836262ddf763f84e3a32a7a4/coredis-5.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bef2b5a675be39f944e10c2aef0af19f0ce4818076aad6219022042524ea9dfd", size = 362198, upload-time = "2025-12-18T01:29:09.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/df/79f2278e0d4b5987dacdb976aa9da91e3f77d0998430f59350cd487d6e9e/coredis-5.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eaba0f30ee4d94fbf6b573f77ba6a2924dc6fca3cf20c45549785bdce6e6d4ac", size = 356877, upload-time = "2025-12-18T01:29:10.763Z" },
-    { url = "https://files.pythonhosted.org/packages/35/4f/9da793fe4d89a2510d7851ed9447d051ecd378a4ad32832b1579aae74305/coredis-5.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:837558b7a184cadfa064df2efcd08f92ffa2285ac8ddc513f98e223539b400ec", size = 370697, upload-time = "2025-12-18T01:29:12.289Z" },
-    { url = "https://files.pythonhosted.org/packages/97/fa/fb69cc2ab272159f64fbe6247454229e24fe3716ac8c9b184d45d2b3be3c/coredis-5.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a81eef183c6a6e580a5f11dbb36b0a1814505222e0ac6926b1910d4a03ae0163", size = 375402, upload-time = "2025-12-18T01:29:14.43Z" },
-    { url = "https://files.pythonhosted.org/packages/19/7c/8d6dafe76f2ad5ab091c20d66e6d6996104f589c8ecccb9c93728c1b7526/coredis-5.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:836348e02390197cdec990affc1d2a553170acbeedd9fb1f52ec40a7f68bea72", size = 362082, upload-time = "2025-12-18T01:29:15.679Z" },
-    { url = "https://files.pythonhosted.org/packages/25/70/2c86aeb64209f693199737554cf7a822b978bee62c4abea9ec20b15ff6df/coredis-5.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e97cca00295501110bc127c9d10febeffd55e29d3fadcde14ae99006a0d58dda", size = 356718, upload-time = "2025-12-18T01:29:17.163Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/97/d5e98bfae0b87e970699dc7a71a84db11f7b56e908221f642f25ac2d632f/coredis-5.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f86fee3b9c80a7db5841de82efc88854113a54d651a02541a32b8aaad2708cb9", size = 370449, upload-time = "2025-12-18T01:29:18.329Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/cf/5adf38d1c2825982fa2e0f5535cea39d497af65f785e0570add4186b7afa/coredis-5.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5fee3f9bdba5aa8a283d5745c3c9ade74c934bf27d3776e1843087be632a6b8", size = 374996, upload-time = "2025-12-18T01:29:19.484Z" },
-    { url = "https://files.pythonhosted.org/packages/49/4c/6c4f02561b7c36768f9025a84149095bc517f44e1c0cd9fff57bf91ceaaf/coredis-5.4.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4fd6ccf307755957bd0918b98b5202354e34b78686a810dd89d753a7727eb887", size = 361578, upload-time = "2025-12-18T01:29:20.974Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/79/23b0106ec45cfa7f8f6276967969224ad57d8e32d98c532882e97c0faf61/coredis-5.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ff0aa5463eaf17b46954698dc52975ee54a05abec309238616dc52e36134770f", size = 356440, upload-time = "2025-12-18T01:29:22.507Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c8/5319d802006decd629fc94c1aa7aa23ab753f179cfd563e1aa98d217e6a3/coredis-5.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12db7610b62d1011472bd60e82d0cdcbee20820d6e5c0830f3075c1a87073bc7", size = 371743, upload-time = "2025-12-18T01:29:23.667Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/33/584c5abd578f95eea094768ea791b14d48e64d56a8600ae4901f4df08180/coredis-5.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ab0f26b5ef0f3732469a84e157625d820a5633e3c55f7f2a8feb12c0f71c6d9", size = 374660, upload-time = "2025-12-18T01:29:25.224Z" },
-    { url = "https://files.pythonhosted.org/packages/54/1f/fbe87ce4dcc3e4355f80e9fe22d28c03b1faabb2508a9ba087f430b6e810/coredis-5.4.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1ccb5b0af5202f1602426be08b168744f78bf2c343c15b81f5771427e5efd5ee", size = 371528, upload-time = "2025-12-18T01:29:27.13Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/56/ddef4e9f19f336a706397fbbd9372465db0713ec439f9330d7cc9aa43b8a/coredis-5.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb4d804408b766fe06c793f400b27aeb56e52e7922e35da5358ae9bcf61b89d5", size = 367031, upload-time = "2025-12-18T01:29:28.435Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/53/170128955eebad9b545b1d89902353da1feb5539c8d52dff808221923e13/coredis-5.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:687893ac70ededf8c4b6fc5ae8bff5024a8b156246d96fbddc509934da4a244c", size = 384998, upload-time = "2025-12-18T01:29:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/af/d7/ca9c1971fd65757d276773bde0bec7b7ee2c46eed54975e7c7845573545c/coredis-5.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6b4ee4a09a932f806c9e5073113b8e925a79e977ab809090ed45a3881bb524f", size = 387105, upload-time = "2025-12-18T01:29:31.225Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/da/e8746cc3522ee8a8f1376ce7ed286e50d600d1098eaa67b0a6abd28d2939/coredis-5.4.0-py3-none-any.whl", hash = "sha256:67ad5eb4d0040c635eeb8442a0549adf5699ae6392b0a36a0c1ffe38173cc150", size = 239328, upload-time = "2025-12-18T01:29:32.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f2/ffe60a056f38790c8d63eb0d955fef0bcbb3ccda14a87f19f2da5ff6d88a/coredis-5.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:03ecc3f778c68c89baa2212101884ecf57bc7dfd37ea695f763e21498950215b", size = 358855, upload-time = "2026-01-13T02:09:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/20/76/9df15bd9e47c2d64072029589878b947fb3e0723b61a291ad28d46a1e275/coredis-5.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a697dbf51fae77a4343a854aec5d0336ada878926158779ae9cd4f1cbc3de476", size = 353127, upload-time = "2026-01-13T02:09:17.335Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0c/428badadc3608317ae98f3a5d945c90571b34792932d38f5be728f610b9c/coredis-5.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ceab39e99f73cba34247f1002e782bafbd866f8613f0c31cbd72726a8880967", size = 369917, upload-time = "2026-01-13T02:09:19.53Z" },
+    { url = "https://files.pythonhosted.org/packages/10/14/eadd589c1b0592ffcb9596f9ff8335d9dba4a12097eea940cbc2b3a842f8/coredis-5.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ac63f9fea1d063e132e620e07d6a5f389e5b3b2b9b24c3a9af4f13519a53c0a", size = 373737, upload-time = "2026-01-13T02:09:21.393Z" },
+    { url = "https://files.pythonhosted.org/packages/be/dd/0b8e1e460f0d119f8b488ff7f3ae7b4358c235a55b59342beda7a4efb590/coredis-5.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2633f8541be906b33a74d35421ae4a77ed1e2c8bf368a0f5a4e20f716942c999", size = 362241, upload-time = "2026-01-13T02:09:24.645Z" },
+    { url = "https://files.pythonhosted.org/packages/09/97/caf8eb164b38f9c24dc95278c43a17d069575a48e8866f85f465eae13fd3/coredis-5.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5230ec0faf8e8f72c5f8a7134faeeff7b484851f645d5fcf2ef86231c596bc08", size = 356920, upload-time = "2026-01-13T02:09:26.356Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bd/ae7d1e2f8de54651b845384cb716643516b6c2b92341cbbd83dc8ed92540/coredis-5.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9b7ab83947934616b5328f0d17a9f66541acf90c5996f3f5afba4f842821667", size = 370740, upload-time = "2026-01-13T02:09:28.157Z" },
+    { url = "https://files.pythonhosted.org/packages/43/96/c199e932763daa275bbd2de810024242ab3c82b51a5e2344de77686435a0/coredis-5.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4a64805df31adaddb78eba078555b578819fc1d618dcf4ce1073de580258928", size = 375445, upload-time = "2026-01-13T02:09:29.709Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/70/53b1592b8995aff3f1a0f09f37dcefa76958cbb11c4c7840a129ea9d0af4/coredis-5.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:746ddc5fd7adb214f8e19dfdaf0061f7a44386f47d8ca055b75190736f3b04ac", size = 362126, upload-time = "2026-01-13T02:09:31.375Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f1/ccc8a20245e3932140aaaa25c75c215526f8b0461b22a70ff676de6ce303/coredis-5.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b524af3ab8e8677405a1fcf556382d9e81176db47937393076745b8d375fe88a", size = 356762, upload-time = "2026-01-13T02:09:33.035Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/16/8cee7e24efdf07a8b84f039e977088bf553a47298089cd9308ea31d9952f/coredis-5.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c885664a6c23c3d298c7f0343ae3730e24d39994266628824d106d0c53acfd7", size = 370493, upload-time = "2026-01-13T02:09:34.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/4d/63b2276156f5be164c9f8e71b30cdc2f9740982ac799eafb8b26cdfa524c/coredis-5.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28c4ac22a984e72ce3d4b251baa18064216b65905ac4bab690da1735c0675f9d", size = 375039, upload-time = "2026-01-13T02:09:35.976Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8f/357623526e9bbe64cc8e4e85ba7aa397599a64fd436dc08051b3d4c78f0f/coredis-5.5.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:049553088dc62bae4a27bcdcdb6cda927ce133888775984674113b6c17c2a7e1", size = 361621, upload-time = "2026-01-13T02:09:38.205Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/f857affb57137953436be1c6bec63c1eef41ba3737d1abb8eda4050dfd1d/coredis-5.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2057cd7f4eb81bcf4b437bf089c7e6f986c33ae3f05d4d5c5745444691e98079", size = 356483, upload-time = "2026-01-13T02:09:40.149Z" },
+    { url = "https://files.pythonhosted.org/packages/17/4a/931652d868b05a9d5594ffa8171a8457f4fda6fcf5b0b33f0f57fb9b252b/coredis-5.5.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ee6eb78e02b2ea199516b707c986db75161d32c59f31c05f4fb580b9e5bf942", size = 371786, upload-time = "2026-01-13T02:09:41.929Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/84/d6fc2f31e85d3a59f42e0269e04a2710fe64a9e77d10390885931cf95a16/coredis-5.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b381d203ea88dc190ee801cc281c9ba318dba1e9f903099eca65c1c52b264ea", size = 374703, upload-time = "2026-01-13T02:09:44.27Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b6/2a4852bc205bfca840d77220397eb89009436522e29d79cf172fb72ff74d/coredis-5.5.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9f2cc301b4b8e97b0a5426f36860abadd3c63a771f8c53841a9f39090e9e888e", size = 371574, upload-time = "2026-01-13T02:09:45.724Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ba/9dee968fd890be36a5c30f68a9db36e556c3235284801db75645d62d4d1f/coredis-5.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1e5c24a61274f2bc22f7ffcf21f9b08d68a175a278d90365a086d54bd1d23ff2", size = 367077, upload-time = "2026-01-13T02:09:47.487Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/8b/90de03592a9cbac62e5fda7384e9e1541695a11f46a2ae7bc57e03a91283/coredis-5.5.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7015c8af852e3fd66fe628c77e18d809227e9114f8eef91993a005fc7a578e9d", size = 385041, upload-time = "2026-01-13T02:09:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/12938772928a77cf80101c3d80ee2cc8f2fa2dff5948e5d3034c6e932b30/coredis-5.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c93b1eec9b33645cd3b61e5dc8f3a4edff911c379556c838d2d1a9a1fc8df2c8", size = 387149, upload-time = "2026-01-13T02:09:50.729Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/cd/46b3fc3b7bb9d1085a28a36be4b1bfd747366b68649d3bb054f6a3912893/coredis-5.5.0-py3-none-any.whl", hash = "sha256:6bc06cc94ef38a7e12a11b9a83755a19875b99a41656889e716323ac912bb51b", size = 239370, upload-time = "2026-01-13T02:09:52.585Z" },
 ]
 
 [[package]]
@@ -1595,11 +1595,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.0.2"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/b9/6eb731b52f132181a9144bbe77ff82117f6b2d2fbfba49aaab2c014c4760/pathspec-1.0.2.tar.gz", hash = "sha256:fa32b1eb775ed9ba8d599b22c5f906dc098113989da2c00bf8b210078ca7fb92", size = 130502, upload-time = "2026-01-08T04:33:27.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/bb8e495d5262bfec41ab5cb18f522f1012933347fb5d9e62452d446baca2/pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d", size = 130841, upload-time = "2026-01-09T15:46:46.009Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/6b/14fc9049d78435fd29e82846c777bd7ed9c470013dc8d0260fff3ff1c11e/pathspec-1.0.2-py3-none-any.whl", hash = "sha256:62f8558917908d237d399b9b338ef455a814801a4688bc41074b25feefd93472", size = 54844, upload-time = "2026-01-08T04:33:26.4Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c", size = 55021, upload-time = "2026-01-09T15:46:44.652Z" },
 ]
 
 [[package]]
@@ -2295,17 +2295,17 @@ wheels = [
 
 [[package]]
 name = "rumdl"
-version = "0.0.212"
+version = "0.0.215"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/4f/9aef550622afd24c031f87d74ceb3f9e44d04ba9d51b1d1ec67c75a46557/rumdl-0.0.212.tar.gz", hash = "sha256:a2a05d579426e320dd18cfcc29a0c2d7ad07978003f0d3f140796e2c12becd00", size = 1535171, upload-time = "2026-01-07T18:57:51.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/b0/22a78a2d5cdd9ce1756b92975309df4e99735369ffb028f138f35f24c1b9/rumdl-0.0.215.tar.gz", hash = "sha256:81d8e5eceea13703f08fc80f489115262f11b3fbff86de3d4e011b0bdabdf676", size = 1557071, upload-time = "2026-01-12T14:57:01.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/69/59216572ae4deba446fc3bb76e8bdb75d8b085b2a64ba16e37ca90f09363/rumdl-0.0.212-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1b42094831d42a8a3598e0a0a98d5f8aa44102050efa26f545f6caa867d13924", size = 3104871, upload-time = "2026-01-07T18:57:46.374Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/0c/ff7b43bee654a437a5c8282b4318f6d4ece25ea96132d5cc3727fdbff398/rumdl-0.0.212-py3-none-macosx_11_0_arm64.whl", hash = "sha256:75811ca1b5476869b44bdd2d9c98ba27cae12519b7fc38ae945d863fc2dda459", size = 2984946, upload-time = "2026-01-07T18:57:41.67Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/88/944c3289cfa76cb4a4b30a1e2b21d5a7a55bcf93706234f707498cbf8059/rumdl-0.0.212-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:4f793addc60adab4dfac090f909f79cef17679e5ba9d00bec77d5e2121534697", size = 3345895, upload-time = "2026-01-07T18:57:43.72Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/a1/c55fc8b4bdb674baad148dc21fbb408152d414c1854c6bdd4ffb556d0b05/rumdl-0.0.212-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2417267ff85dcdf5add7bbcd712d43ae2a3f4b0be94dc2824cc42e713a0e91e2", size = 3376832, upload-time = "2026-01-07T18:57:49.196Z" },
-    { url = "https://files.pythonhosted.org/packages/06/22/55d7a5a7314d83905d29196a3110b415af55a9e881c9687b698bbc90219c/rumdl-0.0.212-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a686e7ef45094f7c6ae720a001338eaad80b468eb9537fa5628489d416e1340", size = 3337025, upload-time = "2026-01-07T18:57:44.877Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/dc/8071688a7a346b30843f6152b69c77e6485fdedbc70169c612b518880ee5/rumdl-0.0.212-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:90802904aab83d903cf2493f2ad7147c2ac306434356d131a22361d4b0ac944b", size = 3367276, upload-time = "2026-01-07T18:57:50.366Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a7/17926fec1c339d2d5e67e96a371e306dd367f32a2905dec1587b68841655/rumdl-0.0.212-py3-none-win_amd64.whl", hash = "sha256:ecbe63bac0a214b4de76b28fea403ab9f045915b578024879a9c3a76e712e715", size = 3190205, upload-time = "2026-01-07T18:57:47.645Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/5c567b85bd26d6a32e8dcc5b6183a5cf42dbcd33c2eaad12df587130d4a8/rumdl-0.0.215-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5ec4ee6314371bc5a87736e0b8d176e5fd26812379e2e5de503ad1deb3060d2f", size = 3118519, upload-time = "2026-01-12T14:56:56.39Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a2/fecae1b5e7e128e4aef1699a1d4a78a6e4defb598967a36a47cba8f2283c/rumdl-0.0.215-py3-none-macosx_11_0_arm64.whl", hash = "sha256:10b1341e62015b8cea36f7d77ce1fd739d752828ad90f786a8b685db8feaa160", size = 2995043, upload-time = "2026-01-12T14:56:52.352Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2f/ae47ad816bc9c80dba965f5dd9d78f591fa331f1cd177ad1157a174d26a6/rumdl-0.0.215-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:3208788df4633526a92ca42822eaf66f9e5c047757b7daddb05b80eda157a53c", size = 3360504, upload-time = "2026-01-12T14:56:53.948Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2f/55eeef66c71d4d755e41d447665dd6618c047c91e19b40e35d93c496c139/rumdl-0.0.215-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c2d47999cb64a2e77a1b1416e1b3987a5d496d0bc28c6a69b7a4d6e8bc3ab290", size = 3391266, upload-time = "2026-01-12T14:56:58.95Z" },
+    { url = "https://files.pythonhosted.org/packages/53/50/fb0629fa3de91226a858c6ff53a14a65a61b19443f7c0f7a13e87c1dcb75/rumdl-0.0.215-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f93068d5c9fd4cc2749fae114209fde15a3e61efc4abcdf4f2522d9288144665", size = 3350914, upload-time = "2026-01-12T14:56:55.2Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8f/7baec997f07b5e10cb621d344552c0197384a8072bbbe97b2515240ae4fd/rumdl-0.0.215-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3d501a8b52bed28016e95f400c173d8c0b3ed04eb48c4183deb2df95cee600e1", size = 3382144, upload-time = "2026-01-12T14:57:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/db/46927ac23de51ecb9b81175457820fce3ae943970cc545efd21f743161b7/rumdl-0.0.215-py3-none-win_amd64.whl", hash = "sha256:92cd295d9b867face415efee33bbf222a321db3e166471b66d36c1f62523eec4", size = 3202791, upload-time = "2026-01-12T14:56:57.786Z" },
 ]
 
 [[package]]
@@ -2694,11 +2694,11 @@ wheels = [
 
 [[package]]
 name = "types-awscrt"
-version = "0.30.0"
+version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/1f/febd2df22e24f77b759db0dd9ecdd7f07f055e6a4dbbb699c5eb34b617ef/types_awscrt-0.30.0.tar.gz", hash = "sha256:362fd8f5eaebcfcd922cb9fd8274fb375df550319f78031ee3779eac0b9ecc79", size = 17761, upload-time = "2025-12-12T01:55:59.626Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/9f/9be587f2243ea7837ad83aad248ff4d8f9a880ac5a84544e9661e5840a22/types_awscrt-0.31.0.tar.gz", hash = "sha256:aa8b42148af0847be14e2b8ea3637a3518ffab038f8d3be7083950f3ce87d3ff", size = 17817, upload-time = "2026-01-12T06:42:37.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/5f/15999051fca2949a67562c3f80fae2dd5d3404a3f97b326b614533843281/types_awscrt-0.30.0-py3-none-any.whl", hash = "sha256:8204126e01a00eaa4a746e7a0076538ca0e4e3f52408adec0ab9b471bb0bb64b", size = 42392, upload-time = "2025-12-12T01:55:58.194Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/8d/87ac494b5165e7650b2bc92ee3325c1339a47323489beeda32dffc9a1334/types_awscrt-0.31.0-py3-none-any.whl", hash = "sha256:009cfe5b9af8c75e8304243490e20a5229e7a56203f1d41481f5522233453f51", size = 42509, upload-time = "2026-01-12T06:42:36.187Z" },
 ]
 
 [[package]]
@@ -2747,15 +2747,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "uv-bump"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/16/0b9f89d10df58d6376130ee98fd0ee679726b9ce2f5de6585cb3fd48c19d/uv_bump-0.4.0.tar.gz", hash = "sha256:ee230c26287d4ef93e72f8068e52bf00a23d95bcdc59cd93cd3098fad4baaca9", size = 5257, upload-time = "2025-12-13T09:08:21.859Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/a1/865ba99e107a79e58ab4b802845ffe2dda6b8f121aae4ad7223856c94603/uv_bump-0.4.0-py3-none-any.whl", hash = "sha256:312de0d83007bf359c8efe420f2d2f58595fb1dba8934cfd1747cb649e5305c6", size = 6579, upload-time = "2025-12-13T09:08:20.856Z" },
 ]
 
 [[package]]
@@ -2822,7 +2813,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "2.46.4"
+version = "2.46.5"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -2867,7 +2858,6 @@ dev = [
     { name = "types-aioboto3", extra = ["s3", "ses"] },
     { name = "types-authlib" },
     { name = "types-pyyaml" },
-    { name = "uv-bump" },
 ]
 test = [
     { name = "pytest" },
@@ -2916,7 +2906,6 @@ requires-dist = [
     { name = "types-aioboto3", extras = ["s3", "ses"], marker = "extra == 'dev'", specifier = ">=15.5.0" },
     { name = "types-authlib", marker = "extra == 'dev'", specifier = ">=1.6.6.20251220" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },
-    { name = "uv-bump", marker = "extra == 'dev'", specifier = ">=0.4.0" },
 ]
 provides-extras = ["dev", "test"]
 
@@ -3018,44 +3007,61 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "15.0.1"
+version = "16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
-    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
-    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
-    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
-    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
-    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
-    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
-    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
-    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
-    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
-    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
uv bump is always executed with uvx, so no need to explicitly install it