### PR TITLE
fix: remove **kwargs from CRUD list route handler

### DIFF
--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -118,7 +118,6 @@ def _register_list_route(
         fields: str | None = Query(
             None, description="Comma-separated field names to include"
         ),
-        **kwargs,
     ):
         query = model.find()
         query = _apply_filters(query, request, filterable)


### PR DESCRIPTION
## Summary
- Remove `**kwargs` from the `list_items` route handler signature in `_register_list_route`
- FastAPI treats all unknown `**kwargs` as required query parameters, which breaks the list endpoint
- Filtering is already handled via `request.query_params` in `_apply_filters`, so `**kwargs` was unnecessary

Closes #1007

## Test plan
- [ ] Verify list endpoint returns paginated results without errors
- [ ] Verify filtering via query params still works (e.g. `?status=active`)
- [ ] Verify search via `?q=term` still works
- [ ] Verify OpenAPI docs show only the expected query parameters (offset, limit, sort, fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)