### PR TITLE
feat!: upgrade htmx from v2.0.8 to v4.0 (alpha)

### DIFF
--- a/vibetuner-js/bun.lock
+++ b/vibetuner-js/bun.lock
@@ -8,9 +8,7 @@
         "@tailwindcss/cli": "^4.1.18",
         "@tailwindcss/typography": "^0.5.19",
         "daisyui": "^5.5.18",
-        "htmx-ext-preload": "^2.1.2",
-        "htmx-ext-sse": "^2.2.4",
-        "htmx.org": "2.0.8",
+        "htmx.org": "4.0.0-alpha6",
         "tailwindcss": "^4.1.18",
       },
     },
@@ -100,11 +98,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "htmx-ext-preload": ["htmx-ext-preload@2.1.2", "", { "dependencies": { "htmx.org": "^2.0.3" } }, "sha512-foD06XAITUUQApCUQnPexyJ6B7+4vFGMQ+t42unTVTGRu/CYHdAAt6oHg7eekPHT7NRnbM5hjnGVKtClryPabg=="],
-
-    "htmx-ext-sse": ["htmx-ext-sse@2.2.4", "", { "dependencies": { "htmx.org": "^2.0.2" } }, "sha512-LJmxVhykyflBWgh5PvbRidcyuqMHlgfajmmzumvKctv9puvsufeH6OaejSMZTNTnEI8O2wXXn4ZZtBdpEMqmEQ=="],
-
-    "htmx.org": ["htmx.org@2.0.8", "", {}, "sha512-fm297iru0iWsNJlBrjvtN7V9zjaxd+69Oqjh4F/Vq9Wwi2kFisLcrLCiv5oBX0KLfOX/zG8AUo9ROMU5XUB44Q=="],
+    "htmx.org": ["htmx.org@4.0.0-alpha6", "", {}, "sha512-EEJkuX+divCVx4VfXTspB9dNs3EfXeHXbZNW9Y4kjjubzTqKAivoVQAE9LcQihCkrMD6ZSJU8BNdEbg5oHZOWA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -173,10 +167,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "htmx-ext-preload/htmx.org": ["htmx.org@2.0.7", "", {}, "sha512-YiJqF3U5KyO28VC5mPfehKJPF+n1Gni+cupK+D69TF0nm7wY6AXn3a4mPWIikfAXtl1u1F1+ZhSCS7KT8pVmqA=="],
-
-    "htmx-ext-sse/htmx.org": ["htmx.org@2.0.7", "", {}, "sha512-YiJqF3U5KyO28VC5mPfehKJPF+n1Gni+cupK+D69TF0nm7wY6AXn3a4mPWIikfAXtl1u1F1+ZhSCS7KT8pVmqA=="],
 
     "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
   }

--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -27,9 +27,7 @@
     "@tailwindcss/cli": "^4.1.18",
     "@tailwindcss/typography": "^0.5.19",
     "daisyui": "^5.5.18",
-    "htmx.org": "2.0.8",
-    "htmx-ext-preload": "^2.1.2",
-    "htmx-ext-sse": "^2.2.4"
+    "htmx.org": "4.0.0-alpha6"
   },
   "publishConfig": {
     "access": "public"

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -23,7 +23,7 @@
         {% block head %}
         {% endblock head %}
     </head>
-    <body hx-ext="preload" preload="mousedown" class="{{ BODY_CLASS }}">
+    <body preload="mousedown" class="{{ BODY_CLASS }}">
         {% block start_of_body %}
         {% endblock start_of_body %}
         {% block header %}

--- a/vibetuner-template/config.js
+++ b/vibetuner-template/config.js
@@ -2,7 +2,6 @@
 // Do not change anything between this comment and the next comment
 import htmx from "htmx.org";
 window.htmx = htmx;
-import "htmx-ext-preload";
-import "htmx-ext-sse";
+import "htmx.org/dist/ext/hx-preload.js";
 // Do not change anything between this comment and the previous one
 // End of File: do not remove this comment (do not add anything after)


### PR DESCRIPTION
## Summary
- Upgrade `htmx.org` from `2.0.8` to `4.0.0-alpha6`
- Remove `htmx-ext-sse` dependency — SSE is now built into htmx 4 core
- Remove `htmx-ext-preload` dependency — now bundled in `htmx.org` package at `dist/ext/hx-preload.js`
- Use default import (`import htmx from "htmx.org"; window.htmx = htmx;`) to properly expose `window.htmx`
- Remove `hx-ext="preload"` from skeleton template — `hx-ext` attribute is removed in htmx 4; extensions auto-register when imported via JS

### Breaking changes for downstream projects
- `hx-ext` attribute is removed — extensions auto-register when imported
- `hx-vars` is removed — use `hx-vals` with `js:` prefix instead
- SSE: `hx-ext="sse" sse-connect sse-swap` pattern replaced by native streaming (server responds with `Content-Type: text/event-stream`)
- `hx-disable` → `hx-ignore`
- Attribute inheritance is now explicit (use `:inherited` modifier)

Closes #1038

## Test plan
- [ ] Scaffold a new project and verify `window.htmx` is defined
- [ ] Verify preload extension works (mousedown preloading on links)
- [ ] Verify htmx attributes (hx-get, hx-post, etc.) work correctly
- [ ] Test SSE streaming if applicable
- [ ] Check browser console for htmx errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)