### PR TITLE
fix(tasks): add missing exports to tasks/__init__.py

### DIFF
--- a/vibetuner-py/src/vibetuner/tasks/__init__.py
+++ b/vibetuner-py/src/vibetuner/tasks/__init__.py
@@ -1,2 +1,6 @@
 # ABOUTME: Background task infrastructure exports.
 # ABOUTME: Re-exports robust_task decorator and DeadLetterModel for convenience.
+
+from .robust import DeadLetterModel, robust_task
+
+__all__ = ["DeadLetterModel", "robust_task"]


### PR DESCRIPTION
## Summary
- Add re-exports for `robust_task` and `DeadLetterModel` from `vibetuner.tasks`
- Define `__all__` for explicit public API surface

Closes #1063

## Test plan
- [ ] Verify `from vibetuner.tasks import robust_task, DeadLetterModel` works
- [ ] Verify `from vibetuner.tasks import *` only exports the declared names

🤖 Generated with [Claude Code](https://claude.com/claude-code)