### PR TITLE
chore: switch lint-po back to upstream repo

### DIFF
--- a/vibetuner-template/.justfiles/linting.justfile
+++ b/vibetuner-template/.justfiles/linting.justfile
@@ -26,7 +26,7 @@ lint-yaml:
 # Lint PO translation files with lint-po
 [group('Code quality: linting')]
 lint-po:
-    @bash -c 'shopt -s nullglob; files=(locales/*/LC_MESSAGES/*.po); if (( ${#files[@]} )); then uvx --from "git+https://github.com/davidpoblador/lint-po@support-gettext-plural-forms" lint-po "${files[@]}"; else echo "No .po files to lint"; fi'
+    @bash -c 'shopt -s nullglob; files=(locales/*/LC_MESSAGES/*.po); if (( ${#files[@]} )); then uvx --from "git+https://github.com/himdel/lint-po" lint-po "${files[@]}"; else echo "No .po files to lint"; fi'
 
 # Type check Python files with ty
 [group('Code quality: linting')]

--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -58,6 +58,6 @@ repos:
     hooks:
       - id: lint-po
         name: lint-po
-        entry: uvx --from "git+https://github.com/davidpoblador/lint-po@support-gettext-plural-forms" lint-po
+        entry: uvx --from "git+https://github.com/himdel/lint-po" lint-po
         language: system
         files: \.po$


### PR DESCRIPTION
## Summary
- Switch `lint-po` dependency from our fork (`davidpoblador/lint-po@support-gettext-plural-forms`) back to upstream (`himdel/lint-po`)
- The gettext plural form support feature has landed upstream: https://github.com/himdel/lint-po/pull/3
- Still using `git+` install since it hasn't been released to PyPI yet

## Test plan
- [ ] Verify `lint-po` runs correctly against `.po` files with plural forms using the upstream repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)