### PR TITLE
feat: make default_language configurable via copier.yml

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -63,12 +63,14 @@ default_language:
   type: str
   help: Default language for your project (2-letter ISO 639-1 code)
   default: "en"
+  when: false
 
 supported_languages:
   type: yaml
   help: List of 2-letter lang codes of additional supported languages
   multiline: true
   default: []
+  when: false
 
 enable_watchtower:
   type: bool


### PR DESCRIPTION
## Summary
- Add `when: false` to `default_language` and `supported_languages` in `copier.yml` so they are not prompted during `vibetuner scaffold new` but remain configurable via `.copier-answers.yml`
- The framework already reads `default_language` from `.copier-answers.yml` in `config.py` via `_load_project_config()`, so no Python changes are needed

## Test plan
- [ ] Run `vibetuner scaffold new /tmp/test --defaults` and verify `default_language` is not prompted
- [ ] Verify `.copier-answers.yml` in generated project contains `default_language: en`
- [ ] Manually edit `.copier-answers.yml` to set `default_language: es` and verify `settings.project.default_language` reflects the change

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)