### PR TITLE
fix(rendering): improve type safety for context providers

### DIFF
--- a/vibetuner-py/src/vibetuner/rendering.py
+++ b/vibetuner-py/src/vibetuner/rendering.py
@@ -1,5 +1,6 @@
 # ABOUTME: Jinja2 template rendering for HTML responses.
 # ABOUTME: Lives outside vibetuner.frontend to avoid circular imports with tune.py.
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 
@@ -31,7 +32,7 @@ __all__ = [
 
 # App-level template context: static globals and dynamic providers
 _template_globals: dict[str, Any] = {}
-_context_providers: list[Any] = []
+_context_providers: list[Callable[[], dict[str, Any]]] = []
 
 
 def register_globals(globals_dict: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- Change `_context_providers` type annotation from `list[Any]` to `list[Callable[[], dict[str, Any]]]`
- Add `from collections.abc import Callable` import
- Enables type checkers to verify context provider signatures at registration time

Closes #1062

## Test plan
- [ ] Verify `register_context_provider` still works as bare decorator and decorator factory
- [ ] Verify context providers are called correctly during template rendering
- [ ] Verify type checkers accept valid context provider functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)