### PR TITLE
fix: quote command substitution in setup-tw-sources script

### DIFF
--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "setup-tw-sources": "[ -d .core-templates ] && [ ! -L .core-templates ] || (rm -rf .core-templates && ln -s $(uv run python -c \"import vibetuner; print(vibetuner.__path__[0])\")/templates/frontend .core-templates)",
+    "setup-tw-sources": "[ -d .core-templates ] && [ ! -L .core-templates ] || (rm -rf .core-templates && ln -s \"$(uv run python -c \"import vibetuner; print(vibetuner.__path__[0])\")/templates/frontend\" .core-templates)",
     "build:css": "bun tailwindcss -i config.css -o assets/statics/css/bundle.css",
     "build:js": "bun build config.js --outdir=assets/statics/js --entry-naming=\"bundle.[ext]\" --sourcemap",
     "dev:css": "bun tailwindcss -w -i config.css -o assets/statics/css/bundle.css",


### PR DESCRIPTION
## Summary
- Quotes the `$(uv run python ...)` command substitution in the `setup-tw-sources` script to prevent word-splitting when concurrent `uv` processes output extra content to stdout
- Without quoting, `ln -s` receives three arguments instead of two, interpreting `.core-templates` as a target directory

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)