### PR TITLE
fix: use --watch=always to prevent tailwindcss watcher from dying silently

### DIFF
--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -7,7 +7,7 @@
     "setup-tw-sources": "[ -d .core-templates ] && [ ! -L .core-templates ] || (rm -rf .core-templates && ln -s \"$(uv run --frozen python -c \"import vibetuner; print(vibetuner.__path__[0])\")/templates/frontend\" .core-templates)",
     "build:css": "bun tailwindcss -i config.css -o assets/statics/css/bundle.css",
     "build:js": "bun build config.js --outdir=assets/statics/js --entry-naming=\"bundle.[ext]\" --sourcemap",
-    "dev:css": "bun tailwindcss -w -i config.css -o assets/statics/css/bundle.css",
+    "dev:css": "bun tailwindcss -w=always -i config.css -o assets/statics/css/bundle.css",
     "dev:js": "bun build config.js --watch --outdir=assets/statics/js --entry-naming=\"bundle.[ext]\" --sourcemap",
     "dev": "bun run --sequential setup-tw-sources build:js build:css && bun run --parallel dev:css dev:js",
     "build-prod:css": "bun run setup-tw-sources && bun tailwindcss -i config.css --minify -o assets/statics/css/bundle.css",


### PR DESCRIPTION
## Summary

- Use `--watch=always` flag in the template's `dev:css` script to prevent the tailwindcss
  watcher from exiting when stdin is closed by `bun run --parallel`

## Root Cause

The tailwindcss CLI uses stdin closure as a signal to exit cleanly. When spawned via
`bun run --parallel`, stdin is not connected to child processes (it's piped/closed rather
than being a TTY). The watcher detects the closed stdin, interprets it as "parent is gone",
and exits with code 0 immediately after the first build. Meanwhile `bun build --watch`
(esbuild) doesn't use stdin as a lifecycle signal, so it survives.

The `--watch=always` flag was added to tailwindcss specifically for this class of problem
(tailwindlabs/tailwindcss#8517, tailwindlabs/tailwindcss#9966).

Closes #1313

## Test plan

- [ ] Run `bun dev` and verify the tailwindcss watcher stays alive
- [ ] Edit `config.css` or a template file and confirm CSS is rebuilt automatically
- [ ] Run `just local-all` and verify everything still works
- [ ] Check `ps aux | grep tailwind` confirms the process is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)