### PR TITLE
fix: mark session cookie as Secure in production

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -182,7 +182,11 @@ class AuthBackend(AuthenticationBackend):
 middlewares: list[Middleware] = [
     Middleware(TrustedHostMiddleware),
     Middleware(HtmxMiddleware),
-    Middleware(SessionMiddleware, secret_key=settings.session_key.get_secret_value()),
+    Middleware(
+        SessionMiddleware,
+        secret_key=settings.session_key.get_secret_value(),
+        secure=not ctx.DEBUG,
+    ),
     Middleware(
         LocaleMiddleware,
         locales=list(ctx.supported_languages),


### PR DESCRIPTION
## Summary
- Adds `secure=not ctx.DEBUG` to `SessionMiddleware` configuration
- Session cookie is now marked `Secure` in production (requiring HTTPS)
- Development mode still works on localhost without HTTPS

## Test plan
- [ ] Scaffold a test project with `DEBUG=true` and verify cookie does NOT have Secure flag
- [ ] Set `DEBUG=false` and verify cookie HAS Secure flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)