### PR TITLE
feat: print HTTPS localdev URL on startup when LOCALDEV_URL is configured

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -201,6 +201,23 @@ just local-dev
 
 A database (MongoDB or SQL) is required if using database features. Redis is only required if background jobs are enabled.
 
+**HTTPS via Local Reverse Proxy**
+
+Set `LOCALDEV_URL` in your `.env` to have vibetuner print an HTTPS URL on startup:
+
+```bash
+LOCALDEV_URL=https://{port}.localdev.localhost:12000
+```
+
+The `{port}` placeholder is replaced with the actual port. Output on startup:
+
+```
+website reachable at http://localhost:8124
+  https reachable at https://8124.localdev.localhost:12000
+```
+
+Use this with any local HTTPS reverse proxy (Caddy with wildcard certs, mkcert, etc.).
+
 #### Adding New Routes
 
 Create a new file in `src/app/frontend/routes/`:

--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -89,6 +89,13 @@ def _run_frontend(
 
     console.print(f"[green]Starting frontend in {mode} mode on {host}:{port}[/green]")
     console.print(f"[cyan]website reachable at http://localhost:{port}[/cyan]")
+
+    from vibetuner.config import settings
+
+    if settings.localdev_url:
+        https_url = settings.localdev_url.replace("{port}", str(port))
+        console.print(f"[cyan]  https reachable at {https_url}[/cyan]")
+
     if is_dev:
         console.print("[dim]Watching for changes in src/ and templates/[/dim]")
     else:

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -185,6 +185,10 @@ class CoreConfiguration(BaseSettings):
     # SECURITY: Only IPs in this list can set forwarded headers. Use "*" to trust all (NOT recommended for production)
     trusted_proxy_hosts: str = "127.0.0.1"
 
+    # Local HTTPS reverse proxy URL template (e.g., "https://{port}.localdev.localhost:12000")
+    # When set, vibetuner prints this URL on startup with {port} replaced by the actual port.
+    localdev_url: str | None = None
+
     @cached_property
     def trusted_proxy_hosts_list(self) -> list[str]:
         """Parse trusted proxy hosts into a list for Granian's proxy header wrapper."""

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2923,7 +2923,7 @@ wheels = [
 
 [[package]]
 name = "vibetuner"
-version = "7.0.1"
+version = "8.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -893,6 +893,19 @@ DATABASE_URL=mongodb://localhost:27017/[dbname]
 REDIS_URL=redis://localhost:6379  # If background jobs enabled
 SECRET_KEY=your-secret-key
 DEBUG=true  # Development only
+LOCALDEV_URL=https://{port}.localdev.localhost:12000  # Optional: HTTPS reverse proxy
+```
+
+#### LOCALDEV_URL
+
+When set, vibetuner prints an additional HTTPS URL on startup with `{port}` replaced by
+the actual port. Use this with a local HTTPS reverse proxy (Caddy, nginx, mkcert) to get
+clickable HTTPS URLs without manual port mapping:
+
+```
+Starting frontend in dev mode on 0.0.0.0:8124
+website reachable at http://localhost:8124
+  https reachable at https://8124.localdev.localhost:12000
 ```
 
 ### Pydantic Settings


### PR DESCRIPTION
## Summary
- Add `LOCALDEV_URL` setting to `CoreConfiguration` (defaults to `None`)
- When set, `vibetuner run dev` prints the HTTPS URL with `{port}` replaced by the actual port
- Document the feature in AGENTS.md (scaffold template) and llms-full.txt

## Test plan
- [ ] Set `LOCALDEV_URL=https://{port}.localdev.localhost:12000` in `.env`
- [ ] Run `just local-all` and verify HTTPS URL is printed
- [ ] Run without `LOCALDEV_URL` and verify no extra output
- [ ] Verify `{port}` is correctly replaced in the URL

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)