### PR TITLE
fix: remove broken debug_claude link from debug nav

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
@@ -52,14 +52,6 @@
             </svg>
             Config
         </a>
-        <a href="{{ url_for('debug_claude') }}"
-           class="btn btn-outline btn-accent gap-2">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9">
-                </path>
-            </svg>
-            Claude Events
-        </a>
         <a href="{{ url_for('health_ping') }}"
            class="btn btn-outline btn-success gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- Removes the `url_for('debug_claude')` link from the debug navigation component
- This route never existed, causing a `NoMatchFound` crash on every debug page

## Test plan
- [ ] Visit any debug page (e.g., `/debug`) and confirm it loads without error
- [ ] Verify the debug nav renders all remaining links correctly

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)