### PR TITLE
feat: encode tailnet target in OAuth state for relay redirect

### DIFF
--- a/vibetuner-template/.justfiles/expose.justfile
+++ b/vibetuner-template/.justfiles/expose.justfile
@@ -21,5 +21,8 @@ dev-exposed: _ensure-deps
     # Ensure we clean up on exit
     trap "tailscale serve --https=$PORT off; echo ''; echo 'Tailscale serve stopped.'" EXIT
 
+    # Export expose URL so vibetuner can encode it in OAuth state params
+    export EXPOSE_URL
+
     # Run local-all bound to localhost only (tailscale handles the tailnet interface)
     just local-all 127.0.0.1


### PR DESCRIPTION
## Summary

- Replace cookie-based OAuth relay with state-param approach
- When `EXPOSE_URL` is set, the OAuth state is wrapped as `{host}:{port}|{original_state}`
  so the tailnet relay can redirect back to the correct dev app
- Export `EXPOSE_URL` from `just dev-exposed` so Python can read it
- Remove old cookie-based helpers (`_get_relay_cookie_domain`, `_get_source_port`)

## Test plan

- [ ] Run `just dev-exposed` in a project with OAuth configured
- [ ] Click login — should redirect to Google with wrapped state
- [ ] Google redirects to relay → relay redirects back to app → login completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)