### PR TITLE
fix: remove AllTuner-specific localdev URL from run dev output

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -89,9 +89,6 @@ def _run_frontend(
 
     console.print(f"[green]Starting frontend in {mode} mode on {host}:{port}[/green]")
     console.print(f"[cyan]website reachable at http://localhost:{port}[/cyan]")
-    console.print(
-        f"[cyan]website reachable at https://{port}.localdev.alltuner.com:12000/[/cyan]"
-    )
     if is_dev:
         console.print("[dim]Watching for changes in src/ and templates/[/dim]")
     else:


### PR DESCRIPTION
## Summary
- Remove the AllTuner-specific `https://{port}.localdev.alltuner.com:12000/` URL from `vibetuner run dev` output
- Keep only the universally valid `http://localhost:{port}` URL

Closes #1164

## Test plan
- [ ] Run `vibetuner run dev` and verify only the localhost URL is printed
- [ ] Confirm no AllTuner-specific localdev URL appears in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)