### PR TITLE
fix(health): reuse existing Redis connections instead of creating new ones per check

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/routes/health.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/health.py
@@ -121,22 +121,26 @@ async def _check_mongodb() -> dict[str, Any]:
 
 
 _redis_client = None
+_redis_lock = asyncio.Lock()
 
 
-def _get_redis_client():
+async def _get_redis_client():
     """Get or create a reusable Redis client for health checks."""
     global _redis_client
     if _redis_client is None:
-        import redis.asyncio as aioredis
+        async with _redis_lock:
+            # Double-check after acquiring the lock
+            if _redis_client is None:
+                import redis.asyncio as aioredis
 
-        _redis_client = aioredis.from_url(str(settings.redis_url))
+                _redis_client = aioredis.from_url(str(settings.redis_url))
     return _redis_client
 
 
 async def _check_redis() -> dict[str, Any]:
     """Ping Redis and measure latency."""
     try:
-        r = _get_redis_client()
+        r = await _get_redis_client()
         start = time.monotonic()
         async with asyncio.timeout(HEALTH_CHECK_TIMEOUT_SECONDS):
             await r.ping()
@@ -147,9 +151,10 @@ async def _check_redis() -> dict[str, Any]:
         return {"status": "error", "error": "Health check timed out"}
     except Exception as e:
         logger.warning("Redis health check failed: {}", e)
-        # Reset the client so it's recreated on next check
+        # Reset only the specific failed client instance
         global _redis_client
-        _redis_client = None
+        if _redis_client is r:
+            _redis_client = None
         return {"status": "error", "error": str(e)}
 
 


### PR DESCRIPTION
## Summary
- Replaces per-check Redis client creation/teardown with a lazily-initialized module-level client
- The client is reused across health checks, avoiding connection overhead on every probe
- Client is reset on connection errors to allow automatic recovery

Closes #1050

## Test plan
- [ ] Verify Redis health check still reports correct status and latency
- [ ] Confirm the client is reused across multiple health check calls
- [ ] Verify error recovery resets the client for the next attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)