### PR TITLE
fix: clarify create_crud_routes is Beanie-only in docs and comments

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/doctor.py
+++ b/vibetuner-py/src/vibetuner/cli/doctor.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from vibetuner.logging import logger
 
+
 doctor_app = typer.Typer(help="Validate project setup", invoke_without_command=True)
 console = Console()
 

--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -1,4 +1,4 @@
-# ABOUTME: Generic CRUD route factory for Beanie Document and SQLModel classes.
+# ABOUTME: Generic CRUD route factory for Beanie Document classes.
 # ABOUTME: Generates list/create/read/update/delete routes with pagination, filtering, and sorting.
 import re
 from collections.abc import Callable
@@ -82,7 +82,10 @@ def _serialize_items(
         selected = {f.strip() for f in fields.split(",")}
         return [_select_fields(item, selected, response_schema) for item in items]
     if response_schema:
-        return [response_schema.model_validate(item.model_dump(mode="json")) for item in items]
+        return [
+            response_schema.model_validate(item.model_dump(mode="json"))
+            for item in items
+        ]
     return items
 
 
@@ -115,9 +118,7 @@ def _register_list_route(
         offset: int = Query(0, ge=0),
         limit: int = Query(page_size, ge=1, le=max_page_size),
         sort: str | None = Query(None),
-        search: str | None = Query(
-            None, description="Search across searchable fields"
-        ),
+        search: str | None = Query(None, description="Search across searchable fields"),
         fields: str | None = Query(
             None, description="Comma-separated field names to include"
         ),

--- a/vibetuner-py/src/vibetuner/frontend/sse.py
+++ b/vibetuner-py/src/vibetuner/frontend/sse.py
@@ -5,4 +5,5 @@ from vibetuner.sse import (
     sse_endpoint as sse_endpoint,
 )
 
+
 __all__ = ["broadcast", "sse_endpoint"]

--- a/vibetuner-py/src/vibetuner/mongo.py
+++ b/vibetuner-py/src/vibetuner/mongo.py
@@ -46,7 +46,9 @@ async def init_mongodb() -> None:
     Silently skips if mongodb_url is not configured, allowing SQL-only projects.
     """
     if settings.mongodb_url is None:
-        logger.debug("MongoDB not configured (no MONGODB_URL) — skipping initialization")
+        logger.debug(
+            "MongoDB not configured (no MONGODB_URL) — skipping initialization"
+        )
         return
 
     _ensure_client()

--- a/vibetuner-py/src/vibetuner/services/errors.py
+++ b/vibetuner-py/src/vibetuner/services/errors.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
+
 _console = Console(stderr=True)
 
 DOCS_BASE = "https://vibetuner.alltuner.com/docs"

--- a/vibetuner-py/src/vibetuner/sse.py
+++ b/vibetuner-py/src/vibetuner/sse.py
@@ -407,7 +407,7 @@ def sse_endpoint(
                     f"sse_endpoint path '{path}' starts with router prefix "
                     f"'{router.prefix}' — this will produce a doubled path "
                     f"'{router.prefix}{path}'. Use a relative path instead "
-                    f"(e.g., '{path[len(router.prefix):]}')"
+                    f"(e.g., '{path[len(router.prefix) :]}')"
                 )
             router.add_api_route(path, endpoint, methods=["GET"], name=name)
 

--- a/vibetuner-py/src/vibetuner/tasks/__init__.py
+++ b/vibetuner-py/src/vibetuner/tasks/__init__.py
@@ -3,4 +3,5 @@
 
 from .robust import DeadLetterModel, robust_task
 
+
 __all__ = ["DeadLetterModel", "robust_task"]


### PR DESCRIPTION
## Summary
- Updated ABOUTME comment in `crud.py` to remove incorrect claim of SQLModel support
- Applied ruff formatting fixes to several files in `src/vibetuner/`

closes #1162

## Test plan
- [x] Verify the ABOUTME comment no longer references SQLModel
- [x] Confirm no code logic was changed, only comments and formatting
- [x] `ruff check` and `ruff format` pass cleanly on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)