### PR TITLE
fix(crud): escape user input in MongoDB regex search query

### DIFF
--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -1,5 +1,6 @@
 # ABOUTME: Generic CRUD route factory for Beanie Document and SQLModel classes.
 # ABOUTME: Generates list/create/read/update/delete routes with pagination, filtering, and sorting.
+import re
 from collections.abc import Callable
 from enum import StrEnum
 from typing import Any
@@ -45,8 +46,9 @@ def _apply_search(query, request: Request, searchable: list[str]):
     """Apply text search across searchable fields."""
     q = request.query_params.get("q")
     if q and searchable:
+        escaped_q = re.escape(q)
         search_filter = {
-            "$or": [{f: {"$regex": q, "$options": "i"}} for f in searchable]
+            "$or": [{f: {"$regex": escaped_q, "$options": "i"}} for f in searchable]
         }
         query = query.find(search_filter)
     return query


### PR DESCRIPTION
## Summary
- Apply `re.escape()` to user-provided search query parameter before constructing MongoDB `$regex` filter in `_apply_search()`
- Prevents regex injection attacks where malicious patterns could cause ReDoS or unintended query behavior

Closes #1061

## Test plan
- [ ] Verify search still works with normal alphanumeric queries
- [ ] Verify special regex characters (e.g., `.*+?^${}()|[]\\`) in search input are treated as literals
- [ ] Verify no regression in CRUD list endpoint filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)