### PR TITLE
feat: add vibetuner scaffold adopt command

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/scaffold.py
+++ b/vibetuner-py/src/vibetuner/cli/scaffold.py
@@ -1,14 +1,172 @@
 # ABOUTME: Scaffolding commands for creating new projects from the vibetuner template
 # ABOUTME: Uses Copier to generate FastAPI+MongoDB+HTMX projects with interactive prompts
+import tomllib
 from pathlib import Path
 from typing import Annotated
 
 import copier
+import git
 import typer
 from rich.console import Console
 
 
 console = Console()
+
+
+def _get_git_config(key: str, cwd: Path) -> str | None:
+    """Get a git config value, returning None if not found.
+
+    Args:
+        key: Config key in "section.option" format (e.g., "user.name", "user.email")
+        cwd: Directory to search for git repository from
+    """
+    try:
+        repo = git.Repo(cwd, search_parent_directories=True)
+        reader = repo.config_reader()
+        section, option = key.split(".", 1)
+        return reader.get_value(section, option)
+    except (git.InvalidGitRepositoryError, git.GitError, KeyError, ValueError):
+        return None
+
+
+def _infer_from_pyproject(path: Path) -> dict[str, str]:
+    """Infer template variables from pyproject.toml."""
+    data: dict[str, str] = {}
+    pyproject_path = path / "pyproject.toml"
+
+    if not pyproject_path.exists():
+        return data
+
+    with pyproject_path.open("rb") as f:
+        pyproject = tomllib.load(f)
+
+    project = pyproject.get("project", {})
+
+    if name := project.get("name"):
+        data["project_name"] = name
+        data["project_slug"] = name.lower().replace("_", "-").replace(" ", "-")
+
+    if description := project.get("description"):
+        data["project_description"] = description
+
+    authors = project.get("authors", [])
+    if authors and isinstance(authors, list) and isinstance(authors[0], dict):
+        first_author = authors[0]
+        if author_name := first_author.get("name"):
+            data["author_name"] = author_name
+        if author_email := first_author.get("email"):
+            data["author_email"] = author_email
+
+    return data
+
+
+def _infer_python_version(path: Path) -> str | None:
+    """Infer Python version from .python-version file."""
+    python_version_path = path / ".python-version"
+    if not python_version_path.exists():
+        return None
+
+    version_str = python_version_path.read_text().strip()
+    parts = version_str.split(".")
+    if len(parts) >= 2:
+        return f"{parts[0]}.{parts[1]}"
+    return None
+
+
+def _infer_project_data(path: Path) -> dict[str, str]:
+    """Infer template variables from existing project files.
+
+    Reads project metadata from pyproject.toml and other files to pre-fill
+    Copier template variables when adopting an existing project.
+    """
+    data = _infer_from_pyproject(path)
+
+    if "author_name" not in data:
+        if git_name := _get_git_config("user.name", path):
+            data["author_name"] = git_name
+
+    if "author_email" not in data:
+        if git_email := _get_git_config("user.email", path):
+            data["author_email"] = git_email
+
+    if python_version := _infer_python_version(path):
+        data["python_version"] = python_version
+
+    return data
+
+
+def _has_vibetuner_dependency(path: Path) -> bool:
+    """Check if vibetuner is listed as a dependency in pyproject.toml."""
+    pyproject_path = path / "pyproject.toml"
+    if not pyproject_path.exists():
+        return False
+
+    with pyproject_path.open("rb") as f:
+        pyproject = tomllib.load(f)
+
+    project = pyproject.get("project", {})
+    dependencies = project.get("dependencies", [])
+
+    return any(
+        isinstance(dep, str) and dep.startswith("vibetuner") for dep in dependencies
+    )
+
+
+def _validate_adopt_path(path: Path) -> None:
+    """Validate path for adopt command, raising typer.Exit on errors."""
+    if not path.exists():
+        console.print(f"[red]Error: Directory does not exist: {path}[/red]")
+        raise typer.Exit(code=1)
+
+    if not path.is_dir():
+        console.print(f"[red]Error: Path is not a directory: {path}[/red]")
+        raise typer.Exit(code=1)
+
+    pyproject_path = path / "pyproject.toml"
+    if not pyproject_path.exists():
+        console.print(f"[red]Error: pyproject.toml not found in {path}[/red]")
+        console.print(
+            "[yellow]The adopt command requires an existing Python project "
+            "with pyproject.toml[/yellow]"
+        )
+        raise typer.Exit(code=1)
+
+    if not _has_vibetuner_dependency(path):
+        console.print(
+            "[red]Error: vibetuner is not listed as a dependency in pyproject.toml[/red]"
+        )
+        console.print(
+            "[yellow]Add vibetuner to your dependencies first: uv add vibetuner[/yellow]"
+        )
+        raise typer.Exit(code=1)
+
+    answers_file = path / ".copier-answers.yml"
+    if answers_file.exists():
+        console.print(
+            "[red]Error: Project is already scaffolded (.copier-answers.yml exists)[/red]"
+        )
+        console.print(
+            "[yellow]Use 'vibetuner scaffold update' to update an existing "
+            "scaffolded project[/yellow]"
+        )
+        raise typer.Exit(code=1)
+
+
+def _parse_data_overrides(data: list[str] | None) -> dict[str, str]:
+    """Parse --data key=value arguments into a dictionary."""
+    if not data:
+        return {}
+
+    result: dict[str, str] = {}
+    for item in data:
+        if "=" not in item:
+            console.print(
+                f"[red]Error: Invalid data format '{item}'. Expected key=value[/red]"
+            )
+            raise typer.Exit(code=1)
+        key, value = item.split("=", 1)
+        result[key] = value
+    return result
 
 
 scaffold_app = typer.Typer(
@@ -192,3 +350,119 @@ def update(
 def copy_core_templates() -> None:
     """Deprecated: This command is a no-op kept for backwards compatibility."""
     console.print("[dim]This command is deprecated and does nothing.[/dim]")
+
+
+@scaffold_app.command(name="adopt")
+def adopt(
+    path: Annotated[
+        Path | None,
+        typer.Argument(
+            help="Path to the existing project to adopt (defaults to current directory)",
+        ),
+    ] = None,
+    defaults: Annotated[
+        bool,
+        typer.Option(
+            "--defaults",
+            "-d",
+            help="Use default values for all prompts (non-interactive mode)",
+        ),
+    ] = False,
+    data: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--data",
+            help="Override template variables in key=value format (can be used multiple times)",
+        ),
+    ] = None,
+    branch: Annotated[
+        str | None,
+        typer.Option(
+            "--branch",
+            "-b",
+            help="Use specific branch/tag from the vibetuner template repository",
+        ),
+    ] = None,
+) -> None:
+    """Adopt vibetuner scaffolding for an existing project.
+
+    This command allows projects that already have vibetuner installed as a
+    dependency to adopt the full scaffolding infrastructure, enabling future
+    `scaffold update` commands.
+
+    The command will:
+    1. Infer template variables from existing project files (pyproject.toml, etc.)
+    2. Apply the vibetuner template to the existing directory
+    3. Prompt for conflict resolution on existing files
+
+    Examples:
+
+        # Adopt scaffolding in current directory
+        vibetuner scaffold adopt
+
+        # Adopt scaffolding in specific directory
+        vibetuner scaffold adopt /path/to/project
+
+        # Use specific branch for testing
+        vibetuner scaffold adopt --branch fix/scaffold-command
+
+        # Override inferred values
+        vibetuner scaffold adopt --data company_name="My Company"
+    """
+    if path is None:
+        path = Path.cwd()
+
+    _validate_adopt_path(path)
+
+    template_src = "gh:alltuner/vibetuner"
+    vcs_ref = branch or "main"
+
+    if branch:
+        console.print(
+            f"[dim]Using vibetuner template from GitHub ({branch} branch)[/dim]"
+        )
+    else:
+        console.print("[dim]Using vibetuner template from GitHub (main branch)[/dim]")
+
+    inferred_data = _infer_project_data(path)
+    if inferred_data:
+        console.print("\n[dim]Inferred values from existing project:[/dim]")
+        for key, value in inferred_data.items():
+            console.print(f"  [dim]{key}: {value}[/dim]")
+
+    user_overrides = _parse_data_overrides(data)
+    default_values = {"company_name": "Acme Corp", "supported_languages": []}
+
+    # Merge: defaults -> inferred -> user overrides (later takes precedence)
+    data_dict: dict = {**default_values, **inferred_data, **user_overrides}
+
+    # Run copier
+    try:
+        console.print(f"\n[green]Adopting scaffolding in: {path}[/green]\n")
+        console.print(
+            "[yellow]Copier will prompt for conflict resolution on existing files.[/yellow]\n"
+        )
+
+        copier.run_copy(
+            src_path=str(template_src),
+            dst_path=path,
+            data=data_dict if data_dict else None,
+            defaults=defaults,
+            quiet=defaults,
+            unsafe=True,
+            vcs_ref=vcs_ref,
+        )
+
+        console.print("\n[green]✓ Scaffolding adopted successfully![/green]")
+        console.print("\nNext steps:")
+        console.print("  1. Review changes: git diff")
+        console.print("  2. Resolve any conflicts in pyproject.toml")
+        console.print("  3. Sync dependencies: uv sync")
+        console.print("  4. Start development: just dev")
+        console.print(
+            "\nYou can now use 'vibetuner scaffold update' to update to future template versions."
+        )
+
+    except Exception as e:
+        console.print(f"[red]Error adopting scaffolding: {e}[/red]")
+        raise typer.Exit(code=1) from None

--- a/vibetuner-py/tests/unit/test_scaffold_adopt.py
+++ b/vibetuner-py/tests/unit/test_scaffold_adopt.py
@@ -1,0 +1,223 @@
+# ABOUTME: Unit tests for vibetuner scaffold adopt command
+# ABOUTME: Tests project data inference and validation logic
+# ruff: noqa: S101
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+from vibetuner.cli import app
+from vibetuner.cli.scaffold import _infer_project_data
+
+
+class TestInferProjectData:
+    """Test the _infer_project_data helper function."""
+
+    def test_infers_project_name_from_pyproject(self):
+        """Test that project_name is inferred from pyproject.toml."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "my-awesome-project"\ndescription = "A test"\n'
+            )
+
+            data = _infer_project_data(path)
+            assert data["project_name"] == "my-awesome-project"
+
+    def test_infers_project_slug_from_name(self):
+        """Test that project_slug is derived from project_name."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "My Awesome Project"\ndescription = "A test"\n'
+            )
+
+            data = _infer_project_data(path)
+            assert data["project_slug"] == "my-awesome-project"
+
+    def test_infers_description_from_pyproject(self):
+        """Test that project_description is inferred from pyproject.toml."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "test"\ndescription = "A useful project"\n'
+            )
+
+            data = _infer_project_data(path)
+            assert data["project_description"] == "A useful project"
+
+    def test_infers_author_name_from_pyproject(self):
+        """Test that author_name is inferred from pyproject.toml authors."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "test"\n'
+                '[[project.authors]]\nname = "Jane Doe"\nemail = "jane@example.com"\n'
+            )
+
+            data = _infer_project_data(path)
+            assert data["author_name"] == "Jane Doe"
+
+    def test_infers_author_email_from_pyproject(self):
+        """Test that author_email is inferred from pyproject.toml authors."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "test"\n'
+                '[[project.authors]]\nname = "Jane Doe"\nemail = "jane@example.com"\n'
+            )
+
+            data = _infer_project_data(path)
+            assert data["author_email"] == "jane@example.com"
+
+    def test_falls_back_to_git_for_author_name(self):
+        """Test that author_name falls back to git config when not in pyproject."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text('[project]\nname = "test"\n')
+
+            mock_reader = MagicMock()
+            mock_reader.get_value.return_value = "Git User"
+            mock_repo = MagicMock()
+            mock_repo.config_reader.return_value = mock_reader
+
+            with patch("git.Repo", return_value=mock_repo):
+                data = _infer_project_data(path)
+                assert data["author_name"] == "Git User"
+                mock_reader.get_value.assert_any_call("user", "name")
+
+    def test_falls_back_to_git_for_author_email(self):
+        """Test that author_email falls back to git config when not in pyproject."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text('[project]\nname = "test"\n')
+
+            def mock_get_value(section, option):
+                if section == "user" and option == "name":
+                    return "Git User"
+                if section == "user" and option == "email":
+                    return "git@example.com"
+                raise KeyError()
+
+            mock_reader = MagicMock()
+            mock_reader.get_value.side_effect = mock_get_value
+            mock_repo = MagicMock()
+            mock_repo.config_reader.return_value = mock_reader
+
+            with patch("git.Repo", return_value=mock_repo):
+                data = _infer_project_data(path)
+                assert data["author_email"] == "git@example.com"
+
+    def test_infers_python_version_from_file(self):
+        """Test that python_version is inferred from .python-version file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text('[project]\nname = "test"\n')
+            python_version_file = path / ".python-version"
+            python_version_file.write_text("3.13.1\n")
+
+            data = _infer_project_data(path)
+            assert data["python_version"] == "3.13"
+
+    def test_extracts_major_minor_from_python_version(self):
+        """Test that only major.minor is extracted from .python-version."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text('[project]\nname = "test"\n')
+            python_version_file = path / ".python-version"
+            python_version_file.write_text("3.12.8\n")
+
+            data = _infer_project_data(path)
+            assert data["python_version"] == "3.12"
+
+    def test_handles_missing_python_version_file(self):
+        """Test that missing .python-version file doesn't cause error."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text('[project]\nname = "test"\n')
+
+            data = _infer_project_data(path)
+            # Should not have python_version key if file doesn't exist
+            assert "python_version" not in data
+
+    def test_handles_missing_optional_fields(self):
+        """Test that missing optional fields don't cause errors."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text('[project]\nname = "test"\n')
+
+            # Mock git to return empty strings (simulating no git config)
+            mock_result = MagicMock()
+            mock_result.stdout = ""
+            mock_result.returncode = 1
+
+            with patch("subprocess.run", return_value=mock_result):
+                data = _infer_project_data(path)
+                assert data["project_name"] == "test"
+                # Optional fields should not be present if not found
+                assert "project_description" not in data
+                assert "author_name" not in data
+                assert "author_email" not in data
+
+
+class TestAdoptValidation:
+    """Test the adopt command validation logic."""
+
+    def test_raises_for_nonexistent_path(self):
+        """Test that adopt raises error for non-existent path."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["scaffold", "adopt", "/nonexistent/path"])
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+
+    def test_raises_for_missing_pyproject(self):
+        """Test that adopt raises error when pyproject.toml is missing."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            result = runner.invoke(app, ["scaffold", "adopt", tmp])
+            assert result.exit_code != 0
+            assert "pyproject.toml" in result.output
+
+    def test_raises_for_missing_vibetuner_dependency(self):
+        """Test that adopt raises error when vibetuner is not a dependency."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "test"\ndependencies = ["fastapi"]\n'
+            )
+
+            result = runner.invoke(app, ["scaffold", "adopt", tmp])
+            assert result.exit_code != 0
+            assert "vibetuner" in result.output.lower()
+
+    def test_raises_for_already_scaffolded_project(self):
+        """Test that adopt raises error when .copier-answers.yml exists."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            pyproject = path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "test"\ndependencies = ["vibetuner"]\n'
+            )
+            answers = path / ".copier-answers.yml"
+            answers.write_text("project_name: test\n")
+
+            result = runner.invoke(app, ["scaffold", "adopt", tmp])
+            assert result.exit_code != 0
+            assert (
+                "already" in result.output.lower() or "copier" in result.output.lower()
+            )


### PR DESCRIPTION
## Summary

  - Adds `vibetuner scaffold adopt` command for existing projects with vibetuner as a dependency
  - Infers template variables from pyproject.toml, .python-version, and git config
  - Validates prerequisites (pyproject.toml exists, vibetuner dependency, not already scaffolded)
  - Uses GitPython instead of subprocess for git config access
  - Includes 15 unit tests covering inference and validation logic

  ## Test plan

  - [x] All 203 unit tests pass
  - [x] Linting passes
  - [ ] Manual test: create project with `uv init && uv add vibetuner`, run `vibetuner scaffold adopt`