### PR TITLE
feat: allow custom OAuth providers via tune.py config

### DIFF
--- a/vibetuner-py/src/vibetuner/app_config.py
+++ b/vibetuner-py/src/vibetuner/app_config.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, ConfigDict
 from starlette.middleware import Middleware
 from typer import Typer
 
+from vibetuner.models.oauth import OauthProviderModel
+
 
 class VibetunerApp(BaseModel):
     """Explicit configuration for a vibetuner application.
@@ -40,6 +42,9 @@ class VibetunerApp(BaseModel):
 
     # OAuth providers (e.g., ["google", "github"])
     oauth_providers: list[str] = []
+
+    # Custom OAuth providers (e.g., {"twitter": OauthProviderModel(...)})
+    custom_oauth_providers: dict[str, OauthProviderModel] = {}
 
     # Worker
     tasks: list[Callable[..., Any]] = []

--- a/vibetuner-py/src/vibetuner/frontend/__init__.py
+++ b/vibetuner-py/src/vibetuner/frontend/__init__.py
@@ -78,7 +78,7 @@ if ctx.DEBUG:
     )
 
 # Auto-register OAuth providers from config + env vars
-auto_register_providers(_app_config.oauth_providers)
+auto_register_providers(_app_config.oauth_providers, _app_config.custom_oauth_providers)
 
 # Register OAuth routes on auth.router (must happen before include_router)
 register_oauth_routes()

--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -95,8 +95,11 @@ _BUILTIN_PROVIDERS: dict[str, OauthProviderModel] = {
 }
 
 
-def auto_register_providers(provider_names: list[str]) -> None:
-    """Register OAuth providers from builtin configs and settings credentials."""
+def auto_register_providers(
+    provider_names: list[str],
+    custom_providers: dict[str, OauthProviderModel] | None = None,
+) -> None:
+    """Register OAuth providers from builtin configs, settings credentials, and custom configs."""
     from vibetuner.config import settings
 
     known = sorted(_BUILTIN_PROVIDERS.keys())
@@ -129,6 +132,16 @@ def auto_register_providers(provider_names: list[str]) -> None:
         )
         register_oauth_provider(name, provider)
         logger.info(f"Auto-registered OAuth provider: {name}")
+
+    # Register custom providers (fully configured by the user)
+    for name, provider in (custom_providers or {}).items():
+        if name in _PROVIDERS:
+            logger.warning(
+                f"Custom OAuth provider '{name}' conflicts with already-registered provider, skipping"
+            )
+            continue
+        register_oauth_provider(name, provider)
+        logger.info(f"Registered custom OAuth provider: {name}")
 
 
 async def _handle_user_account(


### PR DESCRIPTION
## Summary
- Adds `custom_oauth_providers: dict[str, OauthProviderModel]` field to `VibetunerApp` in `app_config.py`
- Updates `auto_register_providers()` to accept and register custom providers alongside builtins
- Includes conflict detection: custom providers that clash with already-registered names are skipped with a warning
- Adds 4 new tests covering custom provider registration, conflict handling, mixed usage, and `None` input

## Test plan
- [x] All 14 existing + new OAuth registration tests pass
- [ ] Scaffold a test project with custom providers in `tune.py` and verify login flow

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)