### PR TITLE
fix: remove all from __future__ import annotations and ban via ruff

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/doctor.py
+++ b/vibetuner-py/src/vibetuner/cli/doctor.py
@@ -1,6 +1,5 @@
 # ABOUTME: Validates project setup: structure, env vars, service connectivity, models, templates.
 # ABOUTME: Provides `vibetuner doctor` CLI command for diagnosing project issues.
-from __future__ import annotations
 
 import importlib.metadata
 import socket

--- a/vibetuner-py/src/vibetuner/runtime_config.py
+++ b/vibetuner-py/src/vibetuner/runtime_config.py
@@ -1,8 +1,6 @@
 # ABOUTME: Layered runtime configuration system with MongoDB persistence.
 # ABOUTME: Provides get/set config with priority: runtime overrides > MongoDB > registered defaults.
 
-from __future__ import annotations
-
 import json
 from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta

--- a/vibetuner-py/src/vibetuner/services/errors.py
+++ b/vibetuner-py/src/vibetuner/services/errors.py
@@ -1,8 +1,6 @@
 # ABOUTME: Centralized, actionable error messages for unconfigured services.
 # ABOUTME: Provides rich console output with example values, setup commands, and doc links.
 
-from __future__ import annotations
-
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text

--- a/vibetuner-py/src/vibetuner/tasks/robust.py
+++ b/vibetuner-py/src/vibetuner/tasks/robust.py
@@ -1,6 +1,5 @@
 # ABOUTME: Robust task decorator with retries, dead letters, and failure notifications.
 # ABOUTME: Wraps Streaq tasks with exponential backoff and MongoDB dead letter collection.
-from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass

--- a/vibetuner-template/.ruff.toml
+++ b/vibetuner-template/.ruff.toml
@@ -10,6 +10,7 @@ extend-select = [
   'RUF100', # ruff (unused noqa)
   'S',      # flake8-bandit
   'W',      # pycodestyle
+  'FA100',  # ban `from __future__ import annotations` (breaks FastAPI/Pydantic)
 ]
 
 [lint.isort]


### PR DESCRIPTION
## Summary
- Removed `from __future__ import annotations` from 6 files (`crud.py`, `errors.py`, `doctor.py`, `sse.py`, `robust.py`, `runtime_config.py`)
- Added `FA100` lint rule to `.ruff.toml` to prevent future usage

## Why
PEP 563 deferred evaluation converts all annotations to strings at runtime, which breaks:
- FastAPI dynamic route parameter detection (body params become query params)
- Pydantic model validation for dynamically constructed models
- Beanie document registration with generic types

Python 3.10+ natively supports `X | Y` union syntax, so the import was unnecessary.

Closes #1011

## Test plan
- [ ] Verify no remaining `from __future__ import annotations` in codebase
- [ ] Verify `ruff check` catches any new additions (FA100 rule)
- [ ] Verify CRUD factory endpoints accept body params correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)