### PR TITLE
fix: cache git branch lookup in versioning module

### DIFF
--- a/vibetuner-py/src/vibetuner/versioning.py
+++ b/vibetuner-py/src/vibetuner/versioning.py
@@ -2,12 +2,14 @@
 # ABOUTME: Reads version from APP_VERSION env var (Docker) or pyproject.toml (local dev).
 
 import os
+from functools import lru_cache
 
 from git import InvalidGitRepositoryError, Repo
 
 from vibetuner.pyproject import get_project_version
 
 
+@lru_cache
 def _get_git_branch() -> str | None:
     """Get current git branch name, or None if not in a git repo."""
     try:


### PR DESCRIPTION
## Summary

- Add `@lru_cache` to `_get_git_branch()` to avoid repeated git operations

The `read_pyproject()` function already had caching, but `_get_git_branch()` didn't. Since the branch won't change during a process's lifetime, caching is safe and avoids unnecessary git operations if `get_version()` is called multiple times.

## Test plan

- [x] Versioning module still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)