### PR TITLE
feat: expose compute_auto_port function with optional path parameter

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -1,7 +1,5 @@
 # ABOUTME: Run commands for starting the application in different modes
 # ABOUTME: Supports dev/prod modes for frontend and worker services
-import hashlib
-import os
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -9,6 +7,7 @@ import typer
 from rich.console import Console
 
 from vibetuner.logging import logger
+from vibetuner.utils import compute_auto_port
 
 
 console = Console()
@@ -19,14 +18,6 @@ run_app = typer.Typer(
 
 DEFAULT_FRONTEND_PORT = 8000
 DEFAULT_WORKER_PORT = 11111
-
-
-def _compute_auto_port() -> int:
-    """Compute deterministic port from current directory path."""
-    cwd = os.getcwd()
-    hash_bytes = hashlib.sha256(cwd.encode()).digest()
-    hash_int = int.from_bytes(hash_bytes[:4], "big")
-    return 8001 + (hash_int % 999)
 
 
 def _run_worker(mode: Literal["dev", "prod"], port: int, workers: int) -> None:
@@ -154,7 +145,7 @@ def dev(
         raise typer.Exit(code=1)
 
     if auto_port:
-        port = _compute_auto_port()
+        port = compute_auto_port()
 
     _run_service("dev", service, host, port, workers_count)
 

--- a/vibetuner-py/src/vibetuner/utils.py
+++ b/vibetuner-py/src/vibetuner/utils.py
@@ -1,0 +1,19 @@
+# ABOUTME: Utility functions for vibetuner
+# ABOUTME: Provides compute_auto_port for deterministic port calculation from paths
+import hashlib
+import os
+
+
+def compute_auto_port(path: str | None = None) -> int:
+    """Compute deterministic port from directory path.
+
+    Args:
+        path: Directory path to compute port for. Defaults to current directory.
+
+    Returns:
+        Port number in the range 8001-8999.
+    """
+    target_path = path or os.getcwd()
+    hash_bytes = hashlib.sha256(target_path.encode()).digest()
+    hash_int = int.from_bytes(hash_bytes[:4], "big")
+    return 8001 + (hash_int % 999)

--- a/vibetuner-py/tests/unit/test_utils.py
+++ b/vibetuner-py/tests/unit/test_utils.py
@@ -1,0 +1,54 @@
+# ABOUTME: Unit tests for vibetuner.utils module
+# ABOUTME: Tests auto-port computation utility function
+# ruff: noqa: S101
+
+import os
+from unittest.mock import patch
+
+
+class TestComputeAutoPort:
+    """Test compute_auto_port utility function."""
+
+    def test_returns_int_in_expected_range(self):
+        """Test that auto port is in the range 8001-8999."""
+        from vibetuner.utils import compute_auto_port
+
+        port = compute_auto_port("/some/path")
+        assert isinstance(port, int)
+        assert 8001 <= port <= 8999
+
+    def test_deterministic_for_same_path(self):
+        """Test that same path always returns same port."""
+        from vibetuner.utils import compute_auto_port
+
+        path = "/my/project/path"
+        port1 = compute_auto_port(path)
+        port2 = compute_auto_port(path)
+        assert port1 == port2
+
+    def test_different_paths_can_have_different_ports(self):
+        """Test that different paths can produce different ports."""
+        from vibetuner.utils import compute_auto_port
+
+        port1 = compute_auto_port("/path/a")
+        port2 = compute_auto_port("/path/b")
+        # Not guaranteed to be different, but these specific paths differ
+        assert port1 != port2
+
+    def test_defaults_to_cwd_when_no_path_provided(self):
+        """Test that None path uses current working directory."""
+        from vibetuner.utils import compute_auto_port
+
+        with patch.object(os, "getcwd", return_value="/test/cwd"):
+            port_from_none = compute_auto_port(None)
+            port_from_explicit = compute_auto_port("/test/cwd")
+            assert port_from_none == port_from_explicit
+
+    def test_defaults_to_cwd_when_called_without_args(self):
+        """Test that calling without arguments uses current working directory."""
+        from vibetuner.utils import compute_auto_port
+
+        with patch.object(os, "getcwd", return_value="/test/cwd"):
+            port_from_no_args = compute_auto_port()
+            port_from_explicit = compute_auto_port("/test/cwd")
+            assert port_from_no_args == port_from_explicit


### PR DESCRIPTION
## Summary

- Move auto-port calculation from private `_compute_auto_port()` to public `compute_auto_port()` in `vibetuner.utils`
- Add optional `path` parameter that defaults to current directory
- Enable external tooling to calculate deterministic ports for different worktree paths

Closes #825

## Test plan

- [x] Unit tests for `compute_auto_port` function
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)