### PR TITLE
feat: replace localdev_url with tailscale expose recipes

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -201,22 +201,10 @@ just local-dev
 
 A database (MongoDB or SQL) is required if using database features. Redis is only required if background jobs are enabled.
 
-**HTTPS via Local Reverse Proxy**
+**HTTPS via Tailscale Expose**
 
-Set `LOCALDEV_URL` in your `.env` to have vibetuner print an HTTPS URL on startup:
-
-```bash
-LOCALDEV_URL=https://{port}.localdev.localhost:28000
-```
-
-The `{port}` placeholder is replaced with the actual port. Output on startup:
-
-```
-website reachable at http://localhost:8124
-  https reachable at https://8124.localdev.localhost:28000
-```
-
-Use this with any local HTTPS reverse proxy (Caddy with wildcard certs, mkcert, etc.).
+Use `just dev-exposed` to run the dev server with HTTPS via Tailscale Serve.
+This wraps `just local-all` with automatic tailscale serve setup/teardown.
 
 #### Adding New Routes
 

--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -81,12 +81,6 @@ def _run_frontend(
     console.print(f"[green]Starting frontend in {mode} mode on {host}:{port}[/green]")
     console.print(f"[cyan]website reachable at http://localhost:{port}[/cyan]")
 
-    from vibetuner.config import settings
-
-    if settings.localdev_url:
-        https_url = settings.localdev_url.replace("{port}", str(port))
-        console.print(f"[cyan]  https reachable at {https_url}[/cyan]")
-
     if is_dev:
         console.print("[dim]Watching for changes in src/ and templates/[/dim]")
     else:

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -244,10 +244,6 @@ class CoreConfiguration(BaseSettings):
     # SECURITY: Only IPs in this list can set forwarded headers. Use "*" to trust all (NOT recommended for production)
     trusted_proxy_hosts: str = "127.0.0.1"
 
-    # Local HTTPS reverse proxy URL template (e.g., "https://{port}.localdev.localhost:28000")
-    # When set, vibetuner prints this URL on startup with {port} replaced by the actual port.
-    localdev_url: str | None = None
-
     # OAuth relay URL for shared redirect URI across multiple local apps.
     # When set, OAuth flows use this stable URL instead of the app's own URL.
     # Example: "https://oauth.localdev.alltuner.com:28000"

--- a/vibetuner-template/.justfiles/expose.justfile
+++ b/vibetuner-template/.justfiles/expose.justfile
@@ -1,0 +1,25 @@
+# Runs local-all with HTTPS exposed via Tailscale Serve
+[group('Local Development')]
+dev-exposed: _ensure-deps
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Resolve port: DEV_PORT env, or auto-calculate via Python
+    PORT="${DEV_PORT:-$(uv run --frozen python -c "from vibetuner.config import settings; print(settings.resolved_port)")}"
+
+    # Start tailscale serve in background
+    tailscale serve --bg --https="$PORT" "http://localhost:$PORT"
+
+    # Extract hostname from tailscale status
+    HOSTNAME=$(tailscale status --json | uv run --frozen python -c "import sys,json; print(json.load(sys.stdin)['Self']['DNSName'].rstrip('.'))")
+    EXPOSE_URL="https://${HOSTNAME}:${PORT}"
+
+    echo ""
+    echo "🔒 HTTPS reachable at $EXPOSE_URL"
+    echo ""
+
+    # Ensure we clean up on exit
+    trap "tailscale serve --https=$PORT off; echo ''; echo 'Tailscale serve stopped.'" EXIT
+
+    # Run local-all (server + assets)
+    just local-all

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -931,19 +931,6 @@ DATABASE_URL=mongodb://localhost:27017/[dbname]
 REDIS_URL=redis://localhost:6379  # If background jobs enabled
 SECRET_KEY=your-secret-key
 DEBUG=true  # Development only
-LOCALDEV_URL=https://{port}.localdev.localhost:28000  # Optional: HTTPS reverse proxy
-```
-
-#### LOCALDEV_URL
-
-When set, vibetuner prints an additional HTTPS URL on startup with `{port}` replaced by
-the actual port. Use this with a local HTTPS reverse proxy (Caddy, nginx, mkcert) to get
-clickable HTTPS URLs without manual port mapping:
-
-```text
-Starting frontend in dev mode on 0.0.0.0:8124
-website reachable at http://localhost:8124
-  https reachable at https://8124.localdev.localhost:28000
 ```
 
 ### Pydantic Settings

--- a/vibetuner-template/justfile
+++ b/vibetuner-template/justfile
@@ -3,6 +3,7 @@ _default:
 
 import '.justfiles/helpers.justfile'
 import '.justfiles/localdev.justfile'
+import '.justfiles/expose.justfile'
 import '.justfiles/cicd.justfile'
 import '.justfiles/i18n.justfile'
 import '.justfiles/linting.justfile'


### PR DESCRIPTION
## Summary

- Remove `localdev_url` config field from `CoreConfiguration` and its startup printing
  logic in `vibetuner run dev`
- Add `just dev-exposed` justfile recipe to scaffold template — wraps `just local-all`
  with automatic `tailscale serve` setup/teardown
- Update docs (AGENTS.md, llms-full.txt) to reflect the new approach
- Keep `oauth_relay_url` as-is for OAuth redirect flows

## How `just dev-exposed` works

1. Resolves port from `DEV_PORT` env or Python auto-calc
2. Runs `tailscale serve --bg --https=$PORT http://localhost:$PORT`
3. Extracts hostname from `tailscale status --json`
4. Prints the HTTPS URL
5. Starts `just local-all` (server + assets)
6. On exit (trap), runs `tailscale serve --https=$PORT off`

Closes #1265, closes #1270, closes #1276

## Test plan

- [ ] Verify `vibetuner run dev` no longer prints localdev URL
- [ ] Verify `LOCALDEV_URL` env var is ignored (no crash, just unused)
- [ ] Scaffold a new project, verify `just dev-exposed` is available
- [ ] Test `just dev-exposed` on a tailscale-connected machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)