### PR TITLE
fix(cli): register user CLI extensions as named subcommand groups

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/__init__.py
+++ b/vibetuner-py/src/vibetuner/cli/__init__.py
@@ -120,11 +120,10 @@ app.add_typer(scaffold_app, name="scaffold")
 try:
     _app_config = load_app_config()
     if _app_config.cli:
-        # Add user's Typer app as a sub-command group or merge commands
-        for command in _app_config.cli.registered_commands:
-            app.registered_commands.append(command)
-        for group in _app_config.cli.registered_groups:
-            app.registered_groups.append(group)
+        # Register user's Typer app as a named subcommand group.
+        # The user's Typer name attribute is used as the group name
+        # (e.g., typer.Typer(name="linkboard") → `vibetuner linkboard <cmd>`).
+        app.add_typer(_app_config.cli)
         logger.debug("Registered user CLI commands from tune.py")
 except ConfigurationError:
     # Not in a project directory or tune.py misconfigured, skip user CLI


### PR DESCRIPTION
## Summary
- Replace direct mutation of `app.registered_commands`/`registered_groups` with `app.add_typer()`
- User CLI extensions now appear as named subcommand groups (e.g., `vibetuner linkboard seed`)
- Uses the Typer's `name` attribute as the group name

Closes #1118

## Test plan
- [ ] `vibetuner linkboard seed` works when user defines `typer.Typer(name="linkboard")`
- [ ] Built-in commands (`vibetuner run dev`, `vibetuner scaffold new`) still work
- [ ] `vibetuner --help` shows user group under subcommands

Generated with [Claude Code](https://claude.com/claude-code)