### PR TITLE
fix: call _ensure_engine() lazily in get_session()

### DIFF
--- a/vibetuner-py/src/vibetuner/sqlmodel.py
+++ b/vibetuner-py/src/vibetuner/sqlmodel.py
@@ -101,8 +101,8 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
     - raise HTTPException(500), OR
     - return a dummy object in tests.
     """
+    _ensure_engine()
     if async_session is None:
-        # Fail fast – you can customize this to HTTPException if used only in web context
         raise RuntimeError("database_url is not configured. No DB session available.")
 
     async with async_session() as session:


### PR DESCRIPTION
## Summary
- `get_session()` now calls `_ensure_engine()` before checking if `async_session` is None
- This allows the session dependency to work even if `init_sqlmodel()` wasn't called during startup

## Test plan
- [ ] Verify `get_session()` initializes engine lazily when `database_url` is set
- [ ] Verify `get_session()` still raises RuntimeError when `database_url` is not configured

Closes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)