### PR TITLE
fix: add --frozen flag to uv run in setup-tw-sources script

### DIFF
--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "setup-tw-sources": "[ -d .core-templates ] && [ ! -L .core-templates ] || (rm -rf .core-templates && ln -s \"$(uv run python -c \"import vibetuner; print(vibetuner.__path__[0])\")/templates/frontend\" .core-templates)",
+    "setup-tw-sources": "[ -d .core-templates ] && [ ! -L .core-templates ] || (rm -rf .core-templates && ln -s \"$(uv run --frozen python -c \"import vibetuner; print(vibetuner.__path__[0])\")/templates/frontend\" .core-templates)",
     "build:css": "bun tailwindcss -i config.css -o assets/statics/css/bundle.css",
     "build:js": "bun build config.js --outdir=assets/statics/js --entry-naming=\"bundle.[ext]\" --sourcemap",
     "dev:css": "bun tailwindcss -w -i config.css -o assets/statics/css/bundle.css",


### PR DESCRIPTION
## Summary
- Adds `--frozen` flag to the `uv run python` call in the `setup-tw-sources` script in
  `vibetuner-template/package.json`
- Prevents `uv.lock` from being silently regenerated when `pyproject.toml` and `uv.lock`
  versions drift (e.g., after a Release Please version bump)

Closes #1305

## Test plan
- [ ] Scaffold a new project, bump the version in `pyproject.toml` without updating `uv.lock`
- [ ] Run `bun dev` and verify `uv.lock` is not modified
- [ ] Verify the `setup-tw-sources` symlink is still created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)