### PR TITLE
feat: add default_language question to copier scaffold

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -58,9 +58,14 @@ python_version:
     - "3.13"
     - "3.14"
 
+default_language:
+  type: str
+  help: Default language for your project (2-letter ISO 639-1 code)
+  default: "en"
+
 supported_languages:
   type: yaml
-  help: List of 2 letter lang codes in JSON format of supported languages (in addition to English)
+  help: List of 2-letter lang codes of additional supported languages
   multiline: true
   default: []
 


### PR DESCRIPTION
## Summary
- Adds `default_language` question to copier.yml allowing users to choose their project's default language during scaffolding
- Previously hardcoded to English ("en")
- The default language is automatically included in the merged `languages` set, so users don't need to also add it to `supported_languages`

## Test plan
- [ ] Scaffold a new project and verify `default_language` appears in `.copier-answers.yml`
- [ ] Verify the default language is included in the app's supported languages set

🤖 Generated with [Claude Code](https://claude.com/claude-code)