### PR TITLE
fix: remove --no-sources from Dockerfile deps stage

### DIFF
--- a/vibetuner-template/Dockerfile
+++ b/vibetuner-template/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
-    uv sync --frozen --no-sources --no-install-project --no-group dev
+    uv sync --frozen --no-install-project --no-group dev
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Stage 3: Install Project (editable mode for source access)


### PR DESCRIPTION
## Summary

- Remove `--no-sources` from the deps stage `uv sync` command in the template Dockerfile
- `--no-sources` is incompatible with `--frozen` (added in #947), causing Docker builds to fail
  with `error: the argument '--frozen' cannot be used with '--no-sources'`
- `--no-sources` is redundant with `--frozen` since `--frozen` skips resolution entirely

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)