### PR TITLE
fix: lazy-import git in scaffold.py to prevent CLI crash in production

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/scaffold.py
+++ b/vibetuner-py/src/vibetuner/cli/scaffold.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Annotated
 
 import copier
-import git
 import typer
 from rich.console import Console
 
@@ -20,6 +19,10 @@ def _get_git_config(key: str, cwd: Path) -> str | None:
         key: Config key in "section.option" format (e.g., "user.name", "user.email")
         cwd: Directory to search for git repository from
     """
+    try:
+        import git
+    except ImportError:
+        return None
     try:
         repo = git.Repo(cwd, search_parent_directories=True)
         reader = repo.config_reader()

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2947,7 +2947,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "6.3.4"
+version = "6.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- Moves `import git` from module level to inside `_get_git_config()` with a `try/except ImportError` guard
- Prevents the entire CLI from crashing when the git binary is missing (e.g., `python:slim` Docker images)
- Matches the lazy-import pattern already used in `versioning.py`

Closes #951

## Test plan

- [x] New regression test `test_scaffold_module_loads_without_git` verifies the module imports cleanly when git is unavailable
- [x] New unit test `test_returns_none_when_git_unavailable` verifies `_get_git_config` returns `None` gracefully
- [x] All 17 existing scaffold adopt tests pass unchanged
- [x] `vibetuner --help` and `vibetuner scaffold --help` work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)