### PR TITLE
feat: add --auto-port support for worker monitoring UI

### DIFF
--- a/vibetuner-py/src/vibetuner/utils.py
+++ b/vibetuner-py/src/vibetuner/utils.py
@@ -4,16 +4,21 @@ import hashlib
 import os
 
 
-def compute_auto_port(path: str | None = None) -> int:
+def compute_auto_port(
+    path: str | None = None, port_min: int = 8001, port_max: int = 8999
+) -> int:
     """Compute deterministic port from directory path.
 
     Args:
         path: Directory path to compute port for. Defaults to current directory.
+        port_min: Minimum port number (inclusive).
+        port_max: Maximum port number (inclusive).
 
     Returns:
-        Port number in the range 8001-8999.
+        Port number in the range port_min to port_max.
     """
     target_path = path or os.getcwd()
     hash_bytes = hashlib.sha256(target_path.encode()).digest()
     hash_int = int.from_bytes(hash_bytes[:4], "big")
-    return 8001 + (hash_int % 999)
+    port_range = port_max - port_min + 1
+    return port_min + (hash_int % port_range)


### PR DESCRIPTION
## Summary
- Worker monitoring UI (`run_web`) always started on fixed port 11111, causing conflicts when
  multiple workers run on the same host
- Extended `compute_auto_port()` with `port_min`/`port_max` parameters for configurable port ranges
- Worker `--auto-port` uses range 11112-11999 (separate from frontend's 8001-8999) to avoid collisions
- Added `--auto-port` flag to `prod` command for consistency with `dev`

## Test plan
- [ ] Run `vibetuner run dev worker --auto-port` and verify port is in 11112-11999 range
- [ ] Run `vibetuner run dev frontend --auto-port` and verify port is still in 8001-8999 range
- [ ] Run `vibetuner run prod worker --auto-port` and verify port is in 11112-11999 range
- [ ] Verify `--port` and `--auto-port` are mutually exclusive for both dev and prod
- [ ] Verify same project path produces same deterministic port across runs

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)