### PR TITLE
fix(runtime_config): validate config_value decorated functions take no parameters

### DIFF
--- a/vibetuner-py/src/vibetuner/runtime_config.py
+++ b/vibetuner-py/src/vibetuner/runtime_config.py
@@ -322,6 +322,11 @@ def config_value(
     """
 
     def decorator(func: Callable[[], Any]) -> Callable[[], Coroutine[Any, Any, Any]]:
+        if func.__code__.co_argcount > 0:
+            raise ValueError(
+                f"@config_value() decorated function '{func.__name__}' must take no parameters, "
+                f"but it has {func.__code__.co_argcount}"
+            )
         default = func()
         register_config_value(
             key=key,


### PR DESCRIPTION
## Summary
- Adds a validation check in the `@config_value()` decorator to ensure the decorated function takes no parameters
- Raises `ValueError` with a clear message if the function has `__code__.co_argcount > 0`
- Prevents misuse where users accidentally pass arguments to config value providers

Closes #1049

## Test plan
- [ ] Verify zero-argument config functions still work correctly
- [ ] Confirm functions with parameters raise ValueError at decoration time
- [ ] Verify error message is clear about the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)