### PR TITLE
fix(crud): use search query parameter for CRUD list filtering

### DIFF
--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -42,9 +42,9 @@ def _apply_filters(query, request: Request, filterable: list[str]):
     return query
 
 
-def _apply_search(query, request: Request, searchable: list[str]):
+def _apply_search(query, search: str | None, searchable: list[str]):
     """Apply text search across searchable fields."""
-    q = request.query_params.get("q")
+    q = search
     if q and searchable:
         escaped_q = re.escape(q)
         search_filter = {
@@ -115,13 +115,16 @@ def _register_list_route(
         offset: int = Query(0, ge=0),
         limit: int = Query(page_size, ge=1, le=max_page_size),
         sort: str | None = Query(None),
+        search: str | None = Query(
+            None, description="Search across searchable fields"
+        ),
         fields: str | None = Query(
             None, description="Comma-separated field names to include"
         ),
     ):
         query = model.find()
         query = _apply_filters(query, request, filterable)
-        query = _apply_search(query, request, searchable)
+        query = _apply_search(query, search, searchable)
         query = _apply_sort(query, sort, sortable)
 
         total = await query.count()


### PR DESCRIPTION
## Summary
- The search function was reading `request.query_params.get("q")` but users expect `?search=`
- Changed to a proper FastAPI `Query` parameter named `search`
- Now appears in OpenAPI docs and works with `?search=htmx`

Closes #1120

## Test plan
- [ ] `GET /api/links?search=htmx` returns only matching items
- [ ] `GET /api/links` (no search) returns all items
- [ ] OpenAPI docs show `search` parameter on list endpoints
- [ ] Existing `filterable_fields` still work

Generated with [Claude Code](https://claude.com/claude-code)