### PR TITLE
feat: add sql_models field to VibetunerApp for explicit model registration

### DIFF
--- a/vibetuner-py/src/vibetuner/app_config.py
+++ b/vibetuner-py/src/vibetuner/app_config.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 from beanie import Document, View
 from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict
+from sqlmodel import SQLModel
 from starlette.middleware import Middleware
 from typer import Typer
 
@@ -33,6 +34,9 @@ class VibetunerApp(BaseModel):
 
     # Models (Beanie documents and views)
     models: list[type[Document] | type[View]] = []
+
+    # SQL Models (SQLModel table models)
+    sql_models: list[type[SQLModel]] = []
 
     # Frontend
     routes: list[APIRouter] = []

--- a/vibetuner-py/src/vibetuner/cli/doctor.py
+++ b/vibetuner-py/src/vibetuner/cli/doctor.py
@@ -202,19 +202,40 @@ def _check_service_connectivity() -> list[CheckResult]:
 
 
 def _check_models() -> list[CheckResult]:
+    results: list[CheckResult] = []
+
     try:
         from vibetuner.mongo import get_all_models
 
         models = get_all_models()
-        return [
+        results.append(
             CheckResult(
-                "Registered models",
+                "Beanie models",
                 "ok",
                 f"{len(models)} model(s): {', '.join(m.__name__ for m in models)}",
             )
-        ]
+        )
     except Exception as exc:
-        return [CheckResult("Registered models", "warn", f"Cannot load models: {exc}")]
+        results.append(CheckResult("Beanie models", "warn", f"Cannot load: {exc}"))
+
+    try:
+        from vibetuner.sqlmodel import get_all_sql_models
+
+        sql_models = get_all_sql_models()
+        if sql_models:
+            results.append(
+                CheckResult(
+                    "SQL models",
+                    "ok",
+                    f"{len(sql_models)} model(s): {', '.join(m.__name__ for m in sql_models)}",
+                )
+            )
+        else:
+            results.append(CheckResult("SQL models", "skip", "None registered"))
+    except Exception as exc:
+        results.append(CheckResult("SQL models", "warn", f"Cannot load: {exc}"))
+
+    return results
 
 
 def _check_templates(root: Path | None) -> list[CheckResult]:

--- a/vibetuner-py/src/vibetuner/sqlmodel.py
+++ b/vibetuner-py/src/vibetuner/sqlmodel.py
@@ -44,6 +44,13 @@ def _ensure_engine() -> None:
         )
 
 
+def get_all_sql_models() -> list[type[SQLModel]]:
+    """Get all registered SQL models from tune.py."""
+    from vibetuner.loader import load_app_config
+
+    return list(load_app_config().sql_models)
+
+
 async def init_sqlmodel() -> None:
     """
     Called from lifespan/startup.
@@ -57,6 +64,14 @@ async def init_sqlmodel() -> None:
     if engine is None:
         # Nothing to do, DB not configured
         return
+
+    sql_models = get_all_sql_models()
+    if sql_models:
+        logger.debug(
+            "Registered {} SQL model(s): {}",
+            len(sql_models),
+            ", ".join(m.__name__ for m in sql_models),
+        )
 
     logger.info("SQLModel engine initialized successfully.")
 


### PR DESCRIPTION
## Summary
- Adds `sql_models: list[type[SQLModel]]` field to `VibetunerApp` for explicit SQL model registration
- `init_sqlmodel()` now logs registered SQL models at startup
- `get_all_sql_models()` function exposes the registered list programmatically
- `vibetuner doctor` now reports both Beanie and SQL models separately

## Test plan
- [ ] Verify `sql_models=[]` default works (backward compatible)
- [ ] Verify `sql_models=[MyTable]` registers and logs correctly
- [ ] Verify `vibetuner doctor` shows both Beanie and SQL model counts

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)