### PR TITLE
docs: document render_template path convention

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -176,10 +176,10 @@ For SQL databases, create tables with: `vibetuner db create-schema`
 
 ### Creating Templates
 
-Add templates in `templates/`:
+Add templates in `templates/frontend/`:
 
 ```html
-<!-- templates/blog/list.html.jinja -->
+<!-- templates/frontend/blog/list.html.jinja -->
 {% extends "base/skeleton.html.jinja" %}
 {% block content %}
     <div class="container mx-auto">
@@ -194,6 +194,27 @@ Add templates in `templates/`:
         </div>
     </div>
 {% endblock content %}
+```
+
+#### Template Path Convention
+
+The template search path already includes `templates/frontend/`, so when calling
+`render_template()` use paths **relative to that directory**:
+
+```python
+# Correct - path relative to templates/frontend/
+render_template("blog/list.html.jinja", request)
+render_template("admin/dashboard.html.jinja", request)
+
+# Wrong - "frontend/" prefix is redundant and causes TemplateNotFound
+render_template("frontend/blog/list.html.jinja", request)  # TemplateNotFound!
+```
+
+The same convention applies to `{% extends %}` and `{% include %}` inside templates:
+
+```html
+{% extends "base/skeleton.html.jinja" %}          {# correct #}
+{% extends "frontend/base/skeleton.html.jinja" %} {# wrong #}
 ```
 
 ### Built-in Template Filters

--- a/vibetuner-py/src/vibetuner/rendering.py
+++ b/vibetuner-py/src/vibetuner/rendering.py
@@ -363,6 +363,30 @@ def render_template(
     ctx: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> HTMLResponse:
+    """Render a Jinja2 template and return an HTMLResponse.
+
+    The template search path already includes the ``templates/frontend/``
+    directory, so template names should be **relative to that directory**.
+
+    Args:
+        template: Path to template file relative to ``templates/frontend/``.
+            Use ``"blog/list.html.jinja"``, **not** ``"frontend/blog/list.html.jinja"``.
+        request: FastAPI Request object.
+        ctx: Optional context dictionary merged into the template context.
+        **kwargs: Extra keyword arguments forwarded to ``TemplateResponse``.
+
+    Returns:
+        HTMLResponse with the rendered template.
+
+    Example::
+
+        # Correct - path is relative to templates/frontend/
+        render_template("blog/list.html.jinja", request)
+        render_template("admin/dashboard.html.jinja", request, {"stats": stats})
+
+        # Wrong - "frontend/" prefix is redundant and will cause a TemplateNotFound error
+        render_template("frontend/blog/list.html.jinja", request)  # TemplateNotFound!
+    """
     _ensure_custom_filters()
     ctx = ctx or {}
     language = getattr(request.state, "language", data_ctx.default_language)


### PR DESCRIPTION
## Summary
- Added docstring to `render_template()` explaining that template paths are relative to
  `templates/frontend/` (not the project root)
- Added "Template Path Convention" section to the development guide with correct/incorrect
  examples for both Python calls and Jinja `{% extends %}`/`{% include %}`

Closes #1008

## Test plan
- [ ] Verify docstring renders correctly in IDE tooltips
- [ ] Verify development guide section is clear and examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)