### PR TITLE
feat: add template block introspection to debug panel

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/routes/debug.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/debug.py
@@ -86,6 +86,104 @@ def debug_version(request: Request):
     return render_template("debug/version.html.jinja", request)
 
 
+# Skeleton template block definitions for introspection
+_SKELETON_BLOCKS = [
+    {
+        "name": "title",
+        "location": "<head> > <title>",
+        "description": "Sets the page title shown in the browser tab.",
+        "example": '{% block title %}My Page{% endblock title %}',
+    },
+    {
+        "name": "head",
+        "location": "<head> (after default meta/CSS/JS)",
+        "description": "Inject additional meta tags, stylesheets, or inline styles.",
+        "example": (
+            "{% block head %}\n"
+            '    <link rel="stylesheet" href="/extra.css" />\n'
+            "{% endblock head %}"
+        ),
+    },
+    {
+        "name": "start_of_body",
+        "location": "<body> (first child)",
+        "description": "Content rendered before the header. Useful for banners or skip-nav links.",
+        "example": (
+            "{% block start_of_body %}\n"
+            '    <a href="#main" class="sr-only">Skip to content</a>\n'
+            "{% endblock start_of_body %}"
+        ),
+    },
+    {
+        "name": "header",
+        "location": "<body> (before main content)",
+        "description": (
+            "The page header. Includes the default header unless SKIP_HEADER is set. "
+            "Override to replace the entire header."
+        ),
+        "example": (
+            "{% block header %}\n"
+            "    <nav>Custom navigation</nav>\n"
+            "{% endblock header %}"
+        ),
+    },
+    {
+        "name": "body",
+        "location": "<body> (between header and footer)",
+        "description": "Primary content area. This is where your page content goes.",
+        "example": (
+            "{% block body %}\n"
+            "    <main>Hello, world!</main>\n"
+            "{% endblock body %}"
+        ),
+    },
+    {
+        "name": "content",
+        "location": "Inside {% block body %} (alias)",
+        "description": (
+            "Alias for the body block. Use either body or content — "
+            "content is the conventional name in Django/Flask/Laravel."
+        ),
+        "example": (
+            "{% block content %}\n"
+            "    <main>Hello, world!</main>\n"
+            "{% endblock content %}"
+        ),
+    },
+    {
+        "name": "footer",
+        "location": "<body> (after main content)",
+        "description": (
+            "The page footer. Includes the default footer unless SKIP_FOOTER is set. "
+            "Override to replace the entire footer."
+        ),
+        "example": (
+            "{% block footer %}\n"
+            "    <footer>Custom footer</footer>\n"
+            "{% endblock footer %}"
+        ),
+    },
+    {
+        "name": "end_of_body",
+        "location": "<body> (last child)",
+        "description": "Content rendered after the footer. Ideal for deferred scripts or modals.",
+        "example": (
+            "{% block end_of_body %}\n"
+            '    <script src="/app.js" defer></script>\n'
+            "{% endblock end_of_body %}"
+        ),
+    },
+]
+
+
+@router.get("/blocks", response_class=HTMLResponse)
+def debug_blocks(request: Request):
+    """Debug endpoint to list available skeleton template blocks."""
+    return render_template(
+        "debug/blocks.html.jinja", request, {"blocks": _SKELETON_BLOCKS}
+    )
+
+
 @router.get("/info", response_class=HTMLResponse)
 def debug_info(request: Request):
     cookies = dict(request.cookies)

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/blocks.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/blocks.html.jinja
@@ -1,0 +1,44 @@
+{% extends "base/skeleton.html.jinja" %}
+
+{% block title %}
+    Template Blocks - Debug
+{% endblock title %}
+{% block body %}
+    <div class="container mx-auto px-4 py-8 max-w-4xl">
+        <header class="mb-8">
+            <h1 class="text-4xl font-bold text-base-content mb-2">Template Blocks</h1>
+            <p class="text-base-content/70">
+                Available blocks in <code class="badge badge-ghost">base/skeleton.html.jinja</code>.
+                Override any block in your child templates.
+            </p>
+        </header>
+        <div class="space-y-4">
+            {% for block in blocks %}
+                <div class="card bg-base-100 shadow border border-base-200">
+                    <div class="card-body py-4">
+                        <div class="flex items-start justify-between gap-4">
+                            <div class="flex-1">
+                                <h2 class="font-mono text-lg font-bold text-primary">
+                                    {% block block_name scoped %}
+                                        {{ block.name }}
+                                    {% endblock block_name %}
+                                </h2>
+                                <p class="text-sm text-base-content/60 mb-1">{{ block.location }}</p>
+                                <p class="text-base-content/80">{{ block.description }}</p>
+                            </div>
+                        </div>
+                        <div class="mt-3">
+                            <div class="mockup-code text-sm">
+                                {% for line in block.example.split('\n') %}
+                                    <pre><code>{{ line }}</code></pre>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+        {% include "debug/components/debug_nav.html.jinja" %}
+
+    </div>
+{% endblock body %}

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
@@ -52,13 +52,13 @@
             </svg>
             Config
         </a>
-        <a href="{{ url_for('debug_claude') }}"
+        <a href="{{ url_for('debug_blocks') }}"
            class="btn btn-outline btn-accent gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z">
                 </path>
             </svg>
-            Claude Events
+            Template Blocks
         </a>
         <a href="{{ url_for('health_ping') }}"
            class="btn btn-outline btn-success gap-2">

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/index.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/index.html.jinja
@@ -77,6 +77,22 @@
                     </div>
                 </div>
             </div>
+            <!-- Template Blocks -->
+            <div class="card bg-base-100 shadow-xl border border-base-200 hover:shadow-2xl transition-shadow">
+                <div class="card-body">
+                    <h2 class="card-title text-accent flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z">
+                            </path>
+                        </svg>
+                        Template Blocks
+                    </h2>
+                    <p class="text-base-content/70 mb-4">Discover available skeleton template blocks for page customization</p>
+                    <div class="card-actions justify-end">
+                        <a href="{{ url_for('debug_blocks') }}" class="btn btn-accent btn-sm">View Blocks</a>
+                    </div>
+                </div>
+            </div>
             <!-- Runtime Configuration -->
             <div class="card bg-base-100 shadow-xl border border-base-200 hover:shadow-2xl transition-shadow">
                 <div class="card-body">


### PR DESCRIPTION
## Summary
- Adds a `/debug/blocks` page listing all available skeleton template blocks
- Each block shows its name, location in the HTML, description, and example usage
- Adds a "Template Blocks" card to the debug dashboard index
- Replaces the broken `debug_claude` nav link with a link to the new blocks page

## Test plan
- [ ] Visit `/debug/blocks` and confirm it shows all skeleton blocks
- [ ] Verify each block entry has name, location, description, and code example
- [ ] Check the debug dashboard shows the new "Template Blocks" card
- [ ] Confirm the debug nav links to the blocks page correctly

Closes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)