### PR TITLE
fix: bind to localhost only in dev-exposed to avoid port conflict

### DIFF
--- a/vibetuner-template/.justfiles/expose.justfile
+++ b/vibetuner-template/.justfiles/expose.justfile
@@ -21,5 +21,5 @@ dev-exposed: _ensure-deps
     # Ensure we clean up on exit
     trap "tailscale serve --https=$PORT off; echo ''; echo 'Tailscale serve stopped.'" EXIT
 
-    # Run local-all (server + assets)
-    just local-all
+    # Run local-all bound to localhost only (tailscale handles the tailnet interface)
+    just local-all 127.0.0.1

--- a/vibetuner-template/.justfiles/localdev.justfile
+++ b/vibetuner-template/.justfiles/localdev.justfile
@@ -11,8 +11,8 @@ dev:
 
 # Runs the dev environment locally without Docker
 [group('Local Development')]
-local-dev:
-    @DEBUG=true uv run --frozen vibetuner run dev
+local-dev host="0.0.0.0":
+    @DEBUG=true uv run --frozen vibetuner run dev --host {{ host }}
 
 # Runs the task worker locally without Docker
 [group('Local Development')]
@@ -25,11 +25,11 @@ _ensure-deps:
 
 # Runs local dev server and assets in parallel
 [group('Local Development')]
-local-all: _ensure-deps
+local-all host="0.0.0.0": _ensure-deps
     bunx concurrently --kill-others \
         --names "web,assets" \
         --prefix-colors "blue,green" \
-        "just local-dev" \
+        "just local-dev {{ host }}" \
         "bun dev"
 
 # Runs local dev server, assets, and worker in parallel (requires Redis)


### PR DESCRIPTION
## Summary

`tailscale serve --https=PORT` binds to the tailnet interface on the same port,
conflicting with granian's default `0.0.0.0` binding. Fix by passing `--host 127.0.0.1`
so the app only listens on localhost while tailscale handles the tailnet HTTPS traffic.

## Test plan

- [ ] Run `just dev-exposed` — should no longer get "Address already in use"
- [ ] Verify app is reachable at the tailscale HTTPS URL
- [ ] Verify localhost:PORT also works for local access

🤖 Generated with [Claude Code](https://claude.com/claude-code)