### PR TITLE
feat: enable OpenAPI docs (/docs, /redoc) in DEBUG mode

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/__init__.py
+++ b/vibetuner-py/src/vibetuner/frontend/__init__.py
@@ -35,9 +35,9 @@ dependencies: list[Any] = [
 app = FastAPI(
     debug=ctx.DEBUG,
     lifespan=lifespan_module.lifespan,
-    docs_url=None,
-    redoc_url=None,
-    openapi_url=None,
+    docs_url="/docs" if ctx.DEBUG else None,
+    redoc_url="/redoc" if ctx.DEBUG else None,
+    openapi_url="/openapi.json" if ctx.DEBUG else None,
     middleware=middlewares,
     dependencies=dependencies,
 )


### PR DESCRIPTION
## Summary
- Enable Swagger UI (`/docs`), ReDoc (`/redoc`), and OpenAPI schema (`/openapi.json`) when `DEBUG=true`
- These remain disabled in production (no behavior change for non-debug deployments)
- Especially useful when using the CRUD factory, as auto-generated endpoints are fully documented

Closes #1027

## Test plan
- [ ] Start dev server with `DEBUG=true`, verify `/docs` returns Swagger UI
- [ ] Start dev server with `DEBUG=true`, verify `/redoc` returns ReDoc
- [ ] Start with `DEBUG=false`, verify `/docs` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)