### PR TITLE
fix: ensure Ctrl+C cleanly stops dev server with SSE connections

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -87,6 +87,7 @@ def _run_frontend(
         port=port,
         interface=Interfaces.ASGI,
         workers=workers,
+        workers_kill_timeout=5,
         reload=is_dev,
         reload_paths=paths.reload_paths if is_dev else [],
         log_level="info",

--- a/vibetuner-py/src/vibetuner/frontend/lifespan.py
+++ b/vibetuner-py/src/vibetuner/frontend/lifespan.py
@@ -11,6 +11,7 @@ from vibetuner.mongo import init_mongodb, teardown_mongodb
 from vibetuner.sqlmodel import init_sqlmodel, teardown_sqlmodel
 
 from .hotreload import hotreload
+from .routes.debug import reset_sse_state, shutdown_sse_connections
 
 
 @asynccontextmanager
@@ -31,8 +32,11 @@ async def base_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await RuntimeConfig.refresh_cache()
         logger.debug("Runtime config cache initialized")
 
+    reset_sse_state()
+
     yield
 
+    await shutdown_sse_connections()
     logger.info("Vibetuner frontend stopping")
     if ctx.DEBUG:
         await hotreload.shutdown()


### PR DESCRIPTION
## Summary

- Add `workers_kill_timeout=5` to Granian config as a safety net
- Add shutdown signaling so SSE generators exit gracefully within 1 second
- Reset SSE state on startup for dev mode reloads

## Test plan

- [ ] Start dev server: `just local-all`
- [ ] Open browser to `/debug/claude` (creates SSE connection)
- [ ] Press Ctrl+C
- [ ] Server should shut down within ~2 seconds (graceful) or 5 seconds max (forced)

Fixes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)