### PR TITLE
fix: use frozen lockfiles, enable bytecode compilation, remove git from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Install UV package manager from official image
 COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
 
-# Configure UV for optimal performance and behavior
-ENV UV_COMPILE_BYTECODE=0 \
+# Configure UV: pre-compile bytecode at build time for faster worker cold starts
+ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=0
 

--- a/vibetuner-template/.justfiles/deps.justfile
+++ b/vibetuner-template/.justfiles/deps.justfile
@@ -65,5 +65,5 @@ deps-scaffolding-pr:
 # Install dependencies from lockfiles
 [group('Dependencies')]
 install-deps:
-    @bun install
-    @uv sync --all-extras --all-groups
+    @bun install --frozen-lockfile
+    @uv sync --all-extras --all-groups --frozen

--- a/vibetuner-template/.justfiles/localdev.justfile
+++ b/vibetuner-template/.justfiles/localdev.justfile
@@ -25,8 +25,8 @@ worker-dev:
     @DEBUG=true uv run --frozen vibetuner run dev worker
 
 _ensure-deps:
-    @[ -d node_modules ] || bun install
-    @[ -d .venv ] || uv sync --all-extras
+    @[ -d node_modules ] || bun install --frozen-lockfile
+    @[ -d .venv ] || uv sync --all-extras --frozen
 
 # Runs local dev server and assets in parallel (auto-port)
 [group('Local Development')]

--- a/vibetuner-template/Dockerfile
+++ b/vibetuner-template/Dockerfile
@@ -7,18 +7,15 @@ ARG PYTHON_VERSION=3.14
 # ────────────────────────────────────────────────────────────────────────────────
 FROM python:${PYTHON_VERSION}-slim AS python-base
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean && \
-    apt-get update && apt-get install -y --no-install-recommends git
-
 # Install UV package manager from official image
 COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
 
-# Configure UV for optimal performance and behavior
-ENV UV_COMPILE_BYTECODE=0 \
+# Configure UV: pre-compile bytecode at build time for faster worker cold starts
+# ENVIRONMENT=prod ensures vibetuner skips dev-only git branch detection (no git binary needed)
+ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
-    UV_PYTHON_DOWNLOADS=0
+    UV_PYTHON_DOWNLOADS=0 \
+    ENVIRONMENT=prod
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- **#1245**: Add `--frozen` / `--frozen-lockfile` to `_ensure-deps` and `install-deps` recipes so
  dev commands never silently rewrite `uv.lock` after Release Please version bumps
- **#1246**: Set `UV_COMPILE_BYTECODE=1` in both Dockerfiles so `.pyc` files are pre-compiled at
  build time, giving faster worker cold starts in production
- **#1247**: Remove `apt-get install git` from template Dockerfile and add `ENVIRONMENT=prod` to
  the build stage ENV so vibetuner's dev-only GitPython codepath is never reached

## Test plan
- [ ] `just install-deps` uses frozen lockfiles (no `uv.lock` modifications)
- [ ] `just local-all` bootstraps without rewriting lockfiles
- [ ] Docker build succeeds without git in the template Dockerfile
- [ ] Production container starts correctly with pre-compiled bytecode

Closes #1245, closes #1246, closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)