### PR TITLE
feat: allow SQL-only projects without requiring MongoDB

### DIFF
--- a/vibetuner-py/src/vibetuner/mongo.py
+++ b/vibetuner-py/src/vibetuner/mongo.py
@@ -41,7 +41,14 @@ def get_all_models() -> list[type]:
 
 
 async def init_mongodb() -> None:
-    """Initialize MongoDB and register Beanie models."""
+    """Initialize MongoDB and register Beanie models.
+
+    Silently skips if mongodb_url is not configured, allowing SQL-only projects.
+    """
+    if settings.mongodb_url is None:
+        logger.debug("MongoDB not configured (no MONGODB_URL) — skipping initialization")
+        return
+
     _ensure_client()
 
     if mongo_client is None:


### PR DESCRIPTION
## Summary
- `init_mongodb()` now silently skips when `MONGODB_URL` is not configured
- Previously it called `mongodb_not_configured()` which printed a scary error panel even for SQL-only projects
- Now logs a debug message and returns, allowing SQL-only deployments to work cleanly

## Test plan
- [ ] Verify project starts without `MONGODB_URL` when only `DATABASE_URL` is set
- [ ] Verify MongoDB-based projects still work normally
- [ ] Verify `vibetuner doctor` shows MongoDB as "warn" (not error) when not configured

Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)