### PR TITLE
fix: use --frozen instead of --locked in Dockerfile uv sync

### DIFF
--- a/vibetuner-template/Dockerfile
+++ b/vibetuner-template/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
-    uv sync --locked --no-sources --no-install-project --no-group dev
+    uv sync --frozen --no-sources --no-install-project --no-group dev
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Stage 3: Install Project (editable mode for source access)
@@ -48,7 +48,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
-    uv sync --locked --no-group dev && \
+    uv sync --frozen --no-group dev && \
     cp -r $(.venv/bin/python -c "import vibetuner; print(vibetuner.__path__[0])")/templates/frontend .core-templates && \
     find .venv -type d -name 'tests' -exec rm -rf {} + 2>/dev/null || true && \
     find .venv -type f \( -name '*.md' -o -name '*.rst' -o -name '*.txt' \) ! -path '*/METADATA' -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Replace `uv sync --locked` with `uv sync --frozen` in `vibetuner-template/Dockerfile` (lines 36 and 51)
- `--locked` re-validates `uv.lock` against `pyproject.toml`, which fails when Release Please bumps the version without regenerating the lockfile
- `--frozen` installs from the lockfile as-is, which is correct for Docker builds and consistent with bun's `--frozen-lockfile`

Closes #946

## Test plan

- [ ] Verify Docker build succeeds after a Release Please version bump (the scenario that previously broke)
- [ ] Verify Docker build still works normally with a matching lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)