### PR TITLE
lint: remove from __future__ import annotations

### DIFF
--- a/vibetuner-py/src/vibetuner/sse.py
+++ b/vibetuner-py/src/vibetuner/sse.py
@@ -1,7 +1,5 @@
 # ABOUTME: Server-Sent Events helpers for real-time streaming with HTMX.
 # ABOUTME: Provides decorator for SSE endpoints, broadcast function, and Redis pub/sub backend.
-from __future__ import annotations
-
 import asyncio
 import json
 from collections.abc import AsyncGenerator, Callable

--- a/vibetuner-py/src/vibetuner/testing.py
+++ b/vibetuner-py/src/vibetuner/testing.py
@@ -1,7 +1,5 @@
 # ABOUTME: Pytest fixtures and testing utilities for vibetuner applications.
 # ABOUTME: Provides test client, mock auth, mock DB, mock tasks, and config overrides.
-from __future__ import annotations
-
 import uuid
 from typing import Any, AsyncGenerator
 from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
## Summary
- Remove `from __future__ import annotations` from `vibetuner/testing.py` and `vibetuner/sse.py`
- These were the last two files using the deprecated import
- The codebase targets Python 3.10+ where PEP 604 union syntax and generic builtins are natively supported

Closes #1078

## Test plan
- [ ] Verify `grep -r "from __future__ import annotations" vibetuner-py/src/` returns no results
- [ ] Verify `ruff check` passes with FA100 rule enabled
- [ ] Confirm no runtime errors from type annotations in `testing.py` and `sse.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)