### PR TITLE
fix: auto-create SQL tables on startup in dev mode

### DIFF
--- a/vibetuner-py/src/vibetuner/sqlmodel.py
+++ b/vibetuner-py/src/vibetuner/sqlmodel.py
@@ -75,6 +75,10 @@ async def init_sqlmodel() -> None:
 
     logger.info("SQLModel engine initialized successfully.")
 
+    if settings.debug:
+        await create_schema()
+        logger.info("SQLModel tables auto-created (DEBUG mode)")
+
 
 async def create_schema() -> None:
     """


### PR DESCRIPTION
## Summary
- Auto-create SQL tables during startup when `DEBUG=true`, matching Beanie's auto-initialization behavior for MongoDB
- Tables are created idempotently via `create_schema()` (uses `CREATE TABLE IF NOT EXISTS`)

Closes #1200

## Test plan
- [ ] Scaffold a project with SQL models, set `DEBUG=true`, and verify tables are created on startup without manual `db create-schema`
- [ ] Verify production mode (`DEBUG=false`) does NOT auto-create tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)