### PR TITLE
fix: use conventional commit title in deps-pr squash merge

### DIFF
--- a/.justfiles/deps.justfile
+++ b/.justfiles/deps.justfile
@@ -45,7 +45,8 @@ deps-pr:
     set -euo pipefail
 
     # Generate timestamped branch name
-    BRANCH="chore/update-deps-$(date +%Y-%m-%d-%H%M)"
+    DATE_STAMP=$(date +%Y-%m-%d)
+    BRANCH="chore/update-deps-${DATE_STAMP}-$(date +%H%M)"
 
     # Ensure we're on main and up to date
     git checkout main
@@ -76,8 +77,8 @@ deps-pr:
     git push -u origin "$BRANCH"
     gh pr create --fill --base main
 
-    # Merge the PR (squash)
-    gh pr merge --squash --delete-branch
+    # Merge the PR (squash) with conventional commit title
+    gh pr merge --squash --delete-branch --subject "chore: update deps ${DATE_STAMP}"
 
     # Return to main
     git checkout main


### PR DESCRIPTION
## Summary
- Fix `just deps-pr` to use proper conventional commit format when squash merging
- The `gh pr merge --squash` command was defaulting to the branch name as commit title
- Now explicitly passes `--subject "chore: update deps ${DATE_STAMP}"` for correct formatting

## Test plan
- [ ] Run `just deps-pr` and verify the resulting commit has a proper conventional commit title

🤖 Generated with [Claude Code](https://claude.com/claude-code)