### PR TITLE
fix: remove --delete-branch from deps-pr gh merge

### DIFF
--- a/.justfiles/deps.justfile
+++ b/.justfiles/deps.justfile
@@ -74,4 +74,5 @@ deps-pr:
 
     git push -u origin "$BRANCH"
     gh pr create --title "chore: update deps ${DATE_STAMP}" --body "" --base main
-    gh pr merge --squash --delete-branch --subject "chore: update deps ${DATE_STAMP}"
+    gh pr merge --squash --subject "chore: update deps ${DATE_STAMP}"
+    git push origin --delete "$BRANCH" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `gh pr merge --delete-branch` tries to `git checkout main` before deleting the local branch, which fails in bare repo + worktree setups where `main` is already checked out
- Removed `--delete-branch` flag and added explicit remote branch deletion instead
- Local cleanup was already handled by the existing `trap cleanup EXIT`

## Test plan
- [ ] Run `just deps-pr` and verify it completes without the `'main' is already used by worktree` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)