### PR TITLE
fix: add defensive check for missing task_context in robust middleware

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/doctor.py
+++ b/vibetuner-py/src/vibetuner/cli/doctor.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from vibetuner.logging import logger
 
+
 doctor_app = typer.Typer(help="Validate project setup", invoke_without_command=True)
 console = Console()
 

--- a/vibetuner-py/src/vibetuner/frontend/sse.py
+++ b/vibetuner-py/src/vibetuner/frontend/sse.py
@@ -5,4 +5,5 @@ from vibetuner.sse import (
     sse_endpoint as sse_endpoint,
 )
 
+
 __all__ = ["broadcast", "sse_endpoint"]

--- a/vibetuner-py/src/vibetuner/services/errors.py
+++ b/vibetuner-py/src/vibetuner/services/errors.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
+
 _console = Console(stderr=True)
 
 DOCS_BASE = "https://vibetuner.alltuner.com/docs"

--- a/vibetuner-py/src/vibetuner/tasks/__init__.py
+++ b/vibetuner-py/src/vibetuner/tasks/__init__.py
@@ -3,4 +3,5 @@
 
 from .robust import DeadLetterModel, robust_task
 
+
 __all__ = ["DeadLetterModel", "robust_task"]

--- a/vibetuner-py/src/vibetuner/tasks/robust.py
+++ b/vibetuner-py/src/vibetuner/tasks/robust.py
@@ -91,7 +91,9 @@ def _ensure_middleware(worker: Any) -> None:
             @worker.middleware
             def robust_retry_middleware(next_fn: Any) -> Any:
                 async def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    ctx = task_context.get()
+                    ctx = task_context.get(None)
+                    if ctx is None:
+                        return await next_fn(*args, **kwargs)
                     config = _configs.get(ctx.fn_name)
                     if config is None:
                         return await next_fn(*args, **kwargs)

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2943,7 +2943,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "7.0.0"
+version = "7.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -2958,6 +2958,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard-no-fastapi-cloud-cli"] },
     { name = "gitpython" },
     { name = "granian", extra = ["pname"] },
+    { name = "greenlet" },
     { name = "httpx", extra = ["http2"] },
     { name = "itsdangerous" },
     { name = "loguru" },
@@ -3012,6 +3013,7 @@ requires-dist = [
     { name = "gitpython", specifier = ">=3.1.46" },
     { name = "granian", extras = ["pname"], specifier = ">=2.7.1" },
     { name = "granian", extras = ["pname", "reload"], marker = "extra == 'dev'", specifier = ">=2.7.1" },
+    { name = "greenlet", specifier = ">=3.0.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "loguru", specifier = ">=0.7.3" },


### PR DESCRIPTION
## Summary
- `robust_retry_middleware` called `task_context.get()` which raises `LookupError` when the `ContextVar` is not set
- Changed to `task_context.get(None)` with a guard clause that passes through to the next middleware/handler when no task context is available

## Test plan
- [ ] Verify middleware passes through gracefully when `task_context` is unset
- [ ] Verify existing retry/backoff behavior is unchanged when `task_context` is available

closes #1180

🤖 Generated with [Claude Code](https://claude.com/claude-code)