### PR TITLE
fix: prevent infinite recursion when user CLI re-exports vibetuner.cli.app

### DIFF
--- a/vibetuner-py/src/vibetuner/__init__.py
+++ b/vibetuner-py/src/vibetuner/__init__.py
@@ -1,6 +1,7 @@
 # ABOUTME: Main vibetuner package entry point.
-# ABOUTME: Exports VibetunerApp and core template rendering functions.
+# ABOUTME: Exports VibetunerApp, AsyncTyper, and core template rendering functions.
 from vibetuner.app_config import VibetunerApp
+from vibetuner.cli import AsyncTyper
 from vibetuner.rendering import (
     register_context_provider,
     register_globals,
@@ -10,6 +11,7 @@ from vibetuner.rendering import (
 
 
 __all__ = [
+    "AsyncTyper",
     "VibetunerApp",
     "register_context_provider",
     "register_globals",

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -585,6 +585,44 @@ from app.tasks.emails import send_digest_email
 task = await send_digest_email.enqueue(user.id)
 ```
 
+### Adding CLI Commands
+
+Create an `AsyncTyper` instance for your CLI commands. `AsyncTyper` extends `typer.Typer` with
+native async support — use `async def` directly without `asyncio.run()` wrappers:
+
+```python
+# src/app/cli/__init__.py
+from vibetuner import AsyncTyper
+
+cli = AsyncTyper(help="My app CLI commands")
+
+@cli.command()
+async def seed(count: int = 10):
+    """Seed the database with sample data."""
+    from app.services.seeder import seed_database
+    await seed_database(count)
+```
+
+```python
+# src/app/tune.py
+from vibetuner import VibetunerApp
+from app.cli import cli
+
+app = VibetunerApp(
+    cli=cli,
+)
+```
+
+Commands are namespaced under `vibetuner app` (or your custom name):
+
+```bash
+uv run vibetuner app seed --count 50
+```
+
+> **Important:** Always create your own `AsyncTyper()` instance. Never re-export
+> `vibetuner.cli.app` — that is the framework's root CLI and adding it back causes a
+> circular reference.
+
 ### Custom Lifespan
 
 For custom startup/shutdown logic, create a lifespan and pass to `tune.py`:

--- a/vibetuner-template/MIGRATION-TO-TUNE-PY.md
+++ b/vibetuner-template/MIGRATION-TO-TUNE-PY.md
@@ -208,16 +208,18 @@ app = VibetunerApp(
 
 **Before:** CLI was auto-discovered from `app.cli`.
 
-**After:** Pass Typer app to `tune.py`.
+**After:** Create an `AsyncTyper` instance and pass it to `tune.py`. `AsyncTyper` extends
+`typer.Typer` with native async support — use `async def` directly in your commands without
+`asyncio.run()` wrappers.
 
 ```python
 # src/myapp/cli/__init__.py
-import typer
+from vibetuner import AsyncTyper
 
-cli = typer.Typer()
+cli = AsyncTyper()
 
 @cli.command()
-def my_command():
+async def my_command():
     print("Hello")
 ```
 
@@ -230,6 +232,10 @@ app = VibetunerApp(
     cli=cli,
 )
 ```
+
+> **Important:** Always create your own `AsyncTyper()` instance. Never re-export
+> `vibetuner.cli.app` — that is the framework's root CLI and adding it back causes a
+> circular reference.
 
 ### Step 9: Migrate OAuth Providers (if any)
 


### PR DESCRIPTION
## Summary

- Add identity check in `vibetuner/cli/__init__.py` to skip registration when user CLI
  is the same object as vibetuner's root app (prevents `RecursionError` with typer >=0.23)
- Export `AsyncTyper` from the `vibetuner` package so users can `from vibetuner import AsyncTyper`
- Update all documentation (cli-reference, AGENTS.md template, migration guide) to recommend
  `AsyncTyper` for user CLI commands instead of plain `typer.Typer()`

Closes #1216

## Test plan

- [ ] Verify `from vibetuner import AsyncTyper` works
- [ ] Verify re-exporting `vibetuner.cli.app` as user CLI logs a warning instead of crashing
- [ ] Verify normal user CLI registration still works with a separate `AsyncTyper()` instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)