### PR TITLE
feat: add response caching decorator with shared Redis client

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -499,7 +499,48 @@ Available helpers: `hx_redirect`, `hx_location`, `hx_trigger`,
 
 JSON serialization is handled internally — you never need to call `json.dumps()`.
 
-### Cache Control Headers
+### Response Caching (Server-Side)
+
+Use the `@cache` decorator to cache route responses in Redis with a configurable TTL.
+This is ideal for expensive queries, aggregation endpoints, or rendered pages that
+don't change on every request:
+
+```python
+from vibetuner.cache import cache
+
+@router.get("/api/stats")
+@cache(expire=60)  # cache for 60 seconds
+async def get_stats(request: Request):
+    return {"users": await count_users()}
+```
+
+The decorator uses vibetuner's existing Redis connection — no extra setup required
+if you already have `REDIS_URL` configured.
+
+**Key features:**
+
+- Cache key derived from route path + sorted query parameters
+- Respects `Cache-Control: no-cache` request header (bypasses cache)
+- Works with JSON, HTML, and dict responses
+- **Disabled by default in debug mode** — pass `force_caching=True` to override
+- If Redis is not configured or unavailable, the decorator is a transparent no-op
+
+**Cache invalidation:**
+
+```python
+from vibetuner.cache import invalidate, invalidate_pattern
+
+# Invalidate a specific path
+await invalidate("/api/stats")
+
+# Invalidate a specific query variant
+await invalidate("/api/stats", query_params="page=1")
+
+# Invalidate all matching paths (uses Redis SCAN)
+await invalidate_pattern("/api/*")
+```
+
+### Cache Control Headers (Browser-Side)
 
 Use the `@cache_control` decorator to set `Cache-Control` HTTP headers declaratively
 instead of manually manipulating response headers:
@@ -515,6 +556,17 @@ async def static_page(request: Request):
 
 Supported directives: `public`, `private`, `no_cache`, `no_store`, `max_age`,
 `s_maxage`, `must_revalidate`, `stale_while_revalidate`, `immutable`.
+
+You can combine both decorators — `@cache` for server-side Redis caching and
+`@cache_control` for browser-side HTTP caching:
+
+```python
+@router.get("/api/stats")
+@cache(expire=60)
+@cache_control(max_age=30, public=True)
+async def get_stats(request: Request):
+    return {"users": await count_users()}
+```
 
 ### Block Rendering for HTMX Partials
 

--- a/vibetuner-py/src/vibetuner/cache.py
+++ b/vibetuner-py/src/vibetuner/cache.py
@@ -1,0 +1,277 @@
+# ABOUTME: Response caching decorator backed by Redis.
+# ABOUTME: Provides @cache for server-side route caching and invalidate() for cache busting.
+import functools
+import hashlib
+import inspect
+import json
+from collections.abc import Callable
+from typing import Any
+
+from vibetuner.logging import logger
+
+
+def _build_cache_key(prefix: str, path: str, query_params: str) -> str:
+    """Build a deterministic Redis key from route path and query string."""
+    raw = f"{path}?{query_params}" if query_params else path
+    key_hash = hashlib.sha256(raw.encode()).hexdigest()[:16]
+    return f"{prefix}cache:{key_hash}:{raw}"
+
+
+def cache(
+    expire: int = 60,
+    *,
+    force_caching: bool = False,
+) -> Callable:
+    """Decorator that caches route responses in Redis with a TTL.
+
+    Cached responses are stored as JSON in Redis, keyed by route path and
+    sorted query parameters.  When Redis is unavailable or not configured
+    the decorator is a transparent no-op — the handler executes normally.
+
+    In debug mode caching is **disabled by default** to avoid stale-data
+    confusion during development.  Pass ``force_caching=True`` to override.
+
+    Respects the ``Cache-Control: no-cache`` request header: when present
+    the cache is bypassed and the response is regenerated (and re-stored).
+
+    Args:
+        expire: Time-to-live in seconds for the cached response.
+        force_caching: Enable caching even when ``DEBUG`` is ``True``.
+
+    Example::
+
+        from vibetuner.cache import cache
+
+        @router.get("/api/stats")
+        @cache(expire=60)
+        async def get_stats():
+            return {"users": await count_users()}
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            from vibetuner.config import settings
+
+            if settings.debug and not force_caching:
+                return await _call_handler(func, *args, **kwargs)
+
+            if settings.redis_url is None:
+                return await _call_handler(func, *args, **kwargs)
+
+            request = _extract_request(args, kwargs, func)
+            if request is None:
+                return await _call_handler(func, *args, **kwargs)
+
+            return await _cached_call(func, args, kwargs, request, expire)
+
+        return wrapper
+
+    return decorator
+
+
+async def _cached_call(
+    func: Callable,
+    args: tuple,
+    kwargs: dict,
+    request: Any,
+    expire: int,
+) -> Any:
+    """Execute the handler with Redis caching, falling back on errors."""
+    from vibetuner.config import settings
+    from vibetuner.redis import get_redis_client, reset_redis_client
+
+    no_cache = request.headers.get("cache-control", "") == "no-cache"
+    sorted_qs = "&".join(f"{k}={v}" for k, v in sorted(request.query_params.items()))
+    cache_key = _build_cache_key(settings.redis_key_prefix, request.url.path, sorted_qs)
+
+    try:
+        client = await get_redis_client()
+        if client is None:
+            return await _call_handler(func, *args, **kwargs)
+
+        if not no_cache:
+            cached = await client.get(cache_key)
+            if cached is not None:
+                return _restore_response(cached)
+
+        response = await _call_handler(func, *args, **kwargs)
+
+        serialized = _serialize_response(response)
+        if serialized is not None:
+            await client.set(cache_key, serialized, ex=expire)
+
+        return response
+
+    except (ConnectionError, OSError, TimeoutError):
+        logger.debug("Redis cache unavailable, executing handler directly")
+        reset_redis_client()
+        return await _call_handler(func, *args, **kwargs)
+    except Exception:
+        logger.debug("Redis cache error, executing handler directly")
+        return await _call_handler(func, *args, **kwargs)
+
+
+async def invalidate(path: str, *, query_params: str = "") -> bool:
+    """Remove a cached response by route path.
+
+    Args:
+        path: The URL path to invalidate (e.g. ``"/api/stats"``).
+        query_params: Optional sorted query string to target a specific variant.
+
+    Returns:
+        ``True`` if a cached entry was deleted, ``False`` otherwise.
+    """
+    try:
+        from vibetuner.config import settings
+        from vibetuner.redis import get_redis_client
+
+        client = await get_redis_client()
+        if client is None:
+            return False
+
+        cache_key = _build_cache_key(settings.redis_key_prefix, path, query_params)
+        deleted = await client.delete(cache_key)
+        return deleted > 0
+    except (ConnectionError, OSError, TimeoutError):
+        logger.debug("Redis unavailable during cache invalidation")
+        return False
+    except Exception:
+        logger.debug("Cache invalidation failed")
+        return False
+
+
+async def invalidate_pattern(pattern: str) -> int:
+    """Remove all cached responses matching a key pattern.
+
+    Uses Redis ``SCAN`` to find matching keys without blocking.
+
+    Args:
+        pattern: Glob pattern relative to the cache namespace
+            (e.g. ``"/api/*"``).
+
+    Returns:
+        Number of keys deleted.
+    """
+    try:
+        from vibetuner.config import settings
+        from vibetuner.redis import get_redis_client
+
+        client = await get_redis_client()
+        if client is None:
+            return 0
+
+        full_pattern = f"{settings.redis_key_prefix}cache:*:{pattern}"
+        deleted = 0
+        async for key in client.scan_iter(match=full_pattern, count=100):
+            await client.delete(key)
+            deleted += 1
+        return deleted
+    except (ConnectionError, OSError, TimeoutError):
+        logger.debug("Redis unavailable during pattern invalidation")
+        return 0
+    except Exception:
+        logger.debug("Pattern invalidation failed")
+        return 0
+
+
+# ── Internal helpers ────────────────────────────────────────────────
+
+
+async def _call_handler(func: Callable, *args: Any, **kwargs: Any) -> Any:
+    """Call the route handler, supporting both sync and async functions."""
+    if inspect.iscoroutinefunction(func):
+        return await func(*args, **kwargs)
+    return func(*args, **kwargs)
+
+
+def _extract_request(args: tuple, kwargs: dict, func: Callable):
+    """Find the Request object from route arguments."""
+    # Check kwargs first (FastAPI typically passes as keyword)
+    from starlette.requests import Request
+
+    for v in kwargs.values():
+        if isinstance(v, Request):
+            return v
+    for v in args:
+        if isinstance(v, Request):
+            return v
+    return None
+
+
+def _serialize_response(response: Any) -> bytes | None:
+    """Serialize a response for Redis storage."""
+    from starlette.responses import HTMLResponse, JSONResponse, Response
+
+    if isinstance(response, JSONResponse):
+        return json.dumps(
+            {
+                "type": "json",
+                "body": response.body.decode(),
+                "status": response.status_code,
+            }
+        ).encode()
+
+    if isinstance(response, HTMLResponse):
+        return json.dumps(
+            {
+                "type": "html",
+                "body": response.body.decode(),
+                "status": response.status_code,
+            }
+        ).encode()
+
+    if isinstance(response, Response) and hasattr(response, "body"):
+        content_type = response.headers.get("content-type", "")
+        return json.dumps(
+            {
+                "type": "response",
+                "body": response.body.decode(),
+                "status": response.status_code,
+                "content_type": content_type,
+            }
+        ).encode()
+
+    # Dict responses (FastAPI auto-serializes these)
+    if isinstance(response, dict):
+        return json.dumps(
+            {
+                "type": "dict",
+                "body": json.dumps(response),
+            }
+        ).encode()
+
+    return None
+
+
+def _restore_response(cached: bytes) -> Any:
+    """Deserialize a cached response back into a Starlette response or dict."""
+    from starlette.responses import HTMLResponse, Response
+
+    data = json.loads(cached)
+    resp_type = data["type"]
+
+    if resp_type == "json":
+        return Response(
+            content=data["body"],
+            status_code=data.get("status", 200),
+            media_type="application/json",
+        )
+
+    if resp_type == "html":
+        return HTMLResponse(
+            content=data["body"],
+            status_code=data.get("status", 200),
+        )
+
+    if resp_type == "response":
+        return Response(
+            content=data["body"],
+            status_code=data.get("status", 200),
+            media_type=data.get("content_type", "text/plain"),
+        )
+
+    if resp_type == "dict":
+        return json.loads(data["body"])
+
+    return Response(content=data.get("body", ""), status_code=200)

--- a/vibetuner-py/src/vibetuner/frontend/lifespan.py
+++ b/vibetuner-py/src/vibetuner/frontend/lifespan.py
@@ -53,6 +53,11 @@ async def base_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Vibetuner frontend stopping")
     if ctx.DEBUG:
         await hotreload.shutdown()
+
+    from vibetuner.redis import close_redis_client
+
+    await close_redis_client()
+
     logger.info("Vibetuner frontend stopped")
 
     await teardown_sqlmodel()

--- a/vibetuner-py/src/vibetuner/redis.py
+++ b/vibetuner-py/src/vibetuner/redis.py
@@ -1,0 +1,53 @@
+# ABOUTME: Shared async Redis client for the vibetuner framework.
+# ABOUTME: Provides a lazy-initialized, reusable Redis connection with graceful degradation.
+import asyncio
+
+from vibetuner.logging import logger
+
+
+_client = None
+_lock = asyncio.Lock()
+
+
+async def get_redis_client():
+    """Get or create the shared async Redis client.
+
+    Returns None if ``redis_url`` is not configured. The client is lazily
+    initialized on first call and reused across the application.
+    """
+    global _client
+    if _client is not None:
+        return _client
+
+    from vibetuner.config import settings
+
+    if settings.redis_url is None:
+        return None
+
+    async with _lock:
+        if _client is not None:
+            return _client
+
+        import redis.asyncio as aioredis
+
+        _client = aioredis.from_url(str(settings.redis_url))
+        logger.debug("Shared Redis client initialized")
+        return _client
+
+
+async def close_redis_client() -> None:
+    """Close the shared Redis client (call during application shutdown)."""
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+        logger.debug("Shared Redis client closed")
+
+
+def reset_redis_client() -> None:
+    """Reset the client reference after a connection error.
+
+    The next call to :func:`get_redis_client` will create a fresh connection.
+    """
+    global _client
+    _client = None

--- a/vibetuner-py/tests/unit/test_cache.py
+++ b/vibetuner-py/tests/unit/test_cache.py
@@ -1,0 +1,305 @@
+# ruff: noqa: S101
+"""Tests for the @cache response caching decorator."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse
+from vibetuner.cache import (
+    _build_cache_key,
+    _restore_response,
+    _serialize_response,
+    cache,
+)
+
+
+# All decorator tests patch vibetuner.config.settings since cache.py imports it
+# lazily inside the wrapper function.
+_SETTINGS_PATH = "vibetuner.config.settings"
+_GET_CLIENT_PATH = "vibetuner.redis.get_redis_client"
+_RESET_CLIENT_PATH = "vibetuner.redis.reset_redis_client"
+
+
+def _make_request(
+    path: str = "/test", query_string: str = "", headers: dict | None = None
+):
+    """Create a minimal Starlette Request for testing."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "query_string": query_string.encode(),
+        "headers": [
+            (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
+        ],
+    }
+    return Request(scope)
+
+
+def _mock_settings(
+    *, debug: bool = False, redis_url="redis://localhost", redis_key_prefix="test:"
+):
+    mock = MagicMock()
+    mock.debug = debug
+    mock.redis_url = redis_url
+    mock.redis_key_prefix = redis_key_prefix
+    return mock
+
+
+class TestBuildCacheKey:
+    """Test cache key generation."""
+
+    def test_simple_path(self):
+        key = _build_cache_key("myapp:dev:", "/api/stats", "")
+        assert key.startswith("myapp:dev:cache:")
+        assert "/api/stats" in key
+
+    def test_with_query_params(self):
+        key = _build_cache_key("myapp:", "/api/stats", "page=1&sort=name")
+        assert "page=1&sort=name" in key
+
+    def test_different_paths_different_keys(self):
+        key1 = _build_cache_key("p:", "/a", "")
+        key2 = _build_cache_key("p:", "/b", "")
+        assert key1 != key2
+
+    def test_different_params_different_keys(self):
+        key1 = _build_cache_key("p:", "/a", "x=1")
+        key2 = _build_cache_key("p:", "/a", "x=2")
+        assert key1 != key2
+
+
+class TestSerializeRestore:
+    """Test response serialization round-trips."""
+
+    def test_json_response(self):
+        resp = JSONResponse({"users": 42})
+        serialized = _serialize_response(resp)
+        assert serialized is not None
+
+        restored = _restore_response(serialized)
+        assert restored.status_code == 200
+        body = json.loads(restored.body)
+        assert body == {"users": 42}
+
+    def test_html_response(self):
+        resp = HTMLResponse("<h1>Hello</h1>")
+        serialized = _serialize_response(resp)
+        assert serialized is not None
+
+        restored = _restore_response(serialized)
+        assert isinstance(restored, HTMLResponse)
+        assert b"Hello" in restored.body
+
+    def test_dict_response(self):
+        resp = {"key": "value"}
+        serialized = _serialize_response(resp)
+        assert serialized is not None
+
+        restored = _restore_response(serialized)
+        assert restored == {"key": "value"}
+
+    def test_unsupported_type_returns_none(self):
+        assert _serialize_response("plain string") is None
+
+
+class TestCacheDecorator:
+    """Test the @cache decorator behavior."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_in_debug_mode(self):
+        """Caching is skipped when debug=True."""
+        call_count = 0
+
+        @cache(expire=60)
+        async def handler(request: Request):
+            nonlocal call_count
+            call_count += 1
+            return JSONResponse({"count": call_count})
+
+        request = _make_request()
+
+        with patch(_SETTINGS_PATH, _mock_settings(debug=True)):
+            await handler(request=request)
+            await handler(request=request)
+
+        assert call_count == 2  # Called twice, no caching
+
+    @pytest.mark.asyncio
+    async def test_force_caching_in_debug(self):
+        """force_caching=True enables caching even in debug mode."""
+        call_count = 0
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=None)
+        mock_client.set = AsyncMock()
+
+        @cache(expire=120, force_caching=True)
+        async def handler(request: Request):
+            nonlocal call_count
+            call_count += 1
+            return JSONResponse({"count": call_count})
+
+        request = _make_request()
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings(debug=True)),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=mock_client)),
+            patch(_RESET_CLIENT_PATH),
+        ):
+            await handler(request=request)
+
+        assert call_count == 1
+        mock_client.set.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_redis_url_is_noop(self):
+        """When redis_url is None the decorator is a transparent no-op."""
+        call_count = 0
+
+        @cache(expire=60)
+        async def handler(request: Request):
+            nonlocal call_count
+            call_count += 1
+            return JSONResponse({"ok": True})
+
+        request = _make_request()
+
+        with patch(_SETTINGS_PATH, _mock_settings(redis_url=None)):
+            await handler(request=request)
+            await handler(request=request)
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_hit(self):
+        """Serves cached response without calling handler."""
+        cached_data = json.dumps(
+            {
+                "type": "json",
+                "body": '{"cached": true}',
+                "status": 200,
+            }
+        ).encode()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=cached_data)
+        call_count = 0
+
+        @cache(expire=60)
+        async def handler(request: Request):
+            nonlocal call_count
+            call_count += 1
+            return JSONResponse({"cached": False})
+
+        request = _make_request()
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=mock_client)),
+            patch(_RESET_CLIENT_PATH),
+        ):
+            result = await handler(request=request)
+
+        assert call_count == 0
+        body = json.loads(result.body)
+        assert body["cached"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_cache_header_bypasses_cache(self):
+        """Cache-Control: no-cache header forces re-execution."""
+        cached_data = json.dumps(
+            {
+                "type": "json",
+                "body": '{"stale": true}',
+                "status": 200,
+            }
+        ).encode()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=cached_data)
+        mock_client.set = AsyncMock()
+
+        @cache(expire=60)
+        async def handler(request: Request):
+            return JSONResponse({"fresh": True})
+
+        request = _make_request(headers={"Cache-Control": "no-cache"})
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=mock_client)),
+            patch(_RESET_CLIENT_PATH),
+        ):
+            result = await handler(request=request)
+
+        body = json.loads(result.body)
+        assert body["fresh"] is True
+        mock_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis_connection_error_falls_through(self):
+        """ConnectionError causes graceful fallback to direct execution."""
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=ConnectionError("refused"))
+
+        @cache(expire=60)
+        async def handler(request: Request):
+            return JSONResponse({"fallback": True})
+
+        request = _make_request()
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=mock_client)),
+            patch(_RESET_CLIENT_PATH) as mock_reset,
+        ):
+            result = await handler(request=request)
+
+        body = json.loads(result.body)
+        assert body["fallback"] is True
+        mock_reset.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_request_in_args_is_noop(self):
+        """Without a Request argument, the decorator skips caching."""
+        call_count = 0
+
+        @cache(expire=60)
+        async def handler():
+            nonlocal call_count
+            call_count += 1
+            return JSONResponse({"ok": True})
+
+        with patch(_SETTINGS_PATH, _mock_settings()):
+            await handler()
+            await handler()
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_preserves_function_name(self):
+        """Wrapper preserves the original function name."""
+
+        @cache(expire=60)
+        async def my_cached_route(request: Request):
+            return JSONResponse({"ok": True})
+
+        assert my_cached_route.__name__ == "my_cached_route"
+
+    @pytest.mark.asyncio
+    async def test_sync_handler(self):
+        """Works with synchronous route handlers."""
+
+        @cache(expire=60)
+        def handler(request: Request):
+            return JSONResponse({"sync": True})
+
+        request = _make_request()
+
+        with patch(_SETTINGS_PATH, _mock_settings(debug=True)):
+            result = await handler(request=request)
+
+        body = json.loads(result.body)
+        assert body["sync"] is True

--- a/vibetuner-py/tests/unit/test_redis.py
+++ b/vibetuner-py/tests/unit/test_redis.py
@@ -1,0 +1,82 @@
+# ruff: noqa: S101
+"""Tests for the shared Redis client module."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import vibetuner.redis as redis_mod
+
+
+class TestGetRedisClient:
+    """Test lazy initialization of the shared Redis client."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_redis_url(self):
+        """Returns None if redis_url is not configured."""
+        redis_mod._client = None
+        with patch("vibetuner.config.settings") as mock_settings:
+            mock_settings.redis_url = None
+            result = await redis_mod.get_redis_client()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_creates_client_when_url_configured(self):
+        """Creates and caches a client when redis_url is set."""
+        redis_mod._client = None
+        mock_client = AsyncMock()
+
+        with (
+            patch("vibetuner.config.settings") as mock_settings,
+            patch("redis.asyncio.from_url", return_value=mock_client) as mock_from_url,
+        ):
+            mock_settings.redis_url = "redis://localhost:6379/0"
+            result = await redis_mod.get_redis_client()
+
+        assert result is mock_client
+        mock_from_url.assert_called_once_with("redis://localhost:6379/0")
+
+        # Cleanup
+        redis_mod._client = None
+
+    @pytest.mark.asyncio
+    async def test_reuses_cached_client(self):
+        """Returns the same client on subsequent calls."""
+        mock_client = AsyncMock()
+        redis_mod._client = mock_client
+
+        result = await redis_mod.get_redis_client()
+        assert result is mock_client
+
+        # Cleanup
+        redis_mod._client = None
+
+
+class TestCloseRedisClient:
+    """Test client shutdown."""
+
+    @pytest.mark.asyncio
+    async def test_closes_and_clears(self):
+        """Closes the client and sets it to None."""
+        mock_client = AsyncMock()
+        redis_mod._client = mock_client
+
+        await redis_mod.close_redis_client()
+
+        mock_client.aclose.assert_called_once()
+        assert redis_mod._client is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_client(self):
+        """Does nothing if no client exists."""
+        redis_mod._client = None
+        await redis_mod.close_redis_client()
+        assert redis_mod._client is None
+
+
+class TestResetRedisClient:
+    """Test client reset after connection errors."""
+
+    def test_resets_to_none(self):
+        redis_mod._client = AsyncMock()
+        redis_mod.reset_redis_client()
+        assert redis_mod._client is None

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -897,7 +897,46 @@ return response
 | `hx_retarget(response, selector)` | `HX-Retarget` | Override target element |
 | `hx_refresh(response)` | `HX-Refresh` | Force full page refresh |
 
-### Cache Control Headers
+### Response Caching (Server-Side)
+
+Use the `@cache` decorator to cache route responses in Redis with a TTL:
+
+```python
+from vibetuner.cache import cache
+
+@router.get("/api/stats")
+@cache(expire=60)  # cache for 60 seconds
+async def get_stats(request: Request):
+    return {"users": await count_users()}
+
+@router.get("/dashboard")
+@cache(expire=300)
+async def dashboard(request: Request):
+    return render_template("dashboard.html.jinja", request)
+```
+
+**Behavior:**
+
+- Cache key is derived from route path + sorted query parameters
+- Respects `Cache-Control: no-cache` request header (bypasses cache)
+- Works with JSON, HTML, and dict responses
+- **Disabled by default in debug mode** to avoid stale-data confusion
+- Pass `force_caching=True` to enable even in debug mode
+
+**Cache invalidation:**
+
+```python
+from vibetuner.cache import invalidate, invalidate_pattern
+
+await invalidate("/api/stats")                   # exact path
+await invalidate("/api/stats", query_params="page=1")  # specific variant
+await invalidate_pattern("/api/*")               # glob pattern
+```
+
+**Graceful degradation:** If Redis is not configured or unavailable, the decorator
+is a transparent no-op — handlers execute normally with zero overhead.
+
+### Cache Control Headers (Browser-Side)
 
 Use the `@cache_control` decorator to set `Cache-Control` headers declaratively:
 
@@ -922,6 +961,17 @@ async def config_js():
 
 Supported directives: `public`, `private`, `no_cache`, `no_store`, `max_age`,
 `s_maxage`, `must_revalidate`, `stale_while_revalidate`, `immutable`.
+
+**Combining both:** Use `@cache` for server-side Redis caching and
+`@cache_control` for browser-side caching together:
+
+```python
+@router.get("/api/stats")
+@cache(expire=60)
+@cache_control(max_age=30, public=True)
+async def get_stats(request: Request):
+    return {"users": await count_users()}
+```
 
 ### Block Rendering for HTMX Partials
 


### PR DESCRIPTION
## Summary

- Add `@cache(expire=N)` decorator for server-side response caching backed by Redis
- Add shared `vibetuner.redis` module with lazy-initialized async Redis client
- Add `invalidate()` and `invalidate_pattern()` cache busting helpers
- Caching disabled by default in debug mode (`force_caching=True` to override)
- Graceful degradation: transparent no-op when Redis is unavailable or unconfigured
- Close shared Redis client on frontend shutdown

## New files
- `vibetuner-py/src/vibetuner/redis.py` — shared async Redis client
- `vibetuner-py/src/vibetuner/cache.py` — `@cache` decorator and invalidation helpers
- `vibetuner-py/tests/unit/test_redis.py` — 6 tests
- `vibetuner-py/tests/unit/test_cache.py` — 17 tests

## Modified files
- `vibetuner-py/src/vibetuner/frontend/lifespan.py` — shutdown cleanup
- `vibetuner-template/AGENTS.md` — user-facing caching docs
- `vibetuner-docs/docs/development-guide.md` — docs site caching section

## Follow-up issues
- #1368 — Migrate SSE Redis consumers to shared client
- #1369 — Migrate health check Redis client to shared module

## Test plan
- [x] All 432 existing tests pass
- [x] 23 new tests cover: key generation, serialization round-trips, debug mode skip,
  force_caching override, no-cache header bypass, connection error fallback, no-op modes
- [x] Ruff format + lint clean
- [x] Pre-commit hooks pass

Closes #1363

🤖 Generated with [Claude Code](https://claude.com/claude-code)