### PR TITLE
fix: convert ObjectId to string in field selection responses

### DIFF
--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -403,6 +403,8 @@ def _select_fields(
     """Return only the selected fields from a document."""
     data = doc.model_dump()
     filtered = {k: v for k, v in data.items() if k in selected or k == "id"}
+    if "id" in filtered:
+        filtered["id"] = str(doc.id)
     if response_schema:
         return response_schema.model_validate(filtered).model_dump(
             include=selected | {"id"}


### PR DESCRIPTION
## Summary
- Field selection (`?fields=title`) serialized `id` as `{}` instead of string
- `PydanticObjectId` doesn't serialize properly when placed in a plain dict
- Convert `doc.id` to `str(doc.id)` in `_select_fields` response builder

Closes #1026

## Test plan
- [ ] GET a document with `?fields=title` — `id` should be a string, not `{}`
- [ ] GET list with `?fields=title` — all `id` values should be strings
- [ ] GET without `?fields=` — response should be unchanged (uses normal serialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)