### PR TITLE
debug: extract skeleton blocks from template at runtime

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/routes/debug.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/debug.py
@@ -207,7 +207,11 @@ def _get_skeleton_blocks() -> list[dict]:
     are added without updating ``_BLOCK_METADATA``.
     """
     skeleton_path = package_templates / "frontend" / "base" / "skeleton.html.jinja"
-    source = skeleton_path.read_text()
+    try:
+        source = skeleton_path.read_text()
+    except (FileNotFoundError, OSError) as exc:
+        logger.warning(f"Could not read skeleton template: {exc}")
+        return []
 
     # Preserve declaration order, deduplicate (endblock repeats the name)
     block_names = list(dict.fromkeys(_BLOCK_RE.findall(source)))


### PR DESCRIPTION
## Summary
- Replace hardcoded `SKELETON_BLOCKS` list with runtime introspection that parses block names directly from `base/skeleton.html.jinja`
- Rich metadata (descriptions, examples, locations) is still maintained in `_BLOCK_METADATA` dict, but the source of truth for which blocks exist is the template itself
- Warns about stale metadata entries that no longer match the template

Closes #1068

## Test plan
- [ ] Verify `/debug/blocks` page renders correctly with all skeleton blocks
- [ ] Add a new block to skeleton template and confirm it appears on the debug page without code changes
- [ ] Remove a block from `_BLOCK_METADATA` and verify it still shows (with empty metadata)
- [ ] Add a stale entry to `_BLOCK_METADATA` and verify warning is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)