### PR TITLE
feat: add lint-po linter for Gettext translation files

### DIFF
--- a/vibetuner-template/.justfiles/linting.justfile
+++ b/vibetuner-template/.justfiles/linting.justfile
@@ -23,6 +23,11 @@ lint-jinja:
 lint-yaml:
     @uvx --from dprint-py dprint check --plugins https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm
 
+# Lint PO translation files with lint-po
+[group('Code quality: linting')]
+lint-po:
+    @uvx lint-po locales/*/LC_MESSAGES/*.po
+
 # Type check Python files with ty
 [group('Code quality: linting')]
 type-check:
@@ -30,4 +35,4 @@ type-check:
 
 # Run all linting checks
 [group('Code quality: linting')]
-lint: lint-md lint-py lint-toml lint-jinja type-check
+lint: lint-md lint-py lint-toml lint-jinja lint-po type-check

--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -55,3 +55,10 @@ repos:
             --optional-scopes,
             --strict,
           ]
+  - repo: local
+    hooks:
+      - id: lint-po
+        name: lint-po
+        entry: uvx lint-po
+        language: system
+        files: \.po$


### PR DESCRIPTION
## Summary

- Add `lint-po` justfile recipe using `uvx lint-po` (no dev dependency needed)
- Add local pre-commit hook for `.po` files
- Include `lint-po` in composite `lint` task

Closes #773

## Test plan

- [x] Verified `uvx lint-po` works on valid .po files (exit 0)
- [x] Verified it catches format specifier mismatches and other errors (exit 1)
- [x] Pre-commit hook configured correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)