### PR TITLE
fix: add greenlet dependency required by SQLAlchemy async

### DIFF
--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
   "streaq[web]>=6.0.1,<7.0.0",
   "typer-slim[standard]>=0.21.1",
   "deprecated>=1.3.1",
+  "greenlet>=3.0.0",
   "sqlmodel>=0.0.32",
   "gitpython>=3.1.46",
 ]


### PR DESCRIPTION
## Summary
- Adds `greenlet>=3.0.0` as an explicit dependency in pyproject.toml
- SQLAlchemy's async engine requires greenlet at runtime but it wasn't listed as a dependency

## Test plan
- [ ] Verify `uv sync` succeeds with new dependency
- [ ] Verify SQLModel async features work without ImportError

Closes #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)