### PR TITLE
fix: use default import for htmx to expose window.htmx

### DIFF
--- a/vibetuner-template/config.js
+++ b/vibetuner-template/config.js
@@ -1,6 +1,7 @@
 // Start of File: do not remove this comment (do not add anything before)
 // Do not change anything between this comment and the next comment
-import "htmx.org";
+import htmx from "htmx.org";
+window.htmx = htmx;
 import "htmx-ext-preload";
 import "htmx-ext-sse";
 // Do not change anything between this comment and the previous one


### PR DESCRIPTION
## Summary
- Changed `import "htmx.org"` (side-effect import) to `import htmx from "htmx.org"; window.htmx = htmx;` in the scaffolded `config.js`
- The ESM module exports htmx as a default export but the side-effect import doesn't set `window.htmx`, which breaks htmx functionality when bundled by bun

Closes #1036

## Test plan
- [ ] Scaffold a new project and verify `window.htmx` is defined after bundle loads
- [ ] Verify htmx attributes (hx-get, hx-post, etc.) work correctly in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)