### PR TITLE
feat: add request ID / correlation ID middleware

### DIFF
--- a/vibetuner-docs/docs/architecture.md
+++ b/vibetuner-docs/docs/architecture.md
@@ -157,7 +157,7 @@ The `vibetuner` Python package provides the following key modules:
 | `vibetuner.testing` | Pytest fixtures for test client, mock auth, mock tasks |
 | `vibetuner.mongo` | MongoDB connection and model registration |
 | `vibetuner.sqlmodel` | SQLModel/SQLAlchemy integration |
-| `vibetuner.frontend` | FastAPI app, auth, middleware, route discovery |
+| `vibetuner.frontend` | FastAPI app, auth, middleware, request ID, route discovery |
 | `vibetuner.services` | DI wrappers for email, blob storage, runtime config |
 | `vibetuner.tasks` | Background job infrastructure (Streaq worker, robust tasks) |
 | `vibetuner.cli` | CLI commands (scaffold, run, db, doctor) |

--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "redis[hiredis]>=7.2.1",
   "rich>=14.3.3",
   "starlette-babel>=1.0.3",
+  "starlette-context>=0.3.6",
   "starlette-htmx>=0.1.1",
   "streaq[web]>=6.2.1,<7.0.0",
   "typer>=0.24.1",

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -17,6 +17,8 @@ from starlette_babel import (
     LocaleMiddleware,
     get_translator,
 )
+from starlette_context.middleware import RawContextMiddleware
+from starlette_context.plugins import RequestIdPlugin
 from starlette_htmx.middleware import HtmxMiddleware
 
 from vibetuner.config import settings
@@ -284,7 +286,9 @@ def _build_locale_selectors() -> list:
     return selectors
 
 
-middlewares: list[Middleware] = []
+middlewares: list[Middleware] = [
+    Middleware(RawContextMiddleware, plugins=[RequestIdPlugin(validate=False)]),
+]
 
 if settings.security_headers.enabled:
     middlewares.append(Middleware(SecurityHeadersMiddleware))

--- a/vibetuner-py/src/vibetuner/frontend/request_id.py
+++ b/vibetuner-py/src/vibetuner/frontend/request_id.py
@@ -1,0 +1,31 @@
+# ABOUTME: Request ID / correlation ID support via starlette-context.
+# ABOUTME: Provides get_request_id() helper and RequestId FastAPI dependency.
+from fastapi import Request
+from starlette_context import context
+from starlette_context.header_keys import HeaderKeys
+
+
+def get_request_id() -> str:
+    """Return the current request ID from starlette-context.
+
+    Can be called from anywhere during request handling — no need
+    to pass the ``Request`` object around.
+
+    Returns an empty string outside a request context.
+    """
+    try:
+        return context.get(HeaderKeys.request_id, "")
+    except Exception:
+        return ""
+
+
+def request_id_dependency(request: Request) -> str:
+    """FastAPI dependency that returns the current request ID.
+
+    Usage::
+
+        @router.get("/")
+        def index(request_id: str = Depends(request_id_dependency)):
+            ...
+    """
+    return get_request_id()

--- a/vibetuner-py/src/vibetuner/logging.py
+++ b/vibetuner-py/src/vibetuner/logging.py
@@ -35,6 +35,17 @@ class InterceptHandler(logging.Handler):
         )
 
 
+def _request_id_patcher(record):
+    """Inject request_id from starlette-context into every log record."""
+    try:
+        from starlette_context import context
+        from starlette_context.header_keys import HeaderKeys
+
+        record["extra"]["request_id"] = context.get(HeaderKeys.request_id, "")
+    except Exception:
+        record["extra"].setdefault("request_id", "")
+
+
 def setup_logging(
     level: str | int | None = LogLevel.INFO,
     log_file: str | Path | None = None,
@@ -56,11 +67,15 @@ def setup_logging(
     if level is None:
         level = LogLevel.INFO
 
+    # Patch every log record with the current request ID
+    logger.configure(patcher=_request_id_patcher)
+
     # Define format for the logs
     format_string = (
         "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
         "<level>{level: <8}</level> | "
-        "<cyan>{name}</cyan>:<cyan>{line}</cyan> - "
+        "<cyan>{name}</cyan>:<cyan>{line}</cyan> | "
+        "<dim>{extra[request_id]:8.8}</dim> - "
         "<level>{message}</level>"
     )
 

--- a/vibetuner-py/tests/unit/test_request_id_middleware.py
+++ b/vibetuner-py/tests/unit/test_request_id_middleware.py
@@ -1,0 +1,108 @@
+# ABOUTME: Unit tests for request ID / correlation ID middleware
+# ABOUTME: Verifies X-Request-ID generation, propagation, and Loguru integration
+# ruff: noqa: S101
+
+import uuid
+
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+from starlette_context import context
+from starlette_context.header_keys import HeaderKeys
+from starlette_context.middleware import RawContextMiddleware
+from starlette_context.plugins import RequestIdPlugin
+
+
+def _make_app():
+    """Create a minimal app with RawContextMiddleware + RequestIdPlugin."""
+    captured: dict[str, list] = {"ids": [], "context_ids": []}
+
+    async def homepage(request):
+        # Capture request ID from starlette-context
+        rid = context.get(HeaderKeys.request_id, "")
+        captured["ids"].append(rid)
+        return PlainTextResponse("OK")
+
+    app = Starlette(routes=[Route("/", homepage), Route("/{path:path}", homepage)])
+    app = RawContextMiddleware(app, plugins=[RequestIdPlugin(validate=False)])
+    app._captured = captured  # type: ignore[attr-defined]
+    return app
+
+
+class TestRequestIdMiddleware:
+    """Test X-Request-ID generation and propagation."""
+
+    def test_generates_request_id_when_missing(self):
+        """A new UUID is generated when no X-Request-ID header is sent."""
+        app = _make_app()
+        client = TestClient(app)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "X-Request-ID" in resp.headers
+        # Should be a valid UUID
+        rid = resp.headers["X-Request-ID"]
+        uuid.UUID(rid)  # raises if invalid
+
+    def test_propagates_incoming_request_id(self):
+        """An incoming X-Request-ID is reused in the response."""
+        app = _make_app()
+        client = TestClient(app)
+        custom_id = "my-trace-id-12345"
+        resp = client.get("/", headers={"X-Request-ID": custom_id})
+        assert resp.headers["X-Request-ID"] == custom_id
+
+    def test_request_id_available_in_context(self):
+        """The request ID is accessible via starlette_context.context inside handlers."""
+        app = _make_app()
+        client = TestClient(app)
+        custom_id = "ctx-test-id"
+        client.get("/", headers={"X-Request-ID": custom_id})
+        assert app._captured["ids"] == [custom_id]
+
+    def test_different_requests_get_different_ids(self):
+        """Two requests without X-Request-ID get distinct generated IDs."""
+        app = _make_app()
+        client = TestClient(app)
+        resp1 = client.get("/")
+        resp2 = client.get("/")
+        assert resp1.headers["X-Request-ID"] != resp2.headers["X-Request-ID"]
+
+    def test_response_header_present_on_all_status_codes(self):
+        """X-Request-ID is returned even on error responses."""
+        async def error_handler(request):
+            return PlainTextResponse("Not Found", status_code=404)
+
+        error_app = Starlette(routes=[Route("/", error_handler)])
+        error_app = RawContextMiddleware(error_app, plugins=[RequestIdPlugin()])
+        client = TestClient(error_app)
+        resp = client.get("/")
+        assert resp.status_code == 404
+        assert "X-Request-ID" in resp.headers
+
+
+class TestRequestIdLoguruIntegration:
+    """Test that request ID is injected into Loguru log records."""
+
+    def test_patcher_injects_request_id(self):
+        """The _request_id_patcher populates extra['request_id'] from context."""
+        from vibetuner.logging import _request_id_patcher
+
+        # Outside request context — should default to empty string
+        record = {"extra": {}}
+        _request_id_patcher(record)
+        assert record["extra"]["request_id"] == ""
+
+    def test_patcher_reads_from_context(self):
+        """The patcher reads request_id from starlette-context when available."""
+        from starlette_context import _request_scope_context_storage
+        from vibetuner.logging import _request_id_patcher
+
+        # Simulate an active request context
+        token = _request_scope_context_storage.set({HeaderKeys.request_id: "test-rid"})
+        try:
+            record = {"extra": {}}
+            _request_id_patcher(record)
+            assert record["extra"]["request_id"] == "test-rid"
+        finally:
+            _request_scope_context_storage.reset(token)

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2685,6 +2685,18 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette-context"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/fd/d28907759adf31f1112e71006b649c81a74a115b8c14645f87a5f5c83dd3/starlette_context-0.5.1.tar.gz", hash = "sha256:f6025753f8ede041778b2f2c3823e2da9df3c2d94832575bcb59374216b7c2b2", size = 8397, upload-time = "2026-02-28T11:32:00.185Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/9f/c1d842f7a628a1aaa6754f3e7d28218978af8ed28170c7f9eec49dc6401a/starlette_context-0.5.1-py3-none-any.whl", hash = "sha256:df55da1d7ae3453e89874b9d5c1d40a98dd2f1293c37791dd7c1a907087c9b5e", size = 12836, upload-time = "2026-02-28T11:32:01.254Z" },
+]
+
+[[package]]
 name = "starlette-htmx"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2992,6 +3004,7 @@ dependencies = [
     { name = "rich" },
     { name = "sqlmodel" },
     { name = "starlette-babel" },
+    { name = "starlette-context" },
     { name = "starlette-htmx" },
     { name = "streaq", extra = ["web"] },
     { name = "typer" },
@@ -3053,6 +3066,7 @@ requires-dist = [
     { name = "semver", marker = "extra == 'dev'", specifier = ">=3.0.4" },
     { name = "sqlmodel", specifier = ">=0.0.37" },
     { name = "starlette-babel", specifier = ">=1.0.3" },
+    { name = "starlette-context", specifier = ">=0.3.6" },
     { name = "starlette-htmx", specifier = ">=0.1.1" },
     { name = "streaq", extras = ["web"], specifier = ">=6.2.1,<7.0.0" },
     { name = "taplo", marker = "extra == 'dev'", specifier = ">=0.9.3" },

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -1235,6 +1235,37 @@ disabled.
 **Important:** Avoid inline event handlers (`onclick`, `onload`, etc.) in your templates.
 CSP with `strict-dynamic` blocks them. Use `addEventListener` or HTMX attributes instead.
 
+### Request ID / Correlation ID
+
+Every request is assigned a unique `X-Request-ID` header (UUID4). If the incoming request
+already carries an `X-Request-ID` (e.g., from a load balancer or API gateway), vibetuner
+reuses it. The ID is always returned in the response headers.
+
+**In logs:** The request ID is automatically included in every Loguru log line emitted
+during request handling — no configuration needed. Use it to filter logs for a single
+request.
+
+**Accessing the request ID in code:**
+
+```python
+# Option 1: helper function (works anywhere during a request — no Request object needed)
+from vibetuner.frontend.request_id import get_request_id
+
+rid = get_request_id()
+
+# Option 2: FastAPI dependency
+from fastapi import Depends
+from vibetuner.frontend.request_id import request_id_dependency
+
+@router.get("/")
+def index(request_id: str = Depends(request_id_dependency)):
+    ...
+```
+
+**In templates:** The request ID is available via `starlette_context.context` but is
+not injected into the template context by default. If you need it in templates, pass
+it explicitly or use a template context provider.
+
 ## Localization
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #1361

- Add `X-Request-ID` header generation/propagation via `starlette-context` (`RawContextMiddleware` + `RequestIdPlugin`)
- Automatically inject request ID into every Loguru log line via patcher
- Provide `get_request_id()` helper (works anywhere during a request) and `request_id_dependency` for FastAPI `Depends()`
- Accept arbitrary incoming correlation IDs (UUID validation disabled) for compatibility with load balancers/gateways

## Test plan

- [x] 7 unit tests covering generation, propagation, context access, uniqueness, error responses, and Loguru integration
- [x] Full unit test suite passes (416 tests)
- [ ] Manual: verify `X-Request-ID` header in response via `curl -v`
- [ ] Manual: verify request ID appears in log output during request handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)