### PR TITLE
fix: remove `from __future__ import annotations` from CRUD factory

### DIFF
--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -1,7 +1,5 @@
 # ABOUTME: Generic CRUD route factory for Beanie Document and SQLModel classes.
 # ABOUTME: Generates list/create/read/update/delete routes with pagination, filtering, and sorting.
-from __future__ import annotations
-
 from collections.abc import Callable
 from enum import StrEnum
 from typing import Any


### PR DESCRIPTION
## Summary
- Remove `from __future__ import annotations` from `crud.py` which caused PEP 563 deferred evaluation
- This broke FastAPI's ability to resolve dynamic type annotations in generated route handlers (e.g. `data: schema` where `schema` is a closure variable, not a class name)
- All `X | Y` union syntax used in the file is natively supported in Python 3.10+, so the future import was unnecessary

Closes #1010

## Test plan
- [ ] Verify CRUD routes with `create_schema` parameter work (create + update endpoints accept request bodies)
- [ ] Verify CRUD routes without explicit schema (auto-generated schema) work
- [ ] Verify OpenAPI docs render correct request body schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)