### PR TITLE
fix: add invoke_without_command=True to doctor_app

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/doctor.py
+++ b/vibetuner-py/src/vibetuner/cli/doctor.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from vibetuner.logging import logger
 
 
-doctor_app = typer.Typer(help="Validate project setup")
+doctor_app = typer.Typer(help="Validate project setup", invoke_without_command=True)
 console = Console()
 
 


### PR DESCRIPTION
## Summary

- `doctor_app` was missing `invoke_without_command=True`, causing `vibetuner doctor` to fail
  with "Missing command" since all logic is in the callback, not a subcommand
- One-line fix: add the flag to the `typer.Typer()` constructor

Closes #1219

## Test plan

- [x] Verified `vibetuner doctor` runs diagnostic checks successfully after fix
- [x] Confirmed the issue reproduces on main (exits with "Missing command")

🤖 Generated with [Claude Code](https://claude.com/claude-code)