### PR TITLE
fix: serialize ObjectId as string in CRUD response schemas

### DIFF
--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -82,14 +82,14 @@ def _serialize_items(
         selected = {f.strip() for f in fields.split(",")}
         return [_select_fields(item, selected, response_schema) for item in items]
     if response_schema:
-        return [response_schema.model_validate(item.model_dump()) for item in items]
+        return [response_schema.model_validate(item.model_dump(mode="json")) for item in items]
     return items
 
 
 def _serialize_one(doc: Document, response_schema: type[BaseModel] | None):
     """Serialize a single document with optional response schema."""
     if response_schema:
-        return response_schema.model_validate(doc.model_dump())
+        return response_schema.model_validate(doc.model_dump(mode="json"))
     return doc
 
 


### PR DESCRIPTION
## Summary

Closes #1148.

- **Problem:** When a CRUD response schema is applied, `model_dump()` returns MongoDB `ObjectId` instances as-is. Pydantic's `model_validate` then fails (or produces non-JSON-serializable output) because it does not know how to coerce a raw `ObjectId` into a `str`.
- **Fix:** Changed `model_dump()` to `model_dump(mode="json")` in both `_serialize_items` (line 85) and `_serialize_one` (line 92) in `vibetuner-py/src/vibetuner/crud.py`. The `mode="json"` argument tells Pydantic to serialize all fields to their JSON-compatible representations, which converts `ObjectId` to `str` before the response schema validates the data.

## Test plan

- [ ] Verify that list and detail CRUD endpoints using a response schema with an `id: str` field return the ObjectId as a plain string
- [ ] Confirm endpoints without a response schema still return documents unchanged
- [ ] Run existing test suite to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)