### PR TITLE
docs: move ad-hoc database operations to template AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,35 +163,6 @@ uv run python -m pytest tests/unit/     # run unit tests only
 just update-frontend-templates  # Sync frontend templates and commit changes
 ```
 
-## Ad-hoc Database Operations
-
-For one-off database scripts (backfills, migrations, data fixes):
-
-```python
-import asyncio
-from beanie import init_beanie
-from pymongo import AsyncMongoClient
-from vibetuner.config import settings
-
-async def run():
-    client = AsyncMongoClient(str(settings.mongodb_url))
-    db = client[settings.project.project_slug]
-    await init_beanie(database=db, document_models=[YourModel])
-
-    # Use Beanie queries or raw pymongo:
-    col = YourModel.get_pymongo_collection()
-    result = await col.update_many(filter, update)
-
-asyncio.run(run())
-```
-
-**Important**: This project uses `pymongo` (not `motor`). Use `AsyncMongoClient`
-from `pymongo`, and `get_pymongo_collection()` on Beanie documents.
-
-**Gotcha**: Existing documents may have `None` for fields that have defaults in
-Pydantic models. When querying by such fields, include `None` in your filter
-(e.g., `{"status": {"$in": [None, "draft"]}}`).
-
 ## Markdown Line Length
 
 This project enforces a **120 character line limit** for markdown files using `rumdl`.

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -1154,6 +1154,35 @@ on real-world usage, and your feedback helps us prioritize what to fix next.
 This applies to both **developers** and **AI agents**: if these instructions were unclear,
 incomplete, or caused a mistake, that's a vibetuner bug we want to hear about.
 
+## Ad-hoc Database Operations
+
+For one-off database scripts (backfills, migrations, data fixes):
+
+```python
+import asyncio
+from beanie import init_beanie
+from pymongo import AsyncMongoClient
+from vibetuner.config import settings
+
+async def run():
+    client = AsyncMongoClient(str(settings.mongodb_url))
+    db = client[settings.project.project_slug]
+    await init_beanie(database=db, document_models=[YourModel])
+
+    # Use Beanie queries or raw pymongo:
+    col = YourModel.get_pymongo_collection()
+    result = await col.update_many(filter, update)
+
+asyncio.run(run())
+```
+
+**Important**: This project uses `pymongo` (not `motor`). Use `AsyncMongoClient`
+from `pymongo`, and `get_pymongo_collection()` on Beanie documents.
+
+**Gotcha**: Existing documents may have `None` for fields that have defaults in
+Pydantic models. When querying by such fields, include `None` in your filter
+(e.g., `{"status": {"$in": [None, "draft"]}}`).
+
 ## Custom Project Instructions
 
 Add project-specific notes here.


### PR DESCRIPTION
## Summary
- Moved the "Ad-hoc Database Operations" section (pymongo/motor guidance, Beanie gotchas) from root `AGENTS.md` to `vibetuner-template/AGENTS.md`
- This content is relevant to users of scaffolded projects, not vibetuner repo maintainers

## Test plan
- [ ] Verify root `AGENTS.md` no longer contains database operations section
- [ ] Verify `vibetuner-template/AGENTS.md` includes the section before "Custom Project Instructions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)