### PR TITLE
fix: make service error rich panels opt-in to reduce log noise

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/doctor.py
+++ b/vibetuner-py/src/vibetuner/cli/doctor.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from vibetuner.logging import logger
 
+
 doctor_app = typer.Typer(help="Validate project setup", invoke_without_command=True)
 console = Console()
 

--- a/vibetuner-py/src/vibetuner/frontend/sse.py
+++ b/vibetuner-py/src/vibetuner/frontend/sse.py
@@ -5,4 +5,5 @@ from vibetuner.sse import (
     sse_endpoint as sse_endpoint,
 )
 
+
 __all__ = ["broadcast", "sse_endpoint"]

--- a/vibetuner-py/src/vibetuner/services/blob.py
+++ b/vibetuner-py/src/vibetuner/services/blob.py
@@ -28,7 +28,7 @@ class BlobService:
         ):
             from vibetuner.services.errors import s3_not_configured
 
-            raise ValueError(s3_not_configured())
+            raise ValueError(s3_not_configured(log=False))
 
         bucket = default_bucket or settings.r2_default_bucket_name
         if bucket is None:

--- a/vibetuner-py/src/vibetuner/services/email.py
+++ b/vibetuner-py/src/vibetuner/services/email.py
@@ -30,7 +30,7 @@ class EmailService:
         if not settings.mailjet_api_key or not settings.mailjet_api_secret:
             from vibetuner.services.errors import email_not_configured
 
-            raise EmailServiceNotConfiguredError(email_not_configured())
+            raise EmailServiceNotConfiguredError(email_not_configured(log=False))
         self.client = Client(
             auth=(
                 settings.mailjet_api_key.get_secret_value(),

--- a/vibetuner-py/src/vibetuner/services/errors.py
+++ b/vibetuner-py/src/vibetuner/services/errors.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
+
 _console = Console(stderr=True)
 
 DOCS_BASE = "https://vibetuner.alltuner.com/docs"
@@ -59,9 +60,10 @@ MONGODB_ERROR = _build_message(
 )
 
 
-def mongodb_not_configured() -> str:
-    """Return (and optionally print) the MongoDB configuration error."""
-    _print_rich_error(MONGODB_ERROR, "MongoDB not configured")
+def mongodb_not_configured(*, log: bool = True) -> str:
+    """Return the MongoDB configuration error. Optionally print to stderr."""
+    if log:
+        _print_rich_error(MONGODB_ERROR, "MongoDB not configured")
     return MONGODB_ERROR
 
 
@@ -77,9 +79,10 @@ REDIS_ERROR = _build_message(
 )
 
 
-def redis_not_configured() -> str:
-    """Return (and optionally print) the Redis configuration error."""
-    _print_rich_error(REDIS_ERROR, "Redis not configured")
+def redis_not_configured(*, log: bool = True) -> str:
+    """Return the Redis configuration error. Optionally print to stderr."""
+    if log:
+        _print_rich_error(REDIS_ERROR, "Redis not configured")
     return REDIS_ERROR
 
 
@@ -110,9 +113,10 @@ S3_ERROR = _build_message(
 )
 
 
-def s3_not_configured() -> str:
-    """Return (and optionally print) the S3/R2 configuration error."""
-    _print_rich_error(S3_ERROR, "S3/R2 storage not configured")
+def s3_not_configured(*, log: bool = True) -> str:
+    """Return the S3/R2 configuration error. Optionally print to stderr."""
+    if log:
+        _print_rich_error(S3_ERROR, "S3/R2 storage not configured")
     return S3_ERROR
 
 
@@ -127,7 +131,8 @@ EMAIL_ERROR = _build_message(
 )
 
 
-def email_not_configured() -> str:
-    """Return (and optionally print) the email configuration error."""
-    _print_rich_error(EMAIL_ERROR, "Email service not configured")
+def email_not_configured(*, log: bool = True) -> str:
+    """Return the email configuration error. Optionally print to stderr."""
+    if log:
+        _print_rich_error(EMAIL_ERROR, "Email service not configured")
     return EMAIL_ERROR

--- a/vibetuner-py/src/vibetuner/tasks/__init__.py
+++ b/vibetuner-py/src/vibetuner/tasks/__init__.py
@@ -3,4 +3,5 @@
 
 from .robust import DeadLetterModel, robust_task
 
+
 __all__ = ["DeadLetterModel", "robust_task"]

--- a/vibetuner-py/src/vibetuner/tasks/worker.py
+++ b/vibetuner-py/src/vibetuner/tasks/worker.py
@@ -34,5 +34,5 @@ def get_worker() -> Worker:
     if worker is None:
         from vibetuner.services.errors import redis_not_configured
 
-        raise RuntimeError(redis_not_configured())
+        raise RuntimeError(redis_not_configured(log=False))
     return worker

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2943,7 +2943,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "7.0.0"
+version = "7.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -2958,6 +2958,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard-no-fastapi-cloud-cli"] },
     { name = "gitpython" },
     { name = "granian", extra = ["pname"] },
+    { name = "greenlet" },
     { name = "httpx", extra = ["http2"] },
     { name = "itsdangerous" },
     { name = "loguru" },
@@ -3012,6 +3013,7 @@ requires-dist = [
     { name = "gitpython", specifier = ">=3.1.46" },
     { name = "granian", extras = ["pname"], specifier = ">=2.7.1" },
     { name = "granian", extras = ["pname", "reload"], marker = "extra == 'dev'", specifier = ">=2.7.1" },
+    { name = "greenlet", specifier = ">=3.0.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "loguru", specifier = ">=0.7.3" },


### PR DESCRIPTION
## Summary

- Add `log: bool = True` keyword argument to all service error helpers (`mongodb_not_configured`,
  `redis_not_configured`, `s3_not_configured`, `email_not_configured`) in `services/errors.py`
- When `log=True` (the default), the rich panel is printed to stderr as before (backward compatible)
- When `log=False`, only the error message string is returned without printing
- Callers that immediately raise exceptions (`blob.py`, `email.py`, `worker.py`) now pass `log=False`
  since the rich panel output is noise when the error is propagated via exception
- Callers that use the function for its side effect (`mongo.py`, `cli/run.py`) keep the default
  `log=True` behavior

Closes #1158

## Test plan

- [ ] Verify `mongodb_not_configured()` still prints rich panel by default
- [ ] Verify `mongodb_not_configured(log=False)` returns message without printing
- [ ] Verify `BlobService` initialization raises `ValueError` without noisy stderr output
- [ ] Verify `EmailService` initialization raises without noisy stderr output
- [ ] Verify `get_worker()` raises `RuntimeError` without noisy stderr output
- [ ] Verify `vibetuner run worker` still shows rich panel before exiting
- [ ] Verify MongoDB startup path still shows rich panel when URL is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)