### PR TITLE
fix: remove install-deps from local dev commands

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -28,6 +28,7 @@ Changes to Python code, templates, and assets automatically reload.
 Run services locally without Docker:
 
 ```bash
+just install-deps            # Run once after cloning or updating lockfiles
 just local-all               # Runs server + assets with auto-port (recommended)
 just local-all-with-worker   # Includes background worker (requires Redis)
 ```

--- a/vibetuner-docs/docs/quick-start.md
+++ b/vibetuner-docs/docs/quick-start.md
@@ -105,6 +105,7 @@ Everything runs in containers with hot reload. Changes to code, templates, and a
 ### Local Development
 
 ```bash
+just install-deps    # Run once after cloning or updating lockfiles
 just local-all
 ```
 

--- a/vibetuner-template/.justfiles/localdev.justfile
+++ b/vibetuner-template/.justfiles/localdev.justfile
@@ -2,7 +2,7 @@ import 'deps.justfile'
 
 # Runs the dev environment with watch mode and cleans up orphans
 [group('Local Development')]
-dev: install-deps
+dev:
     ENVIRONMENT=development \
     COMPOSE_BAKE=true \
     PYTHON_VERSION={{ PYTHON_VERSION }} \
@@ -11,22 +11,22 @@ dev: install-deps
 
 # Runs the dev environment locally without Docker
 [group('Local Development')]
-local-dev PORT="8000": install-deps
+local-dev PORT="8000":
     @DEBUG=true vibetuner run dev --port {{ PORT }}
 
 # Runs local dev with auto-assigned port (deterministic per project path)
 [group('Local Development')]
-local-dev-auto: install-deps
+local-dev-auto:
     @DEBUG=true vibetuner run dev --auto-port
 
 # Runs the task worker locally without Docker
 [group('Local Development')]
-worker-dev: install-deps
+worker-dev:
     @DEBUG=true vibetuner run dev worker
 
 # Runs local dev server and assets in parallel (auto-port)
 [group('Local Development')]
-local-all: install-deps
+local-all:
     bunx concurrently --kill-others \
         --names "web,assets" \
         --prefix-colors "blue,green" \
@@ -35,7 +35,7 @@ local-all: install-deps
 
 # Runs local dev server, assets, and worker in parallel (requires Redis)
 [group('Local Development')]
-local-all-with-worker: install-deps
+local-all-with-worker:
     bunx concurrently --kill-others \
         --names "web,assets,worker" \
         --prefix-colors "blue,green,yellow" \

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -232,6 +232,7 @@ This project uses **git tags** for versioning:
 ### Development (Local)
 
 ```bash
+just install-deps            # Run once after cloning or updating lockfiles
 just local-all               # Runs server + assets with auto-port (recommended)
 just local-all-with-worker   # Includes background worker (requires Redis)
 ```


### PR DESCRIPTION
## Summary

- Removed `install-deps` as a dependency from all local dev justfile commands (`local-all`,
  `local-all-with-worker`, `local-dev`, `local-dev-auto`, `worker-dev`, `dev`)
- `install-deps` is now a manual step after cloning or updating lockfiles, not run on every
  dev server start
- CI/CD commands (`build-dev`, `build-prod`, `release`, etc.) still depend on `install-deps`
- Updated docs (quick-start, development guide, AGENTS.md) to show `install-deps` as a
  prerequisite step

## Test plan

- [ ] Run `just local-all` in a scaffolded project and verify it starts without running
  `bun install` / `uv sync`
- [ ] Run `just install-deps` manually and verify it still works
- [ ] Verify `just build-dev` still runs `install-deps` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)