### PR TITLE
fix: remove invalid --optional-scopes and fix arg ordering in conventional-pre-commit hook

### DIFF
--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
         stages: [commit-msg]
         args:
           [
+            --strict,
             feat,
             fix,
             docs,
@@ -52,8 +53,6 @@ repos:
             build,
             ci,
             chore,
-            --optional-scopes,
-            --strict,
           ]
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
- Removed `--optional-scopes` flag which was never valid in any version of `conventional-pre-commit`
- Moved `--strict` before positional type args to fix a Python argparse ordering issue where the
  COMMIT_EDITMSG path was rejected as "unrecognized arguments"

The hook was broken in all repos (not just worktrees) — the `--optional-scopes` error masked the
ordering bug underneath.

Closes #1273

## Test plan
- [x] Verified `prek run conventional-pre-commit --hook-stage commit-msg` passes after the fix
- [x] Tested `conventional-pre-commit` directly with various arg orderings to confirm root cause


🤖 Generated with [Claude Code](https://claude.com/claude-code)