### PR TITLE
fix: use lint-po fork with gettext plural form support

### DIFF
--- a/vibetuner-template/.justfiles/linting.justfile
+++ b/vibetuner-template/.justfiles/linting.justfile
@@ -26,7 +26,7 @@ lint-yaml:
 # Lint PO translation files with lint-po
 [group('Code quality: linting')]
 lint-po:
-    @bash -c 'shopt -s nullglob; files=(locales/*/LC_MESSAGES/*.po); if (( ${#files[@]} )); then uvx lint-po "${files[@]}"; else echo "No .po files to lint"; fi'
+    @bash -c 'shopt -s nullglob; files=(locales/*/LC_MESSAGES/*.po); if (( ${#files[@]} )); then uvx --from "git+https://github.com/davidpoblador/lint-po@support-gettext-plural-forms" lint-po "${files[@]}"; else echo "No .po files to lint"; fi'
 
 # Type check Python files with ty
 [group('Code quality: linting')]

--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -58,6 +58,6 @@ repos:
     hooks:
       - id: lint-po
         name: lint-po
-        entry: uvx lint-po
+        entry: uvx --from "git+https://github.com/davidpoblador/lint-po@support-gettext-plural-forms" lint-po
         language: system
         files: \.po$


### PR DESCRIPTION
The upstream `lint-po` package doesn't handle `msgid_plural` / `msgstr[N]`, causing false positives on any `.po` file with plural entries.

This points the pre-commit hook and justfile to a fork with the fix until the upstream PR lands: https://github.com/himdel/lint-po/pull/3

Closes #1312