### PR TITLE
feat: add template blocks reference page to debug panel

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/routes/debug.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/debug.py
@@ -92,6 +92,123 @@ def debug_info(request: Request):
     return render_template("debug/info.html.jinja", request, {"cookies": cookies})
 
 
+# Skeleton template block definitions for developer reference.
+# Each entry documents a block from base/skeleton.html.jinja.
+SKELETON_BLOCKS = [
+    {
+        "name": "title",
+        "description": "Sets the page <title> tag content.",
+        "example": "{% block title %}My Page{% endblock title %}",
+        "location": "<head><title>",
+    },
+    {
+        "name": "scripts",
+        "description": (
+            "Loads JavaScript bundles. Override to add or replace "
+            "the default bundle.js script tag."
+        ),
+        "example": (
+            "{% block scripts %}\n"
+            "    <script src=\"{{ url_for('js', path='bundle.js').path }}\"></script>\n"
+            "    <script src=\"{{ url_for('js', path='extra.js').path }}\"></script>\n"
+            "{% endblock scripts %}"
+        ),
+        "location": "<head>",
+    },
+    {
+        "name": "head",
+        "description": (
+            "Injects extra content at the end of <head>. "
+            "Use for additional stylesheets, meta tags, or inline styles."
+        ),
+        "example": (
+            "{% block head %}\n"
+            '    <link rel="stylesheet" href="/static/custom.css" />\n'
+            "{% endblock head %}"
+        ),
+        "location": "<head> (after scripts & favicons)",
+    },
+    {
+        "name": "start_of_body",
+        "description": "Injects content immediately after the opening <body> tag, before the header.",
+        "example": (
+            "{% block start_of_body %}\n"
+            '    <div id="announcement-banner">...</div>\n'
+            "{% endblock start_of_body %}"
+        ),
+        "location": "<body> (first child)",
+    },
+    {
+        "name": "header",
+        "description": (
+            "Renders the page header. By default includes base/header.html.jinja "
+            "unless SKIP_HEADER is set."
+        ),
+        "example": (
+            "{% block header %}\n"
+            "    <header>Custom header</header>\n"
+            "{% endblock header %}"
+        ),
+        "location": "<body>",
+    },
+    {
+        "name": "body",
+        "description": (
+            "Wraps the main page body between header and footer. "
+            "Contains the 'content' block by default."
+        ),
+        "example": (
+            "{% block body %}\n"
+            '    <main class="container">{{ super() }}</main>\n'
+            "{% endblock body %}"
+        ),
+        "location": "<body> (between header and footer)",
+    },
+    {
+        "name": "content",
+        "description": (
+            "The primary content area inside the body block. "
+            "This is the most commonly overridden block for page content."
+        ),
+        "example": (
+            "{% block content %}\n    <h1>Hello World</h1>\n{% endblock content %}"
+        ),
+        "location": "inside {% block body %}",
+    },
+    {
+        "name": "footer",
+        "description": (
+            "Renders the page footer. By default includes base/footer.html.jinja "
+            "unless SKIP_FOOTER is set."
+        ),
+        "example": (
+            "{% block footer %}\n"
+            "    <footer>Custom footer</footer>\n"
+            "{% endblock footer %}"
+        ),
+        "location": "<body> (after body block)",
+    },
+    {
+        "name": "end_of_body",
+        "description": "Injects content just before the closing </body> tag. Use for deferred scripts.",
+        "example": (
+            "{% block end_of_body %}\n"
+            '    <script src="/static/deferred.js" defer></script>\n'
+            "{% endblock end_of_body %}"
+        ),
+        "location": "<body> (last child)",
+    },
+]
+
+
+@router.get("/blocks", response_class=HTMLResponse)
+def debug_blocks(request: Request):
+    """Debug endpoint listing available skeleton template blocks."""
+    return render_template(
+        "debug/blocks.html.jinja", request, {"blocks": SKELETON_BLOCKS}
+    )
+
+
 def _extract_ref_name(ref: str) -> str:
     """Extract type name from JSON schema $ref."""
     return ref.split("/")[-1]

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/blocks.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/blocks.html.jinja
@@ -1,0 +1,59 @@
+{% extends "base/skeleton.html.jinja" %}
+
+{% block title %}
+    Template Blocks - Debug
+{% endblock title %}
+{% block body %}
+    <div class="container mx-auto px-4 py-8 max-w-4xl">
+        <!-- Header -->
+        <header class="mb-8">
+            <h1 class="text-4xl font-bold text-base-content mb-2">Template Blocks</h1>
+            <p class="text-base-content/70">
+                Available blocks in <code class="text-sm bg-base-200 px-1.5 py-0.5 rounded">base/skeleton.html.jinja</code> for template inheritance
+            </p>
+        </header>
+        <!-- Usage Hint -->
+        <div class="alert alert-info mb-8">
+            <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z">
+                </path>
+            </svg>
+            <div>
+                <p class="font-semibold">How to use</p>
+                <p>
+                    Extend the skeleton template and override any block below.
+                    Using a wrong block name causes a silent blank page.
+                </p>
+                <pre class="mt-2 text-xs"><code>{% raw %}{%- extends "base/skeleton.html.jinja" -%}
+{% block content %}
+    &lt;h1&gt;My Page&lt;/h1&gt;
+{% endblock content %}{% endraw %}</code></pre>
+            </div>
+        </div>
+        <!-- Blocks List -->
+        <div class="space-y-4">
+            {% for block in blocks %}
+                <div class="card bg-base-100 shadow border border-base-200">
+                    <div class="card-body p-5">
+                        <div class="flex items-start justify-between gap-4">
+                            <div class="flex-1">
+                                <h2 class="font-mono text-lg font-bold text-primary">{{ block.name }}</h2>
+                                <p class="text-base-content/70 text-sm mt-1">{{ block.description }}</p>
+                                <p class="text-xs text-base-content/50 mt-1">
+                                    Location: <code class="bg-base-200 px-1 py-0.5 rounded">{{ block.location }}</code>
+                                </p>
+                            </div>
+                            <span class="badge badge-outline badge-sm shrink-0">block</span>
+                        </div>
+                        <div class="mt-3">
+                            <pre class="bg-base-200 rounded-lg p-3 text-xs overflow-x-auto"><code>{{ block.example }}</code></pre>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+        <!-- Debug Navigation Footer -->
+        {% include "debug/components/debug_nav.html.jinja" %}
+
+    </div>
+{% endblock body %}

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
@@ -35,6 +35,14 @@
             </svg>
             User Impersonation
         </a>
+        <a href="{{ url_for('debug_blocks') }}"
+           class="btn btn-outline btn-accent gap-2">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z">
+                </path>
+            </svg>
+            Template Blocks
+        </a>
         <a href="{{ url_for('debug_version') }}"
            class="btn btn-outline btn-primary gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/index.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/index.html.jinja
@@ -94,6 +94,22 @@
                     </div>
                 </div>
             </div>
+            <!-- Template Blocks -->
+            <div class="card bg-base-100 shadow-xl border border-base-200 hover:shadow-2xl transition-shadow">
+                <div class="card-body">
+                    <h2 class="card-title text-accent flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z">
+                            </path>
+                        </svg>
+                        Template Blocks
+                    </h2>
+                    <p class="text-base-content/70 mb-4">Discover available skeleton blocks for template inheritance</p>
+                    <div class="card-actions justify-end">
+                        <a href="{{ url_for('debug_blocks') }}" class="btn btn-accent btn-sm">View Blocks</a>
+                    </div>
+                </div>
+            </div>
         </div>
         <!-- Debug Navigation Footer -->
         {% include "debug/components/debug_nav.html.jinja" %}


### PR DESCRIPTION
## Summary

- Add `/debug/blocks` route that lists all available blocks in `base/skeleton.html.jinja`
  with names, descriptions, locations, and copy-paste usage examples
- Add "Template Blocks" card to the debug dashboard grid
- Add "Template Blocks" link to the debug navigation component

Closes #1004

## Test plan

- [ ] Navigate to `/debug/blocks` and verify all 9 skeleton blocks are listed
- [ ] Verify each block shows name, description, location, and code example
- [ ] Check the debug dashboard (`/debug`) shows the new "Template Blocks" card
- [ ] Check the debug nav bar on any debug page includes the "Template Blocks" link
- [ ] Verify the page renders correctly by extending `base/skeleton.html.jinja`

🤖 Generated with [Claude Code](https://claude.com/claude-code)