### PR TITLE
fix: add content block alias inside body block in skeleton template

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -31,6 +31,8 @@
             {% endif %}
         {% endblock header %}
         {% block body %}
+            {% block content %}
+            {% endblock content %}
         {% endblock body %}
         {% block footer %}
             {% if not SKIP_FOOTER %}


### PR DESCRIPTION
## Summary
- Adds `{% block content %}` as a nested alias inside `{% block body %}` in the skeleton template
- Users coming from Django/Flask/Laravel expect `content` — using the wrong name caused silent content drops
- Fully backward compatible: existing `{% block body %}` usage continues to work

## Test plan
- [ ] Verify `{% block body %}` still works in child templates
- [ ] Verify `{% block content %}` now works as expected in child templates
- [ ] Scaffold a test project and confirm pages render correctly

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)