### PR TITLE
fix: skip logging during CLI help commands

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/__init__.py
+++ b/vibetuner-py/src/vibetuner/cli/__init__.py
@@ -81,8 +81,13 @@ LOG_LEVEL_OPTION = typer.Option(
 
 
 @app.callback()
-def callback(log_level: LogLevel | None = LOG_LEVEL_OPTION) -> None:
+def callback(
+    ctx: typer.Context,
+    log_level: LogLevel | None = LOG_LEVEL_OPTION,
+) -> None:
     """Initialize logging and other global settings."""
+    if ctx.resilient_parsing:
+        return
     setup_logging(level=log_level)
 
 


### PR DESCRIPTION
## Summary

Fixes #1154

- Added `typer.Context` parameter to the CLI `callback` function
- Added an early return when `ctx.resilient_parsing` is `True`, which Typer/Click sets during tab-completion and `--help` invocations
- This prevents `setup_logging()` from running when the user just wants help output, eliminating noisy log initialization messages from `--help` commands

## Test plan

- [ ] Run `vibetuner --help` and verify no logging noise appears in the output
- [ ] Run `vibetuner <subcommand> --help` and verify clean help output
- [ ] Run `vibetuner` normally and verify logging still initializes correctly
- [ ] Run with `--log-level debug` and verify log level is respected as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)