### PR TITLE
fix: fall back to pyproject.toml name for CLI help title

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/__init__.py
+++ b/vibetuner-py/src/vibetuner/cli/__init__.py
@@ -51,9 +51,22 @@ def _get_app_help():
     try:
         from vibetuner.config import settings
 
-        return f"{settings.project.project_name.title()} CLI"
+        name = settings.project.project_name
+        if name and name != "default_project":
+            return f"{name.title()} CLI"
     except (RuntimeError, ImportError):
-        return "Vibetuner CLI"
+        pass
+
+    try:
+        from vibetuner.pyproject import get_project_name
+
+        name = get_project_name()
+        if name:
+            return f"{name.replace('_', ' ').title()} CLI"
+    except Exception:
+        pass
+
+    return "Vibetuner CLI"
 
 
 app = AsyncTyper(help=_get_app_help())


### PR DESCRIPTION
## Summary
- CLI help title now falls back to `get_project_name()` from pyproject.toml when settings has the default value
- Previously showed "Default_Project CLI" when settings weren't properly configured
- Falls back gracefully: settings name → pyproject.toml name → "Vibetuner CLI"

## Test plan
- [ ] Verify CLI help shows correct project name from settings
- [ ] Verify fallback to pyproject.toml name works
- [ ] Verify "Vibetuner CLI" fallback when outside a project

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)