### PR TITLE
refactor: use pydantic-settings for OAuth credentials

### DIFF
--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -167,6 +167,12 @@ class CoreConfiguration(BaseSettings):
     r2_secret_key: SecretStr | None = None
     r2_default_region: str = "auto"
 
+    # OAuth provider credentials (read from env / .env)
+    google_client_id: SecretStr | None = None
+    google_client_secret: SecretStr | None = None
+    github_client_id: SecretStr | None = None
+    github_client_secret: SecretStr | None = None
+
     worker_concurrency: int = 16
 
     # Locale detection settings

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2947,7 +2947,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "6.3.9"
+version = "6.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- Replace `os.environ.get()` with pydantic-settings `SecretStr` fields on `CoreConfiguration`
  for OAuth client credentials (`google_client_id`, `google_client_secret`,
  `github_client_id`, `github_client_secret`)
- Credentials now benefit from `.env` file support, validation, and won't leak in logs
- Remove `import os` from `oauth.py`
- Update tests to use `monkeypatch.setattr(settings, ...)` instead of `patch.dict(os.environ, ...)`

Follow-up to #959.

## Test plan

- [x] `uv run --extra test pytest tests/unit/test_oauth_registration.py -v` (10 tests pass)
- [x] `uv run --extra test pytest tests/ -v` (274 tests pass, no regressions)
- [x] `uv run ruff check . && uv run ruff format --check .` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)