### PR TITLE
fix: use colon notation for worker path in streaq import_string

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -49,7 +49,7 @@ def _run_worker(mode: Literal["dev", "prod"], port: int, workers: int) -> None:
     else:
         console.print(f"[dim]Workers: {workers}[/dim]")
 
-    worker_path = "vibetuner.tasks.worker.worker"
+    worker_path = "vibetuner.tasks.worker:worker"
     verbose = True if is_dev else settings.debug
 
     # Start monitoring web UI and additional workers as background processes


### PR DESCRIPTION
## Summary
- Worker CLI crashed because the worker path used dot notation (`vibetuner.tasks.worker.worker`) instead of the colon notation (`vibetuner.tasks.worker:worker`) expected by streaq's `import_string()`
- Changed the separator between module and attribute from `.` to `:`

Closes #1029

## Test plan
- [ ] Run `vibetuner run dev worker` and verify the worker starts without an import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)