### PR TITLE
fix: resolve OAuth user through account link instead of email

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -142,8 +142,8 @@ async def _handle_user_account(
     )
 
     if oauth_account:
-        # OAuth account exists, get linked user account
-        account = await UserModel.get_by_email(email)
+        # OAuth account exists, resolve user through the link (survives email changes)
+        account = await UserModel.find_one({"oauth_accounts.$id": oauth_account.id})
         if not account:
             raise OAuthError("No account linked to this OAuth account")
         return account


### PR DESCRIPTION
## Summary
- Changes `_handle_user_account()` to resolve existing OAuth users via the `oauth_accounts` link reference on `UserModel` instead of `UserModel.get_by_email(email)`
- Uses `{"oauth_accounts.$id": oauth_account.id}` query to find the user that owns the OAuth account
- This survives email changes on the OAuth provider side (e.g., user updates their email on Google/GitHub)

## Test plan
- [ ] Create a user via OAuth login
- [ ] Change the user's email in the database
- [ ] Log in again via the same OAuth provider and verify the same user account is resolved

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)