### PR TITLE
docs: document that template filters returning HTML must use Markup

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -334,6 +334,17 @@ Use in templates:
 <p>Price: {{ product.price | money }}</p>
 ```
 
+**Important:** If a filter returns HTML, wrap the result with `markupsafe.Markup`
+to prevent Jinja2 auto-escaping. Always escape user input inside the markup:
+
+```python
+from markupsafe import Markup, escape
+
+def tag_badge(value: str) -> Markup:
+    """Render a badge — escape user input, wrap result in Markup."""
+    return Markup('<span class="badge">{}</span>').format(escape(value))
+```
+
 #### Adding Background Jobs
 
 If you enabled background jobs, create tasks in `src/app/tasks/`:

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -507,6 +507,17 @@ app = VibetunerApp(
 
 Use in templates: `{{ post.created_at | ca_date }}` or `{{ post.content | truncate(30) }}`
 
+**Filters returning HTML:** If your filter returns HTML markup, wrap the output
+with `markupsafe.Markup` to prevent Jinja2 auto-escaping:
+
+```python
+from markupsafe import Markup, escape
+
+def tag_badge(value: str) -> Markup:
+    """Render a badge — escape user input, wrap result in Markup."""
+    return Markup('<span class="badge">{}</span>').format(escape(value))
+```
+
 ### Adding Middleware
 
 Create middleware and pass to `tune.py`:


### PR DESCRIPTION
## Summary
- Add documentation about using `markupsafe.Markup` for template filters that return HTML
- Updated both `vibetuner-template/CLAUDE.md` and `vibetuner-docs/docs/llms-full.txt`

Closes #1201

## Test plan
- [ ] Verify documentation renders correctly
- [ ] Confirm the code example is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)