### PR TITLE
fix: wrap JS bundle script tag in overridable block

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -11,7 +11,9 @@
             {% endblock title %}
         </title>
         <link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
-        <script src="{{ url_for('js', path='bundle.js').path }}"></script>
+        {% block scripts %}
+            <script src="{{ url_for('js', path='bundle.js').path }}"></script>
+        {% endblock scripts %}
         {% if umami_website_id and not DEBUG %}
             <script defer src="/meta.js" data-website-id="{{ umami_website_id }}"></script>
         {% endif %}


### PR DESCRIPTION
## Summary
- Wraps the `<script src="bundle.js">` tag in `{% block scripts %}` in the skeleton template
- Projects without an npm package can now override this block to remove the 404-causing script tag
- Existing projects with a JS bundle are unaffected since the default block content is preserved

## Test plan
- [ ] Verify default behavior still includes the bundle.js script tag
- [ ] Verify a child template can override `{% block scripts %}{% endblock scripts %}` to remove it
- [ ] Scaffold a test project and confirm no regressions in page loading

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)