### PR TITLE
fix: bootstrap without requiring just or mise installed

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -78,9 +78,9 @@ enable_watchtower:
 _tasks:
   - command: [uv, sync]
     when: "{{ _copier_operation == 'copy' }}"
-  - command: [just, git-init, "{{ project_slug }}"]
+  - command: [uvx, --from, just-bin, just, git-init, "{{ project_slug }}"]
     when: "{{ _copier_operation == 'copy' }}"
-  - command: [mise, trust]
+  - command: [sh, -c, "command -v mise > /dev/null && mise trust || true"]
     when: "{{ _copier_operation == 'copy' }}"
   - command: [uv, run, prek, install]
     when: "{{ _copier_operation == 'copy' }}"


### PR DESCRIPTION
## Summary

- Use `uvx --from just-bin just` instead of calling `just` directly
- Make `mise trust` gracefully skip if mise isn't installed

Fixes #839

## Test plan

- [ ] Run scaffold without just/mise installed to verify it completes
- [ ] Run scaffold with just/mise installed to verify normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)