### PR TITLE
docs: update localdev port references from 12000 to 28000

### DIFF
--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -466,7 +466,7 @@ just local-all-with-worker
 uv run vibetuner run dev worker
 
 # Custom port for the monitoring UI
-uv run vibetuner run dev worker --port 12000
+uv run vibetuner run dev worker --port 20500
 ```
 
 In development mode, the worker runs with hot reload enabled. Code changes

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -206,14 +206,14 @@ A database (MongoDB or SQL) is required if using database features. Redis is onl
 Set `LOCALDEV_URL` in your `.env` to have vibetuner print an HTTPS URL on startup:
 
 ```bash
-LOCALDEV_URL=https://{port}.localdev.localhost:12000
+LOCALDEV_URL=https://{port}.localdev.localhost:28000
 ```
 
 The `{port}` placeholder is replaced with the actual port. Output on startup:
 
 ```
 website reachable at http://localhost:8124
-  https reachable at https://8124.localdev.localhost:12000
+  https reachable at https://8124.localdev.localhost:28000
 ```
 
 Use this with any local HTTPS reverse proxy (Caddy with wildcard certs, mkcert, etc.).

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -244,13 +244,13 @@ class CoreConfiguration(BaseSettings):
     # SECURITY: Only IPs in this list can set forwarded headers. Use "*" to trust all (NOT recommended for production)
     trusted_proxy_hosts: str = "127.0.0.1"
 
-    # Local HTTPS reverse proxy URL template (e.g., "https://{port}.localdev.localhost:12000")
+    # Local HTTPS reverse proxy URL template (e.g., "https://{port}.localdev.localhost:28000")
     # When set, vibetuner prints this URL on startup with {port} replaced by the actual port.
     localdev_url: str | None = None
 
     # OAuth relay URL for shared redirect URI across multiple local apps.
     # When set, OAuth flows use this stable URL instead of the app's own URL.
-    # Example: "https://oauth.localdev.alltuner.com:12000"
+    # Example: "https://oauth.localdev.alltuner.com:28000"
     oauth_relay_url: str | None = None
 
     @cached_property

--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -235,7 +235,7 @@ async def _create_new_user_with_oauth(
 def _get_relay_cookie_domain(relay_url: str) -> str:
     """Extract parent domain from relay URL for cookie sharing.
 
-    "https://oauth.localdev.alltuner.com:12000" -> ".localdev.alltuner.com"
+    "https://oauth.localdev.alltuner.com:28000" -> ".localdev.alltuner.com"
     """
     from urllib.parse import urlparse
 
@@ -248,7 +248,7 @@ def _get_relay_cookie_domain(relay_url: str) -> str:
 def _get_source_port(request: Request) -> str:
     """Extract the app port from the request host.
 
-    "8001.localdev.alltuner.com:12000" -> "8001"
+    "8001.localdev.alltuner.com:28000" -> "8001"
     """
     host = request.url.hostname or ""
     return host.split(".")[0]

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -931,7 +931,7 @@ DATABASE_URL=mongodb://localhost:27017/[dbname]
 REDIS_URL=redis://localhost:6379  # If background jobs enabled
 SECRET_KEY=your-secret-key
 DEBUG=true  # Development only
-LOCALDEV_URL=https://{port}.localdev.localhost:12000  # Optional: HTTPS reverse proxy
+LOCALDEV_URL=https://{port}.localdev.localhost:28000  # Optional: HTTPS reverse proxy
 ```
 
 #### LOCALDEV_URL
@@ -943,7 +943,7 @@ clickable HTTPS URLs without manual port mapping:
 ```text
 Starting frontend in dev mode on 0.0.0.0:8124
 website reachable at http://localhost:8124
-  https reachable at https://8124.localdev.localhost:12000
+  https reachable at https://8124.localdev.localhost:28000
 ```
 
 ### Pydantic Settings


### PR DESCRIPTION
## Summary
- Update all localdev port references from 12000 to 28000 in config comments, docstrings, template docs, and LLM docs
- Change worker port example from `--port 12000` to `--port 20500` (12000 is now in the frontend auto-calc range)

Companion to alltuner/localdev#3 which moved the Caddy listen port and widened the upstream regex to 8000-17999.

## Test plan
- [ ] Verify no remaining `12000` references in the codebase (outside stale worktrees)
- [ ] Scaffold a new project and confirm AGENTS.md/CLAUDE.md show port 28000

🤖 Generated with [Claude Code](https://claude.com/claude-code)