### PR TITLE
fix: ignore ruff B008 for FastAPI Depends() convention

### DIFF
--- a/vibetuner-template/.ruff.toml
+++ b/vibetuner-template/.ruff.toml
@@ -12,6 +12,9 @@ extend-select = [
   'W',      # pycodestyle
   'FA100',  # ban `from __future__ import annotations` (breaks FastAPI/Pydantic)
 ]
+ignore = [
+  'B008',   # function call in default argument — intentional for FastAPI Depends() / Query()
+]
 
 [lint.isort]
 combine-as-imports = true


### PR DESCRIPTION
## Summary

Closes #1153.

- Adds `B008` to the `ignore` list in `vibetuner-template/.ruff.toml`
- Ruff's B008 rule flags function calls in default argument values as potentially dangerous, but FastAPI idiomatically uses `Depends()`, `Query()`, `Path()`, `Body()`, etc. as parameter defaults in route handlers
- Suppressing B008 project-wide avoids false positives that would otherwise require per-line `# noqa: B008` comments throughout every router file

## Test plan

- [ ] Verify `ruff check` passes without B008 warnings on a project generated from this template that uses `Depends()` / `Query()` in route parameters
- [ ] Verify other flake8-bugbear rules (B0xx) still fire as expected on genuine issues
- [ ] Confirm the template renders correctly with `copier copy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)