### PR TITLE
feat: load parent .env before local .env in configuration

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2900,7 +2900,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "6.1.4"
+version = "6.1.5"
 source = { directory = "vibetuner-py" }
 dependencies = [
     { name = "aioboto3" },
@@ -2994,7 +2994,7 @@ provides-extras = ["dev", "test"]
 
 [[package]]
 name = "vibetuner-scaffolding"
-version = "6.1.4"
+version = "6.1.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -70,7 +70,7 @@ class LocaleDetectionSettings(BaseSettings):
         case_sensitive=False,
         extra="ignore",
         env_prefix="LOCALE_",
-        env_file=".env",
+        env_file=("../.env", ".env"),
     )
 
 
@@ -215,7 +215,7 @@ class CoreConfiguration(BaseSettings):
         return f"{self.project.project_slug}:"
 
     model_config = SettingsConfigDict(
-        case_sensitive=False, extra="ignore", env_file=".env"
+        case_sensitive=False, extra="ignore", env_file=("../.env", ".env")
     )
 
 


### PR DESCRIPTION
## Summary
- Both `CoreConfiguration` and `LocaleDetectionSettings` now load `../.env` first, then `.env`
- Uses pydantic-settings tuple support where later files take precedence
- Enables shared environment defaults in a parent directory while local `.env` can override

## Test plan
- [ ] Verify `.env` values override `../.env` values
- [ ] Verify `../.env` values load when no local `.env` exists
- [ ] Verify behavior is unchanged when only `.env` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)