### PR TITLE
docs: fix settings import and improve configuration documentation

### DIFF
--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -53,6 +53,31 @@ or ergonomic improvements:
 
 ---
 
+## Project Learnings (`LEARNINGS.md`)
+
+If a `LEARNINGS.md` file exists in the project root, **read it before starting work**.
+It contains hard-won lessons from previous sessions — workarounds, gotchas, patterns
+that work well in this specific project. Following it avoids re-discovering things the
+hard way.
+
+**Contributing learnings**: When you discover something non-obvious through trial and
+error — a quirk of this codebase, a pattern that works better than the obvious approach,
+a subtle bug you debugged — add it to `LEARNINGS.md`. This saves future agents (and
+developers) from repeating the same investigation.
+
+**Format guidelines**:
+
+- Keep entries as short bullet points — one or two lines each
+- Add a date to each entry so stale learnings can be identified (e.g.,
+  `- 2026-02-27: Beanie indexes must be ...`)
+- Group related learnings under simple headings if the file grows
+- **Proactively remove learnings that have aged poorly** — if a workaround is no longer
+  needed or a pattern has changed, delete it rather than letting the file accumulate
+  outdated advice
+- This is not a changelog — only record things that would save someone time
+
+---
+
 ## Python Tooling
 
 **IMPORTANT**: `uv` is the sole Python tool for this project. Never use `python`, `python3`, `pip`,


### PR DESCRIPTION
## Summary

- Fix incorrect `project_settings` import in template AGENTS.md — the actual export is
  `settings` from `vibetuner.config`, not `project_settings`
- Document commonly-needed `CoreConfiguration` fields (`environment`, `expose_url`,
  `oauth_relay_url`, `resolved_port`, etc.) alongside project-level settings
- Clarify the distinction between `CoreConfiguration` (top-level `settings`) and
  `ProjectConfiguration` (`settings.project`)
- Add clear encouragement for users and AI agents to file issues for ergonomic
  improvements at alltuner/vibetuner

Closes #1318

## Test plan

- [ ] Verify the documented import `from vibetuner.config import settings` works correctly
- [ ] Verify all documented fields exist on `CoreConfiguration` and `ProjectConfiguration`
- [ ] Check markdown renders correctly in GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)