### PR TITLE
feat: add MongoDB schema migration tooling

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/__init__.py
+++ b/vibetuner-py/src/vibetuner/cli/__init__.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from vibetuner.cli.db import db_app
+from vibetuner.cli.migrate import migrate_app
 from vibetuner.cli.run import run_app
 from vibetuner.cli.scaffold import scaffold_app
 from vibetuner.loader import ConfigurationError, load_app_config
@@ -111,6 +112,7 @@ def version(
 
 
 app.add_typer(db_app, name="db")
+app.add_typer(migrate_app, name="migrate")
 app.add_typer(run_app, name="run")
 app.add_typer(scaffold_app, name="scaffold")
 

--- a/vibetuner-py/src/vibetuner/cli/migrate.py
+++ b/vibetuner-py/src/vibetuner/cli/migrate.py
@@ -1,0 +1,186 @@
+# ABOUTME: MongoDB schema migration CLI commands.
+# ABOUTME: Provides create/up/down/status commands for managing MongoDB migrations.
+from datetime import datetime
+from pathlib import Path
+from typing import Annotated
+
+import asyncer
+import typer
+from rich.console import Console
+from rich.table import Table
+
+
+console = Console()
+
+migrate_app = typer.Typer(
+    help="MongoDB migration management commands", no_args_is_help=True
+)
+
+
+def _get_migrations_dir() -> Path:
+    """Get the migrations directory, creating it if needed."""
+    from vibetuner.paths import root
+
+    if root is None:
+        console.print("[red]Error: Not in a vibetuner project directory.[/red]")
+        raise typer.Exit(code=1)
+
+    migrations_dir = root / "migrations"
+    migrations_dir.mkdir(exist_ok=True)
+    return migrations_dir
+
+
+def _generate_migration_filename(name: str) -> str:
+    """Generate a timestamped migration filename."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    slug = name.lower().replace(" ", "_").replace("-", "_")
+    # Strip non-alphanumeric except underscores
+    slug = "".join(c for c in slug if c.isalnum() or c == "_")
+    return f"{timestamp}_{slug}.py"
+
+
+def _discover_migrations(migrations_dir: Path) -> list[Path]:
+    """Discover migration files sorted by filename (chronological)."""
+    files = sorted(migrations_dir.glob("*.py"))
+    return [f for f in files if not f.name.startswith("__")]
+
+
+MIGRATION_TEMPLATE = '''"""Migration: {name}
+
+Created: {timestamp}
+"""
+
+from pymongo.asynchronous.database import AsyncDatabase
+
+
+async def up(db: AsyncDatabase) -> None:
+    """Apply this migration."""
+    # Example operations:
+    # await db["collection"].create_index("field_name")
+    # await db["collection"].update_many({{}}, {{"$set": {{"new_field": "default"}}}})
+    pass
+
+
+async def down(db: AsyncDatabase) -> None:
+    """Reverse this migration."""
+    # Undo the operations performed in up()
+    # await db["collection"].drop_index("field_name_1")
+    # await db["collection"].update_many({{}}, {{"$unset": {{"new_field": ""}}}})
+    pass
+'''
+
+
+@migrate_app.command("create")
+def create(
+    name: Annotated[str, typer.Argument(help="Name describing the migration")],
+) -> None:
+    """Create a new migration file."""
+    migrations_dir = _get_migrations_dir()
+    filename = _generate_migration_filename(name)
+    filepath = migrations_dir / filename
+
+    content = MIGRATION_TEMPLATE.format(
+        name=name,
+        timestamp=datetime.now().isoformat(),
+    )
+
+    filepath.write_text(content, encoding="utf-8")
+    console.print(
+        f"[green]Created migration:[/green] {filepath.relative_to(migrations_dir.parent)}"
+    )
+
+
+@migrate_app.command("up")
+def up(
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show which migrations would run without applying them"
+    ),
+) -> None:
+    """Apply all pending migrations."""
+    migrations_dir = _get_migrations_dir()
+
+    async def _run() -> None:
+        from vibetuner.migrations import apply_pending_migrations
+
+        applied = await apply_pending_migrations(migrations_dir, dry_run=dry_run)
+        if not applied:
+            console.print("[dim]No pending migrations.[/dim]")
+        elif dry_run:
+            console.print(
+                f"\n[yellow]Dry run: {len(applied)} migration(s) would be applied.[/yellow]"
+            )
+        else:
+            console.print(
+                f"\n[green]{len(applied)} migration(s) applied successfully.[/green]"
+            )
+
+    asyncer.runnify(_run)()
+
+
+@migrate_app.command("down")
+def down(
+    steps: int = typer.Option(
+        1, "--steps", "-n", help="Number of migrations to roll back"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show which migrations would be rolled back"
+    ),
+) -> None:
+    """Roll back the most recent migration(s)."""
+    migrations_dir = _get_migrations_dir()
+
+    async def _run() -> None:
+        from vibetuner.migrations import rollback_migrations
+
+        rolled_back = await rollback_migrations(
+            migrations_dir, steps=steps, dry_run=dry_run
+        )
+        if not rolled_back:
+            console.print("[dim]No migrations to roll back.[/dim]")
+        elif dry_run:
+            console.print(
+                f"\n[yellow]Dry run: {len(rolled_back)} migration(s) would be rolled back.[/yellow]"
+            )
+        else:
+            console.print(
+                f"\n[green]{len(rolled_back)} migration(s) rolled back successfully.[/green]"
+            )
+
+    asyncer.runnify(_run)()
+
+
+@migrate_app.command("status")
+def status() -> None:
+    """Show migration status."""
+    migrations_dir = _get_migrations_dir()
+
+    async def _run() -> None:
+        from vibetuner.migrations import get_migration_status
+
+        statuses = await get_migration_status(migrations_dir)
+
+        if not statuses:
+            console.print("[dim]No migrations found.[/dim]")
+            return
+
+        table = Table(title="Migration Status")
+        table.add_column("Migration", style="cyan", no_wrap=True)
+        table.add_column("Status", style="bold")
+        table.add_column("Applied At", style="dim")
+
+        for entry in statuses:
+            status_str = (
+                "[green]applied[/green]"
+                if entry["applied"]
+                else "[yellow]pending[/yellow]"
+            )
+            applied_at = entry.get("applied_at", "")
+            if applied_at and isinstance(applied_at, datetime):
+                applied_at = applied_at.strftime("%Y-%m-%d %H:%M:%S")
+            table.add_row(
+                entry["name"], status_str, str(applied_at) if applied_at else ""
+            )
+
+        console.print(table)
+
+    asyncer.runnify(_run)()

--- a/vibetuner-py/src/vibetuner/migrations.py
+++ b/vibetuner-py/src/vibetuner/migrations.py
@@ -1,0 +1,199 @@
+# ABOUTME: MongoDB migration engine for applying and rolling back schema changes.
+# ABOUTME: Tracks migration history in a _migrations collection.
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from vibetuner.logging import logger
+
+
+MIGRATIONS_COLLECTION = "_migrations"
+
+
+async def _get_db():
+    """Get the MongoDB database instance."""
+    from vibetuner.config import settings
+    from vibetuner.mongo import _ensure_client, mongo_client
+
+    _ensure_client()
+    if mongo_client is None:
+        raise RuntimeError(
+            "MongoDB is not configured. Set MONGODB_URL to use migrations."
+        )
+    return mongo_client[settings.mongo_dbname]
+
+
+def _load_migration_module(filepath: Path):
+    """Dynamically load a migration file as a Python module."""
+    spec = importlib.util.spec_from_file_location(filepath.stem, filepath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load migration: {filepath}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _discover_migrations(migrations_dir: Path) -> list[Path]:
+    """Discover migration files sorted by filename (chronological)."""
+    files = sorted(migrations_dir.glob("*.py"))
+    return [f for f in files if not f.name.startswith("__")]
+
+
+async def _get_applied_migrations(db) -> dict[str, Any]:
+    """Get all applied migrations from the _migrations collection."""
+    collection = db[MIGRATIONS_COLLECTION]
+    applied = {}
+    async for doc in collection.find().sort("applied_at", 1):
+        applied[doc["name"]] = doc
+    return applied
+
+
+async def apply_pending_migrations(
+    migrations_dir: Path, *, dry_run: bool = False
+) -> list[str]:
+    """Apply all pending migrations in order.
+
+    Args:
+        migrations_dir: Path to the migrations directory.
+        dry_run: If True, only report what would be applied.
+
+    Returns:
+        List of migration names that were applied (or would be applied).
+    """
+    from rich.console import Console
+
+    console = Console()
+    db = await _get_db()
+    applied = await _get_applied_migrations(db)
+    migration_files = _discover_migrations(migrations_dir)
+
+    pending = [f for f in migration_files if f.stem not in applied]
+    if not pending:
+        return []
+
+    applied_names: list[str] = []
+    for filepath in pending:
+        name = filepath.stem
+        if dry_run:
+            console.print(f"  [yellow]Would apply:[/yellow] {name}")
+            applied_names.append(name)
+            continue
+
+        console.print(f"  [cyan]Applying:[/cyan] {name} ... ", end="")
+        module = _load_migration_module(filepath)
+
+        if not hasattr(module, "up"):
+            console.print("[red]SKIP (no up() function)[/red]")
+            continue
+
+        try:
+            await module.up(db)
+            # Record in _migrations collection
+            await db[MIGRATIONS_COLLECTION].insert_one(
+                {
+                    "name": name,
+                    "applied_at": datetime.now(UTC),
+                }
+            )
+            console.print("[green]OK[/green]")
+            applied_names.append(name)
+            logger.info("Applied migration: {}", name)
+        except Exception as e:
+            console.print(f"[red]FAILED: {e}[/red]")
+            logger.error("Migration {} failed: {}", name, e)
+            raise
+
+    return applied_names
+
+
+async def rollback_migrations(
+    migrations_dir: Path, *, steps: int = 1, dry_run: bool = False
+) -> list[str]:
+    """Roll back the most recent migrations.
+
+    Args:
+        migrations_dir: Path to the migrations directory.
+        steps: Number of migrations to roll back.
+        dry_run: If True, only report what would be rolled back.
+
+    Returns:
+        List of migration names that were rolled back (or would be).
+    """
+    from rich.console import Console
+
+    console = Console()
+    db = await _get_db()
+    collection = db[MIGRATIONS_COLLECTION]
+
+    # Get applied migrations in reverse chronological order
+    applied_docs = []
+    async for doc in collection.find().sort("applied_at", -1).limit(steps):
+        applied_docs.append(doc)
+
+    if not applied_docs:
+        return []
+
+    migration_files = {f.stem: f for f in _discover_migrations(migrations_dir)}
+    rolled_back: list[str] = []
+
+    for doc in applied_docs:
+        name = doc["name"]
+        if dry_run:
+            console.print(f"  [yellow]Would roll back:[/yellow] {name}")
+            rolled_back.append(name)
+            continue
+
+        filepath = migration_files.get(name)
+        if filepath is None:
+            console.print(f"  [red]Migration file not found:[/red] {name}")
+            continue
+
+        console.print(f"  [cyan]Rolling back:[/cyan] {name} ... ", end="")
+        module = _load_migration_module(filepath)
+
+        if not hasattr(module, "down"):
+            console.print("[red]SKIP (no down() function)[/red]")
+            continue
+
+        try:
+            await module.down(db)
+            await collection.delete_one({"name": name})
+            console.print("[green]OK[/green]")
+            rolled_back.append(name)
+            logger.info("Rolled back migration: {}", name)
+        except Exception as e:
+            console.print(f"[red]FAILED: {e}[/red]")
+            logger.error("Rollback of {} failed: {}", name, e)
+            raise
+
+    return rolled_back
+
+
+async def get_migration_status(migrations_dir: Path) -> list[dict[str, Any]]:
+    """Get the status of all migrations.
+
+    Returns:
+        List of dicts with 'name', 'applied', and optionally 'applied_at' keys.
+    """
+    db = await _get_db()
+    applied = await _get_applied_migrations(db)
+    migration_files = _discover_migrations(migrations_dir)
+
+    statuses: list[dict[str, Any]] = []
+    for filepath in migration_files:
+        name = filepath.stem
+        if name in applied:
+            statuses.append(
+                {
+                    "name": name,
+                    "applied": True,
+                    "applied_at": applied[name].get("applied_at"),
+                }
+            )
+        else:
+            statuses.append({"name": name, "applied": False, "applied_at": None})
+
+    return statuses


### PR DESCRIPTION
## Summary
- Add `vibetuner migrate` CLI commands: `create`, `up`, `down`, `status`
- Migration files with async `up(db)` / `down(db)` functions
- History tracked in `_migrations` MongoDB collection
- Dry-run mode for all operations

## Test plan
- [ ] Verify `vibetuner migrate create "add users index"` creates timestamped file
- [ ] Verify `vibetuner migrate up` applies pending migrations in order
- [ ] Verify `vibetuner migrate down --steps 2` rolls back correctly
- [ ] Verify `vibetuner migrate status` shows applied/pending table
- [ ] Verify dry-run mode shows what would happen without applying
- [ ] Verify error handling when migration fails mid-batch

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)