### PR TITLE
fix: add --frozen to all uv run commands in justfiles

### DIFF
--- a/.justfiles/deps.justfile
+++ b/.justfiles/deps.justfile
@@ -41,7 +41,7 @@ update-and-commit: update-all update-precommit
 # Update pre-commit hooks and commit changes
 [group('Dependencies')]
 update-precommit:
-    @uv run prek auto-update
+    @uv run --frozen prek auto-update
     @git add vibetuner-template/.pre-commit-config.yaml
     @git commit -m "chore: update pre-commit hooks" \
         vibetuner-template/.pre-commit-config.yaml \

--- a/.justfiles/testing.justfile
+++ b/.justfiles/testing.justfile
@@ -2,31 +2,31 @@
 [group('Testing')]
 test:
     @echo "🧪 Running all tests..."
-    @cd vibetuner-py && uv run --extra test pytest
+    @cd vibetuner-py && uv run --frozen --extra test pytest
     @echo "✅ All tests passed"
 
 # Run tests with verbose output
 [group('Testing')]
 test-verbose:
     @echo "🧪 Running all tests (verbose)..."
-    @cd vibetuner-py && uv run --extra test pytest -v
+    @cd vibetuner-py && uv run --frozen --extra test pytest -v
     @echo "✅ All tests passed"
 
 # Run only unit tests
 [group('Testing')]
 test-unit:
     @echo "🧪 Running unit tests..."
-    @cd vibetuner-py && uv run --extra test pytest tests/unit/ -v
+    @cd vibetuner-py && uv run --frozen --extra test pytest tests/unit/ -v
     @echo "✅ Unit tests passed"
 
 # Run a specific test file
 [group('Testing')]
 test-file FILE:
     @echo "🧪 Running tests in {{FILE}}..."
-    @cd vibetuner-py && uv run --extra test pytest {{FILE}} -v
+    @cd vibetuner-py && uv run --frozen --extra test pytest {{FILE}} -v
 
 # Run tests matching a keyword expression
 [group('Testing')]
 test-match KEYWORD:
     @echo "🧪 Running tests matching '{{KEYWORD}}'..."
-    @cd vibetuner-py && uv run --extra test pytest -k "{{KEYWORD}}" -v
+    @cd vibetuner-py && uv run --frozen --extra test pytest -k "{{KEYWORD}}" -v

--- a/vibetuner-template/.justfiles/cicd.justfile
+++ b/vibetuner-template/.justfiles/cicd.justfile
@@ -1,10 +1,10 @@
 import 'helpers.justfile'
 
 PYTHON_VERSION := `tr -d '\n\r' < .python-version`
-VERSION := `uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"`
-PROJECT_SLUG := `uv run python -c "import yaml, os; p='.copier-answers.yml'; print((yaml.safe_load(open(p)) if os.path.exists(p) else {}).get('project_slug', 'scaffolding').strip())"`
-FQDN := `uv run python -c "import yaml, os, sys; p='.copier-answers.yml'; print((yaml.safe_load(open(p)) if os.path.exists(p) else {}).get('fqdn', '').strip()) if os.path.exists(p) else print('')"`
-ENABLE_WATCHTOWER := `uv run python -c "import yaml, os, sys; p='.copier-answers.yml'; print(str((yaml.safe_load(open(p)) if os.path.exists(p) else {}).get('enable_watchtower', False)).lower()) if os.path.exists(p) else print('false')"`
+VERSION := `uv run --frozen python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"`
+PROJECT_SLUG := `uv run --frozen python -c "import yaml, os; p='.copier-answers.yml'; print((yaml.safe_load(open(p)) if os.path.exists(p) else {}).get('project_slug', 'scaffolding').strip())"`
+FQDN := `uv run --frozen python -c "import yaml, os, sys; p='.copier-answers.yml'; print((yaml.safe_load(open(p)) if os.path.exists(p) else {}).get('fqdn', '').strip()) if os.path.exists(p) else print('')"`
+ENABLE_WATCHTOWER := `uv run --frozen python -c "import yaml, os, sys; p='.copier-answers.yml'; print(str((yaml.safe_load(open(p)) if os.path.exists(p) else {}).get('enable_watchtower', False)).lower()) if os.path.exists(p) else print('false')"`
 
 # Builds the dev image with COMPOSE_BAKE set
 [group('CI/CD')]

--- a/vibetuner-template/.justfiles/formatting.justfile
+++ b/vibetuner-template/.justfiles/formatting.justfile
@@ -6,12 +6,12 @@ format-py:
 # Format TOML files with taplo
 [group('Code quality: formatting')]
 format-toml:
-    @uv run taplo fmt
+    @uv run --frozen taplo fmt
 
 # Format Jinja files with djlint
 [group('Code quality: formatting')]
 format-jinja:
-    @uv run djlint . --reformat
+    @uv run --frozen djlint . --reformat
 
 # Format YAML files with dprint
 [group('Code quality: formatting')]
@@ -21,7 +21,7 @@ format-yaml:
 # Format Markdown files with rumdl
 [group('Code quality: formatting')]
 format-md:
-    @uv run rumdl fmt
+    @uv run --frozen rumdl fmt
 
 # Format all code
 [group('Code quality: formatting')]

--- a/vibetuner-template/.justfiles/i18n.justfile
+++ b/vibetuner-template/.justfiles/i18n.justfile
@@ -6,12 +6,12 @@ i18n: extract-translations update-locale-files compile-locales
 # Extracts translations from source files
 [group('localization')]
 extract-translations:
-    @uv run pybabel extract -F babel.cfg -o locales/messages.pot .
+    @uv run --frozen pybabel extract -F babel.cfg -o locales/messages.pot .
 
 # Creates a new language file for localization
 [group('localization')]
 new-locale LANG:
-    @uv run pybabel init -i locales/messages.pot -d locales -l {{ LANG }}
+    @uv run --frozen pybabel init -i locales/messages.pot -d locales -l {{ LANG }}
 
 # Updates existing language files for localization
 [group('localization')]
@@ -21,7 +21,7 @@ update-locale-files:
 # Compiles the language files into binary format
 [group('localization')]
 compile-locales:
-    @uv run pybabel compile -d locales
+    @uv run --frozen pybabel compile -d locales
 
 # Dump untranslated strings per language to a given DEST directory
 [group('localization')]

--- a/vibetuner-template/.justfiles/linting.justfile
+++ b/vibetuner-template/.justfiles/linting.justfile
@@ -1,7 +1,7 @@
 # Lint markdown files including dot directories
 [group('Code quality: linting')]
 lint-md:
-    @uv run rumdl check . .github
+    @uv run --frozen rumdl check . .github
 
 # Lint Python files with ruff
 [group('Code quality: linting')]
@@ -11,12 +11,12 @@ lint-py:
 # Lint TOML files with taplo (check only)
 [group('Code quality: linting')]
 lint-toml:
-    @uv run taplo fmt --check
+    @uv run --frozen taplo fmt --check
 
 # Lint Jinja files with djlint
 [group('Code quality: linting')]
 lint-jinja:
-    @uv run djlint . --lint
+    @uv run --frozen djlint . --lint
 
 # Lint YAML files with dprint
 [group('Code quality: linting')]

--- a/vibetuner-template/.justfiles/localdev.justfile
+++ b/vibetuner-template/.justfiles/localdev.justfile
@@ -12,17 +12,17 @@ dev:
 # Runs the dev environment locally without Docker
 [group('Local Development')]
 local-dev PORT="8000":
-    @DEBUG=true uv run vibetuner run dev --port {{ PORT }}
+    @DEBUG=true uv run --frozen vibetuner run dev --port {{ PORT }}
 
 # Runs local dev with auto-assigned port (deterministic per project path)
 [group('Local Development')]
 local-dev-auto:
-    @DEBUG=true uv run vibetuner run dev --auto-port
+    @DEBUG=true uv run --frozen vibetuner run dev --auto-port
 
 # Runs the task worker locally without Docker
 [group('Local Development')]
 worker-dev:
-    @DEBUG=true uv run vibetuner run dev worker
+    @DEBUG=true uv run --frozen vibetuner run dev worker
 
 _ensure-deps:
     @[ -d node_modules ] || bun install


### PR DESCRIPTION
## Summary
- Adds `--frozen` flag to all `uv run` invocations across justfiles (22 total)
- Prevents `uv` from rewriting `uv.lock` as a side effect of running tools, tests, linters, formatters, and the dev server
- Explicit dependency management commands (`uv lock`, `uv sync`) are left unchanged

## Test plan
- [ ] Run `just test` and verify tests execute without uv modifying the lockfile
- [ ] Run `just lint` and `just format` in a scaffolded project and confirm no lockfile changes
- [ ] Run `just local-dev-auto` and confirm the dev server starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)