### PR TITLE
feat: add short format to timeago filter

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -267,20 +267,54 @@ Add templates in `templates/`:
 {% endblock content %}
 ```
 
+### Built-in Template Filters
+
+Vibetuner provides several built-in template filters for common formatting needs:
+
+| Filter | Usage | Output |
+|--------|-------|--------|
+| `timeago` | `{{ dt \| timeago }}` | "5 minutes ago" |
+| `timeago(short=True)` | `{{ dt \| timeago(short=True) }}` | "5m ago" |
+| `format_date` | `{{ dt \| format_date }}` | "January 15, 2025" |
+| `format_datetime` | `{{ dt \| format_datetime }}` | "January 15, 2025 at 2:30 PM" |
+| `format_duration` / `duration` | `{{ seconds \| duration }}` | "5 min" or "30 sec" |
+
+#### timeago Filter
+
+The `timeago` filter converts a datetime to a human-readable relative time string:
+
+```html
+<span>Created {{ post.created_at | timeago }}</span>
+<!-- Output: "5 minutes ago", "yesterday", "3 months ago", etc. -->
+
+<!-- Short format for compact displays -->
+<span>{{ post.created_at | timeago(short=True) }}</span>
+<!-- Output: "5m ago", "1d ago", "3mo ago", etc. -->
+```
+
+Short format outputs:
+
+| Time Range | Short Format |
+|------------|--------------|
+| < 60 seconds | "just now" |
+| < 60 minutes | "Xm ago" |
+| < 24 hours | "Xh ago" |
+| < 7 days | "Xd ago" |
+| < 30 days | "Xw ago" |
+| < 365 days | "Xmo ago" |
+| < 4 years | "Xy ago" |
+| >= 4 years | "MMM DD, YYYY" |
+
 ### Adding Custom Template Filters
 
-Create custom Jinja2 filters in `src/app/frontend/templates.py`:
+Register custom Jinja2 filters via the `template_filters` dict in `VibetunerApp`:
 
 ```python
 # src/app/frontend/templates.py
-from vibetuner.frontend.templates import register_filter
-
-@register_filter()
 def uppercase(value):
     """Convert value to uppercase"""
     return str(value).upper()
 
-@register_filter("money")
 def format_money(value):
     """Format value as USD currency"""
     try:
@@ -289,15 +323,25 @@ def format_money(value):
         return str(value)
 ```
 
+```python
+# src/app/tune.py
+from vibetuner import VibetunerApp
+from app.frontend.templates import uppercase, format_money
+
+app = VibetunerApp(
+    template_filters={
+        "uppercase": uppercase,
+        "money": format_money,
+    },
+)
+```
+
 Use in templates:
 
 ```html
 <h1>{{ user.name | uppercase }}</h1>
 <p>Price: {{ product.price | money }}</p>
 ```
-
-The `@register_filter()` decorator automatically registers filters with the Jinja
-environment. If no name is provided, the function name becomes the filter name.
 
 ### Adding Background Jobs
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -279,20 +279,32 @@ Add templates in `templates/`:
 {% endblock %}
 ```
 
+#### Built-in Template Filters
+
+Vibetuner provides several built-in template filters for common formatting needs:
+
+| Filter | Usage | Output |
+|--------|-------|--------|
+| `timeago` | `{{ dt \| timeago }}` | "5 minutes ago" |
+| `timeago(short=True)` | `{{ dt \| timeago(short=True) }}` | "5m ago" |
+| `format_date` | `{{ dt \| format_date }}` | "January 15, 2025" |
+| `format_datetime` | `{{ dt \| format_datetime }}` | "January 15, 2025 at 2:30 PM" |
+| `format_duration` / `duration` | `{{ seconds \| duration }}` | "5 min" or "30 sec" |
+
+The `timeago` filter converts a datetime to a human-readable relative time string. Use `short=True` for compact displays like "5m ago", "1d ago", "3mo ago".
+
+Short format outputs: < 60 seconds = "just now", < 60 minutes = "Xm ago", < 24 hours = "Xh ago", < 7 days = "Xd ago", < 30 days = "Xw ago", < 365 days = "Xmo ago", < 4 years = "Xy ago", >= 4 years = "MMM DD, YYYY".
+
 #### Adding Custom Template Filters
 
-Create custom Jinja2 filters in `src/app/frontend/templates.py`:
+Register custom Jinja2 filters via the `template_filters` dict in `VibetunerApp`:
 
 ```python
 # src/app/frontend/templates.py
-from vibetuner.frontend.templates import register_filter
-
-@register_filter()
 def uppercase(value):
     """Convert value to uppercase"""
     return str(value).upper()
 
-@register_filter("money")
 def format_money(value):
     """Format value as USD currency"""
     try:
@@ -301,14 +313,25 @@ def format_money(value):
         return str(value)
 ```
 
+```python
+# src/app/tune.py
+from vibetuner import VibetunerApp
+from app.frontend.templates import uppercase, format_money
+
+app = VibetunerApp(
+    template_filters={
+        "uppercase": uppercase,
+        "money": format_money,
+    },
+)
+```
+
 Use in templates:
 
 ```html
 <h1>{{ user.name | uppercase }}</h1>
 <p>Price: {{ product.price | money }}</p>
 ```
-
-The `@register_filter()` decorator automatically registers filters with the Jinja environment. If no name is provided, the function name becomes the filter name.
 
 #### Adding Background Jobs
 

--- a/vibetuner-py/src/vibetuner/frontend/templates.py
+++ b/vibetuner-py/src/vibetuner/frontend/templates.py
@@ -27,11 +27,84 @@ __all__ = [
 ]
 
 
-def timeago(dt):
+def _timeago_verbose(diff: timedelta, dt) -> str:
+    """Format timedelta as verbose relative time string."""
+    if diff < timedelta(seconds=60):
+        seconds = diff.seconds
+        return ngettext(
+            "%(seconds)d second ago",
+            "%(seconds)d seconds ago",
+            seconds,
+        ) % {"seconds": seconds}
+    if diff < timedelta(minutes=60):
+        minutes = diff.seconds // 60
+        return ngettext(
+            "%(minutes)d minute ago",
+            "%(minutes)d minutes ago",
+            minutes,
+        ) % {"minutes": minutes}
+    if diff < timedelta(days=1):
+        hours = diff.seconds // 3600
+        return ngettext("%(hours)d hour ago", "%(hours)d hours ago", hours) % {
+            "hours": hours,
+        }
+    if diff < timedelta(days=2):
+        return _("yesterday")
+    if diff < timedelta(days=65):
+        days = diff.days
+        return ngettext("%(days)d day ago", "%(days)d days ago", days) % {
+            "days": days,
+        }
+    if diff < timedelta(days=365):
+        months = diff.days // 30
+        return ngettext("%(months)d month ago", "%(months)d months ago", months) % {
+            "months": months,
+        }
+    if diff < timedelta(days=365 * 4):
+        years = diff.days // 365
+        return ngettext("%(years)d year ago", "%(years)d years ago", years) % {
+            "years": years,
+        }
+    return dt.strftime("%b %d, %Y")
+
+
+def _timeago_short(diff: timedelta, dt) -> str:
+    """Format timedelta as compact relative time string."""
+    if diff < timedelta(seconds=60):
+        return ngettext("just now", "just now", 1)
+    if diff < timedelta(minutes=60):
+        minutes = diff.seconds // 60
+        return ngettext("%(minutes)dm ago", "%(minutes)dm ago", minutes) % {
+            "minutes": minutes,
+        }
+    if diff < timedelta(days=1):
+        hours = diff.seconds // 3600
+        return ngettext("%(hours)dh ago", "%(hours)dh ago", hours) % {"hours": hours}
+    if diff < timedelta(days=2):
+        return ngettext("%(days)dd ago", "%(days)dd ago", 1) % {"days": 1}
+    if diff < timedelta(days=7):
+        days = diff.days
+        return ngettext("%(days)dd ago", "%(days)dd ago", days) % {"days": days}
+    if diff < timedelta(days=30):
+        weeks = diff.days // 7
+        return ngettext("%(weeks)dw ago", "%(weeks)dw ago", weeks) % {"weeks": weeks}
+    if diff < timedelta(days=365):
+        months = diff.days // 30
+        return ngettext("%(months)dmo ago", "%(months)dmo ago", months) % {
+            "months": months,
+        }
+    if diff < timedelta(days=365 * 4):
+        years = diff.days // 365
+        return ngettext("%(years)dy ago", "%(years)dy ago", years) % {"years": years}
+    return dt.strftime("%b %d, %Y")
+
+
+def timeago(dt, short: bool = False):
     """Converts a datetime object to a human-readable string representing the time elapsed since the given datetime.
 
     Args:
         dt (datetime): The datetime object to convert.
+        short (bool): If True, use compact format like "5m ago" instead of "5 minutes ago".
 
     Returns:
         str: A human-readable string representing the time elapsed since the given datetime,
@@ -39,47 +112,14 @@ def timeago(dt):
         "X months ago", or "X years ago". If the datetime is more than 4 years old,
         it returns the date in the format "MMM DD, YYYY".
 
+        In short format, returns compact strings like "just now", "5m ago", "2h ago", etc.
+
     """
     try:
         diff = age_in_timedelta(dt)
-
-        if diff < timedelta(seconds=60):
-            seconds = diff.seconds
-            return ngettext(
-                "%(seconds)d second ago",
-                "%(seconds)d seconds ago",
-                seconds,
-            ) % {"seconds": seconds}
-        if diff < timedelta(minutes=60):
-            minutes = diff.seconds // 60
-            return ngettext(
-                "%(minutes)d minute ago",
-                "%(minutes)d minutes ago",
-                minutes,
-            ) % {"minutes": minutes}
-        if diff < timedelta(days=1):
-            hours = diff.seconds // 3600
-            return ngettext("%(hours)d hour ago", "%(hours)d hours ago", hours) % {
-                "hours": hours,
-            }
-        if diff < timedelta(days=2):
-            return _("yesterday")
-        if diff < timedelta(days=65):
-            days = diff.days
-            return ngettext("%(days)d day ago", "%(days)d days ago", days) % {
-                "days": days,
-            }
-        if diff < timedelta(days=365):
-            months = diff.days // 30
-            return ngettext("%(months)d month ago", "%(months)d months ago", months) % {
-                "months": months,
-            }
-        if diff < timedelta(days=365 * 4):
-            years = diff.days // 365
-            return ngettext("%(years)d year ago", "%(years)d years ago", years) % {
-                "years": years,
-            }
-        return dt.strftime("%b %d, %Y")
+        if short:
+            return _timeago_short(diff, dt)
+        return _timeago_verbose(diff, dt)
     except Exception:
         return ""
 

--- a/vibetuner-py/tests/unit/test_timeago.py
+++ b/vibetuner-py/tests/unit/test_timeago.py
@@ -1,0 +1,374 @@
+# ABOUTME: Unit tests for the timeago template filter
+# ABOUTME: Tests both verbose (default) and short format output for relative time display
+# ruff: noqa: S101
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from vibetuner.frontend.templates import timeago
+
+
+class TestTimeagoVerbose:
+    """Test the default verbose timeago format."""
+
+    @patch("vibetuner.time.now")
+    def test_seconds_ago(self, mock_now):
+        """Test that seconds are displayed correctly."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(seconds=30)
+        result = timeago(dt)
+
+        assert "30" in result
+        assert "second" in result
+
+    @patch("vibetuner.time.now")
+    def test_minutes_ago(self, mock_now):
+        """Test that minutes are displayed correctly."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(minutes=5)
+        result = timeago(dt)
+
+        assert "5" in result
+        assert "minute" in result
+
+    @patch("vibetuner.time.now")
+    def test_hours_ago(self, mock_now):
+        """Test that hours are displayed correctly."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(hours=3)
+        result = timeago(dt)
+
+        assert "3" in result
+        assert "hour" in result
+
+    @patch("vibetuner.time.now")
+    def test_yesterday(self, mock_now):
+        """Test that yesterday is displayed correctly."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=1, hours=12)
+        result = timeago(dt)
+
+        assert "yesterday" in result.lower()
+
+    @patch("vibetuner.time.now")
+    def test_days_ago(self, mock_now):
+        """Test that days are displayed correctly."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=5)
+        result = timeago(dt)
+
+        assert "5" in result
+        assert "day" in result
+
+    @patch("vibetuner.time.now")
+    def test_months_ago(self, mock_now):
+        """Test that months are displayed correctly."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=90)
+        result = timeago(dt)
+
+        assert "3" in result
+        assert "month" in result
+
+    @patch("vibetuner.time.now")
+    def test_years_ago(self, mock_now):
+        """Test that years are displayed correctly."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=730)
+        result = timeago(dt)
+
+        assert "2" in result
+        assert "year" in result
+
+    @patch("vibetuner.time.now")
+    def test_old_date_shows_formatted_date(self, mock_now):
+        """Test that very old dates show formatted date."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = datetime(2020, 3, 15, tzinfo=UTC)
+        result = timeago(dt)
+
+        assert "Mar" in result
+        assert "15" in result
+        assert "2020" in result
+
+    def test_invalid_input_returns_empty_string(self):
+        """Test that invalid input returns empty string."""
+        assert timeago(None) == ""
+        assert timeago("not a date") == ""
+
+
+class TestTimeagoShort:
+    """Test the short timeago format."""
+
+    @patch("vibetuner.time.now")
+    def test_seconds_shows_just_now(self, mock_now):
+        """Test that seconds show 'just now' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(seconds=30)
+        result = timeago(dt, short=True)
+
+        assert result == "just now"
+
+    @patch("vibetuner.time.now")
+    def test_one_minute_ago(self, mock_now):
+        """Test that 1 minute shows '1m ago'."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(minutes=1)
+        result = timeago(dt, short=True)
+
+        assert result == "1m ago"
+
+    @patch("vibetuner.time.now")
+    def test_minutes_ago(self, mock_now):
+        """Test that minutes show 'Xm ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(minutes=45)
+        result = timeago(dt, short=True)
+
+        assert result == "45m ago"
+
+    @patch("vibetuner.time.now")
+    def test_one_hour_ago(self, mock_now):
+        """Test that 1 hour shows '1h ago'."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(hours=1)
+        result = timeago(dt, short=True)
+
+        assert result == "1h ago"
+
+    @patch("vibetuner.time.now")
+    def test_hours_ago(self, mock_now):
+        """Test that hours show 'Xh ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(hours=8)
+        result = timeago(dt, short=True)
+
+        assert result == "8h ago"
+
+    @patch("vibetuner.time.now")
+    def test_yesterday_shows_1d_ago(self, mock_now):
+        """Test that yesterday shows '1d ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=1, hours=12)
+        result = timeago(dt, short=True)
+
+        assert result == "1d ago"
+
+    @patch("vibetuner.time.now")
+    def test_days_ago(self, mock_now):
+        """Test that days (2-6) show 'Xd ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=5)
+        result = timeago(dt, short=True)
+
+        assert result == "5d ago"
+
+    @patch("vibetuner.time.now")
+    def test_one_week_ago(self, mock_now):
+        """Test that 7 days shows '1w ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=7)
+        result = timeago(dt, short=True)
+
+        assert result == "1w ago"
+
+    @patch("vibetuner.time.now")
+    def test_two_weeks_ago(self, mock_now):
+        """Test that 14 days shows '2w ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=14)
+        result = timeago(dt, short=True)
+
+        assert result == "2w ago"
+
+    @patch("vibetuner.time.now")
+    def test_three_weeks_ago(self, mock_now):
+        """Test that 21 days shows '3w ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=21)
+        result = timeago(dt, short=True)
+
+        assert result == "3w ago"
+
+    @patch("vibetuner.time.now")
+    def test_four_weeks_ago(self, mock_now):
+        """Test that 28 days shows '4w ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=28)
+        result = timeago(dt, short=True)
+
+        assert result == "4w ago"
+
+    @patch("vibetuner.time.now")
+    def test_one_month_ago(self, mock_now):
+        """Test that ~30 days shows '1mo ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=35)
+        result = timeago(dt, short=True)
+
+        assert result == "1mo ago"
+
+    @patch("vibetuner.time.now")
+    def test_months_ago(self, mock_now):
+        """Test that months show 'Xmo ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=90)
+        result = timeago(dt, short=True)
+
+        assert result == "3mo ago"
+
+    @patch("vibetuner.time.now")
+    def test_one_year_ago(self, mock_now):
+        """Test that ~365 days shows '1y ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=400)
+        result = timeago(dt, short=True)
+
+        assert result == "1y ago"
+
+    @patch("vibetuner.time.now")
+    def test_years_ago(self, mock_now):
+        """Test that years show 'Xy ago' in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=730)
+        result = timeago(dt, short=True)
+
+        assert result == "2y ago"
+
+    @patch("vibetuner.time.now")
+    def test_old_date_shows_formatted_date(self, mock_now):
+        """Test that very old dates show formatted date in short format too."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = datetime(2020, 3, 15, tzinfo=UTC)
+        result = timeago(dt, short=True)
+
+        assert "Mar" in result
+        assert "15" in result
+        assert "2020" in result
+
+    def test_invalid_input_returns_empty_string(self):
+        """Test that invalid input returns empty string in short format."""
+        assert timeago(None, short=True) == ""
+        assert timeago("not a date", short=True) == ""
+
+
+class TestTimeagoEdgeCases:
+    """Test edge cases and threshold boundaries."""
+
+    @patch("vibetuner.time.now")
+    def test_exactly_60_seconds_shows_minutes(self, mock_now):
+        """Test that exactly 60 seconds shows minutes, not seconds."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(seconds=60)
+        result = timeago(dt)
+
+        assert "minute" in result
+        assert "second" not in result
+
+    @patch("vibetuner.time.now")
+    def test_exactly_60_minutes_shows_hours(self, mock_now):
+        """Test that exactly 60 minutes shows hours, not minutes."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(minutes=60)
+        result = timeago(dt)
+
+        assert "hour" in result
+        assert "minute" not in result
+
+    @patch("vibetuner.time.now")
+    def test_exactly_24_hours_shows_yesterday(self, mock_now):
+        """Test that exactly 24 hours shows yesterday."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(hours=24)
+        result = timeago(dt)
+
+        assert "yesterday" in result.lower()
+
+    @patch("vibetuner.time.now")
+    def test_short_format_at_7_days_boundary(self, mock_now):
+        """Test that 7 days shows weeks in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=7)
+        result = timeago(dt, short=True)
+
+        assert result == "1w ago"
+
+    @patch("vibetuner.time.now")
+    def test_short_format_at_30_days_boundary(self, mock_now):
+        """Test that 30 days shows months in short format."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=30)
+        result = timeago(dt, short=True)
+
+        assert result == "1mo ago"
+
+    @patch("vibetuner.time.now")
+    def test_verbose_format_at_7_days_shows_days(self, mock_now):
+        """Test that 7 days in verbose format still shows days, not weeks."""
+        current_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = current_time
+
+        dt = current_time - timedelta(days=7)
+        result = timeago(dt)
+
+        assert "7" in result
+        assert "day" in result
+        assert "week" not in result.lower()


### PR DESCRIPTION
## Summary

- Add `short` parameter to the `timeago` Jinja filter for compact output like "5m ago" instead of "5 minutes ago"
- Document all built-in template filters (`timeago`, `format_date`, `format_datetime`, `format_duration`)
- Fix outdated custom filter documentation (replaced non-existent `@register_filter()` decorator with `template_filters` dict pattern)

## Changes

| File | Change |
|------|--------|
| `vibetuner-py/src/vibetuner/frontend/templates.py` | Add `short` parameter, refactor into helper functions |
| `vibetuner-py/tests/unit/test_timeago.py` | New test file with 32 tests |
| `vibetuner-docs/docs/development-guide.md` | Add built-in filters docs, fix custom filters docs |
| `vibetuner-docs/docs/llms-full.txt` | Same documentation updates |

## Usage

```jinja
{{ post.created_at | timeago }}               {# "5 minutes ago" #}
{{ post.created_at | timeago(short=True) }}   {# "5m ago" #}
```

## Test plan

- [x] All 32 new timeago tests pass
- [x] Existing time tests still pass (51 total)
- [x] Linting passes

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)