### PR TITLE
refactor: constrain dev_port and worker_port to unprivileged port range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,18 @@ just lint-yaml               # Lint YAML with dprint
 just type-check              # Type check Python with ty
 ```
 
+### Testing (vibetuner-py)
+
+Dev dependencies (pytest, pytest-asyncio) are declared as an optional extra in
+`vibetuner-py/pyproject.toml`. You must install them before running tests:
+
+```bash
+cd vibetuner-py
+uv sync --extra dev
+uv run python -m pytest tests/          # run all tests
+uv run python -m pytest tests/unit/     # run unit tests only
+```
+
 ### Template Management
 
 ```bash

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -50,6 +50,8 @@ class SQLiteDsn(AnyUrl):
 
 current_year: int = datetime.now().year
 
+UnprivilegedPort = Annotated[int, Field(ge=1024, le=65535)]
+
 
 class SecurityHeadersSettings(BaseSettings):
     """Settings for built-in security headers middleware.
@@ -201,8 +203,8 @@ class CoreConfiguration(BaseSettings):
     worker_concurrency: int = 16
 
     # Port configuration (read from DEV_PORT / WORKER_PORT env or .env.local)
-    dev_port: int | None = None
-    worker_port: int | None = None
+    dev_port: UnprivilegedPort | None = None
+    worker_port: UnprivilegedPort | None = None
 
     @staticmethod
     def _compute_auto_port(path: str | None = None) -> int:


### PR DESCRIPTION
## Summary
- Add `UnprivilegedPort` type alias (`Annotated[int, Field(ge=1024, le=65535)]`) to reject
  invalid or privileged ports at config load time
- Apply to `dev_port` and `worker_port` in `CoreConfiguration`
- Add parametrized tests for validation (privileged, above-max, valid, boundary)
- Document how to run `vibetuner-py` tests with dev extras in CLAUDE.md

Closes #1287

## Test plan
- [x] All 19 tests pass including 8 new validation tests
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)