### PR TITLE
fix: enable OpenAPI docs in DEBUG mode

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/__init__.py
+++ b/vibetuner-py/src/vibetuner/frontend/__init__.py
@@ -35,9 +35,9 @@ dependencies: list[Any] = [
 app = FastAPI(
     debug=ctx.DEBUG,
     lifespan=lifespan_module.lifespan,
-    docs_url=None,
-    redoc_url=None,
-    openapi_url=None,
+    docs_url="/docs" if ctx.DEBUG else None,
+    redoc_url="/redoc" if ctx.DEBUG else None,
+    openapi_url="/openapi.json" if ctx.DEBUG else None,
     middleware=middlewares,
     dependencies=dependencies,
 )


### PR DESCRIPTION
## Summary
- FastAPI app was created with `docs_url=None`, `redoc_url=None`, `openapi_url=None`, disabling OpenAPI docs entirely
- Now conditionally enables `/docs`, `/redoc`, and `/openapi.json` when `ctx.DEBUG` is true

Closes #1027

## Test plan
- [ ] Set `DEBUG=true` and verify `/docs`, `/redoc`, `/openapi.json` are accessible
- [ ] With `DEBUG=false` (default), verify these endpoints return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)