### PR TITLE
feat: add OAuth relay for multi-app local development

### DIFF
--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -189,6 +189,11 @@ class CoreConfiguration(BaseSettings):
     # When set, vibetuner prints this URL on startup with {port} replaced by the actual port.
     localdev_url: str | None = None
 
+    # OAuth relay URL for shared redirect URI across multiple local apps.
+    # When set, OAuth flows use this stable URL instead of the app's own URL.
+    # Example: "https://oauth.localdev.alltuner.com:12000"
+    oauth_relay_url: str | None = None
+
     @cached_property
     def trusted_proxy_hosts_list(self) -> list[str]:
         """Parse trusted proxy hosts into a list for Granian's proxy header wrapper."""


### PR DESCRIPTION
## Summary

- Adds `OAUTH_RELAY_URL` setting to `CoreConfiguration` for routing all OAuth flows through a single stable redirect URI
- Modifies the OAuth login handler to set a `_oauth_source_port` cookie on the parent domain and use the relay URL as `redirect_uri` when configured
- No changes to the callback handler — Authlib reads `redirect_uri` from the session so the token exchange matches automatically

## How it works

All local apps send Google the same redirect URI (`https://oauth.localdev.alltuner.com:12000/auth/provider/google`). A Caddy handler on that hostname reads the `_oauth_source_port` cookie and 302-redirects the callback back to the originating app's port.

## Configuration

Each app's `.env`:
```
OAUTH_RELAY_URL=https://oauth.localdev.alltuner.com:12000
```

Google Cloud Console: register one redirect URI `https://oauth.localdev.alltuner.com:12000/auth/provider/google`.

## Test plan

- [ ] Start an app with `OAUTH_RELAY_URL` set, verify Google login redirects through the relay and lands back on the app
- [ ] Start a second app on a different port with the same setting, verify it also works without registering a new redirect URI
- [ ] Verify apps without `OAUTH_RELAY_URL` set continue to use `request.url_for()` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)