### PR TITLE
fix(oauth): add runtime validation for custom OAuth providers

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -135,6 +135,17 @@ def auto_register_providers(
 
     # Register custom providers (fully configured by the user)
     for name, provider in (custom_providers or {}).items():
+        if not isinstance(name, str):
+            logger.warning(
+                f"Skipping custom OAuth provider with non-string key: {name!r}"
+            )
+            continue
+        if not isinstance(provider, OauthProviderModel):
+            logger.warning(
+                f"Skipping custom OAuth provider '{name}': expected OauthProviderModel, "
+                f"got {type(provider).__name__}"
+            )
+            continue
         if name in _PROVIDERS:
             logger.warning(
                 f"Custom OAuth provider '{name}' conflicts with already-registered provider, skipping"


### PR DESCRIPTION
## Summary
- Adds `isinstance()` checks for custom OAuth provider keys (must be `str`) and values (must be `OauthProviderModel`)
- Invalid provider entries are logged with warnings and skipped gracefully
- Prevents cryptic runtime errors when users provide incorrectly typed provider configurations

Closes #1051

## Test plan
- [ ] Verify valid custom OAuth providers still register correctly
- [ ] Confirm invalid provider objects are skipped with a warning log
- [ ] Verify non-string keys are skipped with a warning log

🤖 Generated with [Claude Code](https://claude.com/claude-code)