### PR TITLE
fix: allow extra fields on worker Context model

### DIFF
--- a/vibetuner-py/src/vibetuner/context.py
+++ b/vibetuner-py/src/vibetuner/context.py
@@ -43,7 +43,7 @@ class Context(BaseModel):
 
     fqdn: str | None = settings.project.fqdn
 
-    model_config = {"arbitrary_types_allowed": True}
+    model_config = {"arbitrary_types_allowed": True, "extra": "allow"}
 
 
 ctx = Context()


### PR DESCRIPTION
## Summary

Closes #1146.

- Added `"extra": "allow"` to `Context`'s Pydantic `model_config` in `vibetuner-py/src/vibetuner/context.py`
- This allows users to set custom attributes on the `Context` instance during worker lifespans (e.g., storing database connections, caches, or other shared resources) without Pydantic raising a validation error
- The existing `"arbitrary_types_allowed": True` setting is preserved

## Test plan

- [x] `tests/unit/test_context.py` passes (3/3 tests)
- [ ] Verify that setting a custom field on `ctx` in a worker lifespan no longer raises `ValidationError`
- [ ] Confirm existing context fields (`app`, `fqdn`, etc.) continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)