### PR TITLE
fix: use correct SessionMiddleware parameter for secure cookies

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -185,7 +185,7 @@ middlewares: list[Middleware] = [
     Middleware(
         SessionMiddleware,
         secret_key=settings.session_key.get_secret_value(),
-        secure=not ctx.DEBUG,
+        https_only=not ctx.DEBUG,
     ),
     Middleware(
         LocaleMiddleware,


### PR DESCRIPTION
## Summary
- Fix `TypeError: SessionMiddleware.__init__() got an unexpected keyword argument 'secure'`
- Starlette's SessionMiddleware uses `https_only`, not `secure`, to control the Secure cookie flag

## Test plan
- [ ] Deploy and verify session cookies work in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)