### PR TITLE
feat: expose locale_names to template context

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -442,6 +442,33 @@ from starlette_babel import gettext as _
 message = _("Welcome to {app}", app=app_name)
 ```
 
+### Template Context Variables for i18n
+
+The following language-related variables are available in templates:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `default_language` | `str` | Default language code (e.g., "en") |
+| `supported_languages` | `set[str]` | Set of supported language codes |
+| `locale_names` | `dict[str, str]` | Language codes to native display names |
+
+#### Using `locale_names` for Language Selectors
+
+The `locale_names` dict maps language codes to their native display names, sorted alphabetically:
+
+```html
+<select name="language">
+    {% for code, name in locale_names.items() %}
+        <option value="{{ code }}"
+                {% if code == current_language %}selected{% endif %}>
+            {{ name }}
+        </option>
+    {% endfor %}
+</select>
+```
+
+Example output: `{"ca": "Català", "en": "English", "es": "Español"}`
+
 ### SEO-Friendly Language URLs
 
 Vibetuner supports path-prefix language routing for SEO-friendly URLs (e.g., `/ca/privacy`,

--- a/vibetuner-py/src/vibetuner/context.py
+++ b/vibetuner-py/src/vibetuner/context.py
@@ -1,4 +1,5 @@
-from pydantic import UUID4, BaseModel
+from babel import Locale
+from pydantic import UUID4, BaseModel, PrivateAttr, computed_field
 
 from vibetuner.config import settings
 
@@ -17,6 +18,26 @@ class Context(BaseModel):
 
     default_language: str = settings.project.language
     supported_languages: set[str] = settings.project.languages
+
+    _locale_names_cache: dict[str, str] | None = PrivateAttr(default=None)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def locale_names(self) -> dict[str, str]:
+        """Language codes mapped to native display names, sorted alphabetically."""
+        if self._locale_names_cache is None:
+            self._locale_names_cache = dict(
+                sorted(
+                    {
+                        locale: (
+                            Locale.parse(locale).display_name or locale
+                        ).capitalize()
+                        for locale in self.supported_languages
+                    }.items(),
+                    key=lambda x: x[1],
+                ),
+            )
+        return self._locale_names_cache
 
     umami_website_id: UUID4 | None = settings.project.umami_website_id
 

--- a/vibetuner-py/src/vibetuner/frontend/routes/language.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/language.py
@@ -1,4 +1,3 @@
-from babel import Locale
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
@@ -8,16 +7,6 @@ from ..templates import render_template
 
 
 router = APIRouter()
-
-LOCALE_NAMES: dict[str, str] = dict(
-    sorted(
-        {
-            locale: (Locale.parse(locale).display_name or locale).capitalize()
-            for locale in ctx.supported_languages
-        }.items(),
-        key=lambda x: x[1],
-    ),
-)
 
 
 @router.get("/set-language/{lang}")
@@ -37,7 +26,7 @@ async def get_languages(request: Request) -> HTMLResponse:
         "lang/select.html.jinja",
         request=request,
         ctx={
-            "locale_names": LOCALE_NAMES,
+            "locale_names": ctx.locale_names,
             "current_language": request.state.language,
         },
     )

--- a/vibetuner-py/src/vibetuner/frontend/routes/user.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/user.py
@@ -39,25 +39,12 @@ async def user_edit_form(request: Request) -> HTMLResponse:
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    # Get available languages for the dropdown
-    from babel import Locale
-
-    locale_names = dict(
-        sorted(
-            {
-                locale: (Locale.parse(locale).display_name or locale).capitalize()
-                for locale in ctx.supported_languages
-            }.items(),
-            key=lambda x: x[1],
-        ),
-    )
-
     return render_template(
         "user/edit.html.jinja",
         request,
         {
             "user": user,
-            "locale_names": locale_names,
+            "locale_names": ctx.locale_names,
             "current_language": user.user_settings.language,
         },
     )

--- a/vibetuner-py/tests/unit/test_context.py
+++ b/vibetuner-py/tests/unit/test_context.py
@@ -1,0 +1,52 @@
+# ABOUTME: Tests for the Context model.
+# ABOUTME: Validates locale_names property behavior for language display names.
+# ruff: noqa: S101
+"""Tests for the Context model."""
+
+
+def test_locale_names_returns_sorted_dict():
+    """locale_names returns language codes mapped to native display names, sorted alphabetically."""
+    from vibetuner.context import Context
+
+    ctx = Context()
+    ctx.__dict__["supported_languages"] = {"en", "es", "ca"}
+
+    names = ctx.locale_names
+
+    assert isinstance(names, dict)
+    assert "en" in names
+    assert "es" in names
+    assert "ca" in names
+    # Values should be native display names
+    assert names["en"] == "English"
+    assert names["es"] == "Español"
+    assert names["ca"] == "Català"
+    # Sorted alphabetically by display name: Català, English, Español
+    assert list(names.keys()) == ["ca", "en", "es"]
+
+
+def test_locale_names_handles_single_language():
+    """locale_names works with a single language."""
+    from vibetuner.context import Context
+
+    ctx = Context()
+    ctx.__dict__["supported_languages"] = {"en"}
+
+    names = ctx.locale_names
+
+    assert names == {"en": "English"}
+
+
+def test_locale_names_is_cached():
+    """locale_names result is cached after first access."""
+    from vibetuner.context import Context
+
+    ctx = Context()
+    ctx.__dict__["supported_languages"] = {"en", "es"}
+
+    # Access twice
+    names1 = ctx.locale_names
+    names2 = ctx.locale_names
+
+    # Should be the same object (cached)
+    assert names1 is names2


### PR DESCRIPTION
## Summary

- Add `locale_names` computed property to the `Context` model, providing a single source of truth for language display names
- Remove duplicate code from `language.py` (LOCALE_NAMES constant) and `user.py` (inline computation)
- Add documentation for i18n template context variables
- Add unit tests for the new property

## Test plan

- [x] Unit tests pass for `locale_names` property (3 tests)
- [x] All relevant unit tests pass (72 tests)
- [x] Python linting passes
- [x] Markdown linting passes
- [ ] Manual verification: scaffold test project and verify language selector works

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)