### PR TITLE
docs: document CRUD factory hook signatures

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -793,6 +793,22 @@ post_routes = create_crud_routes(
 )
 ```
 
+**Hook signatures reference:**
+
+All hooks are async callables with these signatures:
+
+| Hook | Signature | Returns |
+|------|-----------|---------|
+| `pre_create` | `async (data, request)` | Modified data or `None` |
+| `post_create` | `async (doc, request)` | `None` |
+| `pre_update` | `async (doc, data, request)` | Modified data or `None` |
+| `post_update` | `async (doc, request)` | `None` |
+| `pre_delete` | `async (doc, request)` | `None` |
+| `post_delete` | `async (doc, request)` | `None` |
+
+`pre_create` and `pre_update` can return the (modified) data object to override
+input. If they return `None`, the original data is used.
+
 ### Server-Sent Events (SSE)
 
 Vibetuner provides SSE helpers for real-time streaming with HTMX. Import from

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -630,9 +630,32 @@ This generates GET (list with pagination/filtering/sorting/search), POST (create
 GET `/{id}` (read), PATCH `/{id}` (update), DELETE `/{id}` endpoints.
 
 Use `operations={Operation.LIST, Operation.READ}` to limit which endpoints are
-generated. Add `pre_create`, `post_create`, `pre_update`, `post_update`,
-`pre_delete`, `post_delete` hooks for custom logic. Use `create_schema`,
-`update_schema`, `response_schema` for custom Pydantic models.
+generated. Use `create_schema`, `update_schema`, `response_schema` for custom
+Pydantic models.
+
+**Hook signatures:**
+
+```python
+from fastapi import Request
+
+# Called before insert. Return modified data (or None to keep original).
+async def pre_create(data: CreateSchema, request: Request) -> CreateSchema: ...
+
+# Called after insert.
+async def post_create(doc: MyModel, request: Request) -> None: ...
+
+# Called before update. Return modified data (or None to keep original).
+async def pre_update(doc: MyModel, data: UpdateSchema, request: Request) -> UpdateSchema: ...
+
+# Called after update.
+async def post_update(doc: MyModel, request: Request) -> None: ...
+
+# Called before deletion.
+async def pre_delete(doc: MyModel, request: Request) -> None: ...
+
+# Called after deletion.
+async def post_delete(doc: MyModel, request: Request) -> None: ...
+```
 
 ### SSE (Server-Sent Events)
 


### PR DESCRIPTION
## Summary
- Add explicit hook signature documentation to the CRUD Factory section
- Shows exact parameter types and return values for all six hooks
- Updated both `vibetuner-template/CLAUDE.md` and `vibetuner-docs/docs/llms-full.txt`

Closes #1204

## Test plan
- [ ] Verify documentation renders correctly
- [ ] Confirm hook signatures match the actual `crud.py` implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)