### PR TITLE
fix: normalize hyphens to underscores in project name for module imports

### DIFF
--- a/vibetuner-py/src/vibetuner/pyproject.py
+++ b/vibetuner-py/src/vibetuner/pyproject.py
@@ -28,8 +28,15 @@ def read_pyproject() -> dict:
 
 
 def get_project_name() -> str | None:
-    """Get project name from pyproject.toml."""
-    return read_pyproject().get("project", {}).get("name")
+    """Get project name from pyproject.toml, normalized for use as a Python module name.
+
+    Converts hyphens to underscores per PEP 503 / Python packaging convention
+    (e.g., ``my-cool-app`` -> ``my_cool_app``).
+    """
+    name = read_pyproject().get("project", {}).get("name")
+    if name is not None:
+        return name.replace("-", "_")
+    return None
 
 
 def get_project_version() -> str:


### PR DESCRIPTION
## Summary
- `get_project_name()` now converts hyphens to underscores when returning the project name
  from `pyproject.toml`, following standard Python packaging convention (PEP 503)
- Fixes `ImportError` when `pyproject.toml` contains `name = "my-cool-app"` — the loader
  tried to import `my-cool-app.tune` instead of `my_cool_app.tune`

Closes #1002

## Test plan
- [ ] Verify a project with `name = "my-cool-app"` in pyproject.toml loads correctly
- [ ] Verify projects without hyphens still work unchanged
- [ ] Verify `get_project_name()` returns `None` when no pyproject.toml exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)