### PR TITLE
fix: stage .pre-commit-config.yaml in update-and-commit-repo-deps

### DIFF
--- a/vibetuner-template/.justfiles/deps.justfile
+++ b/vibetuner-template/.justfiles/deps.justfile
@@ -9,9 +9,9 @@ update-repo-deps:
 # Update all dependencies and commit changes
 [group('Dependencies')]
 update-and-commit-repo-deps: update-repo-deps
-    @git add pyproject.toml uv.lock bun.lock package.json
+    @git add pyproject.toml uv.lock bun.lock package.json .pre-commit-config.yaml
     @git commit -m "chore: update dependencies" \
-        pyproject.toml uv.lock bun.lock package.json \
+        pyproject.toml uv.lock bun.lock package.json .pre-commit-config.yaml \
         || echo "No changes to commit"
 
 # Create PR with updated dependencies and scaffolding


### PR DESCRIPTION
## Summary
- Adds `.pre-commit-config.yaml` to the `git add` and `git commit` commands in `update-and-commit-repo-deps`
- Prevents commit failures when scaffolding updates modify `.pre-commit-config.yaml`

Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)