### PR TITLE
fix: skip OAuth relay URL in production environment

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -263,7 +263,7 @@ def _create_auth_login_handler(provider_name: str):
         if not client:
             return RedirectResponse(url=get_homepage_url(request))
 
-        if settings.oauth_relay_url:
+        if settings.oauth_relay_url and settings.environment == "dev":
             relay_url = settings.oauth_relay_url.rstrip("/")
             redirect_uri = f"{relay_url}/auth/provider/{provider_name}"
             response = await client.authorize_redirect(


### PR DESCRIPTION
## Summary
- Gate `OAUTH_RELAY_URL` usage on `environment == "dev"` so production apps use their own URL for OAuth callbacks instead of the dev relay
- The relay is a dev-only concept for sharing a stable callback URL across local apps behind a reverse proxy

## Test plan
- [ ] Deploy with `ENVIRONMENT=prod` and `OAUTH_RELAY_URL` set — verify OAuth redirects to the app's own `/auth/provider/{name}` endpoint
- [ ] Dev environment with `OAUTH_RELAY_URL` set — verify relay still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)