### PR TITLE
docs: align SECRET_KEY, auth, and CLI reference with implementation

### DIFF
--- a/vibetuner-docs/docs/architecture.md
+++ b/vibetuner-docs/docs/architecture.md
@@ -540,7 +540,7 @@ Pydantic Settings with environment variable support:
 class Settings(BaseSettings):
 # Automatic from .env or environment
 DATABASE_URL: str
-SECRET_KEY: str
+SESSION_KEY: str
 DEBUG: bool = False
 # OAuth
 GOOGLE_CLIENT_ID: str | None = None

--- a/vibetuner-docs/docs/cli-reference.md
+++ b/vibetuner-docs/docs/cli-reference.md
@@ -99,8 +99,10 @@ vibetuner run dev --auto-port
 
 - Sets `DEBUG=1` and enables hot reload.
 - `service` defaults to `frontend`.
-- Frontend watches `src/app/` and `templates/` for changes.
-- Worker runs the Streaq worker with reload enabled (ignores `--workers` > 1).
+- Frontend watches paths from `paths.reload_paths` and
+  `src/<project_slug>/` for changes, dynamically resolved at startup.
+- Worker runs the Streaq worker with reload enabled
+  (ignores `--workers` > 1).
 
 ### `prod`
 
@@ -124,7 +126,8 @@ vibetuner db create-schema
 
 Creates all database tables defined in SQLModel metadata. This command:
 
-1. Imports models from `app.models` to ensure they're registered
+1. Loads SQL models from `VibetunerApp.sql_models` via
+   `load_app_config()` / `get_all_sql_models()`
 2. Creates tables in the database specified by `DATABASE_URL`
 3. Skips if tables already exist (safe to run multiple times)
 
@@ -132,6 +135,8 @@ Creates all database tables defined in SQLModel metadata. This command:
 
 - `DATABASE_URL` environment variable must be set
 - Models must be defined using SQLModel with `table=True`
+- Models must be listed in `VibetunerApp.sql_models` in your
+  `tune.py`
 
 **Example:**
 

--- a/vibetuner-docs/docs/deployment.md
+++ b/vibetuner-docs/docs/deployment.md
@@ -31,7 +31,7 @@ Create a `.env` file for production:
 ```bash
 # Application
 APP_NAME=My Application
-SECRET_KEY=your-production-secret-key
+SESSION_KEY=your-production-secret-key
 DEBUG=false
 ENVIRONMENT=production
 # Database (MongoDB)
@@ -40,11 +40,9 @@ MONGODB_URL=mongodb://user:password@mongodb-host:27017/myapp?authSource=admin
 DATABASE_URL=postgresql+asyncpg://user:password@postgres-host:5432/myapp
 # Redis (if background jobs enabled)
 REDIS_URL=redis://redis-host:6379/0
-# Email
-SMTP_HOST=smtp.sendgrid.net
-SMTP_PORT=587
-SMTP_USER=apikey
-SMTP_PASSWORD=your-sendgrid-api-key
+# Email (Mailjet)
+MAILJET_API_KEY=your-mailjet-api-key
+MAILJET_API_SECRET=your-mailjet-api-secret
 FROM_EMAIL=noreply@example.com
 # OAuth
 GOOGLE_CLIENT_ID=your-production-client-id
@@ -64,7 +62,7 @@ AWS_REGION=us-east-1
 
 ### Security Checklist
 
-- [ ] Use strong, unique `SECRET_KEY`
+- [ ] Use strong, unique `SESSION_KEY`
 - [ ] Set `DEBUG=false`
 - [ ] Enable `SESSION_COOKIE_SECURE=true` (HTTPS)
 - [ ] Use environment variables (not `.env` in image)

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -1211,7 +1211,7 @@ MONGODB_URL=mongodb://localhost:27017/myapp
 DATABASE_URL=postgresql+asyncpg://user:pass@localhost/myapp
 # DATABASE_URL=sqlite+aiosqlite:///./data.db
 
-SECRET_KEY=your-secret-key-here
+SESSION_KEY=your-secret-key-here
 DEBUG=true
 # OAuth (optional)
 GOOGLE_CLIENT_ID=...
@@ -1228,7 +1228,7 @@ MONGODB_URL=mongodb://prod-server:27017/myapp
 # Or SQL database
 DATABASE_URL=postgresql+asyncpg://user:pass@prod-server/myapp
 
-SECRET_KEY=very-secret-key
+SESSION_KEY=very-secret-key
 DEBUG=false
 ```
 


### PR DESCRIPTION
## Summary

- **SECRET_KEY -> SESSION_KEY** (#1155): Updated all documentation files
  (`development-guide.md`, `deployment.md`, `architecture.md`,
  `authentication.md`) to use `SESSION_KEY` instead of the outdated
  `SECRET_KEY` env var name, matching the runtime config.
- **Auth docs outdated examples** (#1157): Replaced SMTP env vars
  (`SMTP_HOST`, `SMTP_USER`, etc.) with Mailjet (`MAILJET_API_KEY`,
  `MAILJET_API_SECRET`); fixed template path `templates/emails/` to
  `templates/email/` (singular); updated user model to use `UserModel`
  with `picture` field instead of `User` with `avatar_url`; replaced
  inline `oauth_accounts` list with linked `OAuthAccountModel` reference;
  fixed broken indentation in code snippets.
- **CLI reference drift** (#1165): Updated `run dev` watch paths
  description to reference `paths.reload_paths` and
  `src/<project_slug>/`; updated `db create-schema` to document that SQL
  models come from `VibetunerApp.sql_models` via `load_app_config()` /
  `get_all_sql_models()`.

closes #1155, closes #1157, closes #1165, closes #1177

## Test plan

- [ ] Verify all `SECRET_KEY` references replaced with `SESSION_KEY` in docs
- [ ] Verify SMTP references replaced with Mailjet in auth and deployment docs
- [ ] Verify template path uses singular `email/` not `emails/`
- [ ] Verify user model shows `picture` not `avatar_url`
- [ ] Verify CLI reference mentions `paths.reload_paths` and `sql_models`
- [ ] Confirm no lines exceed 120 character limit in changed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)