### PR TITLE
fix: use colon notation for streaq worker import path

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -49,7 +49,7 @@ def _run_worker(mode: Literal["dev", "prod"], port: int, workers: int) -> None:
     else:
         console.print(f"[dim]Workers: {workers}[/dim]")
 
-    worker_path = "vibetuner.tasks.worker.worker"
+    worker_path = "vibetuner.tasks.worker:worker"
     verbose = True if is_dev else settings.debug
 
     # Start monitoring web UI and additional workers as background processes


### PR DESCRIPTION
## Summary
- Fix worker crash on startup: `vibetuner.tasks.worker.worker` → `vibetuner.tasks.worker:worker`
- Streaq's `import_string()` expects `module:attribute` format (colon-separated), not dot notation
- **The worker was completely broken** — no scaffolded project could run background tasks

Closes #1029

## Test plan
- [ ] Run `uv run vibetuner run dev worker` — should start without ImportError
- [ ] Verify the worker monitoring UI starts on port 11111

🤖 Generated with [Claude Code](https://claude.com/claude-code)