### PR TITLE
fix(services): move cache refresh lock into RuntimeConfig class

### DIFF
--- a/vibetuner-py/src/vibetuner/services/__init__.py
+++ b/vibetuner-py/src/vibetuner/services/__init__.py
@@ -1,18 +1,14 @@
 # ABOUTME: FastAPI dependency injection wrappers for built-in services.
 # ABOUTME: Provides get_email_service, get_blob_service, get_runtime_config for use with Depends().
 
-import asyncio
 from collections.abc import AsyncGenerator
 
 from fastapi import HTTPException
-
 
 from vibetuner.logging import logger
 from vibetuner.runtime_config import RuntimeConfig
 from vibetuner.services.blob import BlobService
 from vibetuner.services.email import EmailService, EmailServiceNotConfiguredError
-
-_cache_lock = asyncio.Lock()
 
 
 async def get_email_service() -> AsyncGenerator[EmailService, None]:
@@ -62,11 +58,5 @@ async def get_runtime_config() -> AsyncGenerator[RuntimeConfig, None]:
             value = await config.get("features.dark_mode")
     """
     if RuntimeConfig.is_cache_stale():
-        async with _cache_lock:
-            # Double-check after acquiring the lock
-            if RuntimeConfig.is_cache_stale():
-                try:
-                    await RuntimeConfig.refresh_cache()
-                except Exception:
-                    logger.warning("Failed to refresh runtime config cache")
+        await RuntimeConfig.refresh_cache()
     yield RuntimeConfig()


### PR DESCRIPTION
## Summary
- Moves the `_cache_lock` from `services/__init__.py` into `RuntimeConfig.refresh_cache()` itself
- Ensures ALL callers of `refresh_cache()` are synchronized (not just `get_runtime_config()`)
- Other callers in `frontend/lifespan.py` and `frontend/routes/debug.py` are now also protected

Closes #1114

## Test plan
- [ ] Verify `get_runtime_config()` still refreshes correctly
- [ ] Verify startup lifespan refresh works
- [ ] Verify debug panel refresh works
- [ ] Confirm no deadlocks under concurrent access

Generated with [Claude Code](https://claude.com/claude-code)