### PR TITLE
fix: use SQLModel AsyncSession instead of SQLAlchemy AsyncSession

### DIFF
--- a/vibetuner-py/src/vibetuner/sqlmodel.py
+++ b/vibetuner-py/src/vibetuner/sqlmodel.py
@@ -5,11 +5,11 @@ from typing import AsyncGenerator, Optional
 
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
-    AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
 from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from vibetuner.config import settings
 from vibetuner.logging import logger


### PR DESCRIPTION
## Summary
- Changed import from `sqlalchemy.ext.asyncio.AsyncSession` to `sqlmodel.ext.asyncio.session.AsyncSession`
- SQLModel's AsyncSession extends SQLAlchemy's with `exec()` and other SQLModel-specific methods
- Without this, users get AttributeError when using `session.exec(select(...))`

## Test plan
- [ ] Verify `session.exec()` works in async context
- [ ] Verify standard SQLAlchemy operations still work

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)