### PR TITLE
feat: add rate limiting support

### DIFF
--- a/vibetuner-docs/docs/rate-limiting.md
+++ b/vibetuner-docs/docs/rate-limiting.md
@@ -1,0 +1,288 @@
+# Rate Limiting
+
+Protect your routes from abuse with built-in rate limiting, powered by
+[slowapi](https://github.com/laurents/slowapi) and backed by Redis.
+
+<!-- markdownlint-disable MD046 -->
+
+!!! note "Package name convention"
+    In all examples, `app` refers to your project's Python package (the directory
+    under `src/`). The actual name depends on your project slug (e.g.,
+    `src/myproject/` for a project named "myproject").
+
+## Overview
+
+Rate limiting is enabled by default and works out of the box. When Redis is
+configured, limits are shared across workers with automatic in-memory fallback
+if Redis becomes unavailable. Without Redis, limits use in-memory storage
+(per-process, suitable for development).
+
+## Quick Start
+
+### Per-Route Limits
+
+Apply rate limits to individual routes with the `@limiter.limit()` decorator:
+
+```python
+# src/app/frontend/routes/api.py
+from fastapi import APIRouter, Request
+from vibetuner.ratelimit import limiter
+
+router = APIRouter()
+
+@router.get("/api/search")
+@limiter.limit("10/minute")
+async def search(request: Request):
+    return {"results": []}
+
+@router.post("/api/submit")
+@limiter.limit("5/minute")
+async def submit(request: Request):
+    return {"status": "ok"}
+```
+
+!!! warning "Request parameter required"
+    Every rate-limited route **must** have a `request: Request` parameter.
+    slowapi uses it to identify the client. Routes without it will raise
+    an error at startup.
+
+### Global Default Limits
+
+Set default limits that apply to all routes via environment variables:
+
+```bash
+# .env
+RATE_LIMIT_DEFAULT_LIMITS='["100/hour", "10/second"]'
+```
+
+Routes with explicit `@limiter.limit()` decorators override the defaults.
+
+### Exempt Routes
+
+Exclude routes from rate limiting (useful for health checks or public assets):
+
+```python
+from vibetuner.ratelimit import limiter
+
+@router.get("/health")
+@limiter.exempt
+async def health(request: Request):
+    return {"status": "ok"}
+```
+
+## How It Works
+
+### Client Identification
+
+By default, clients are identified by their IP address (from `X-Forwarded-For`
+header when behind a proxy, or the direct client IP). This works for most use
+cases.
+
+### Rate Limit Strings
+
+Limits follow the format `"X per Y"` or `"X/Y"`:
+
+| Format | Meaning |
+|---|---|
+| `"10/second"` | 10 requests per second |
+| `"30/minute"` | 30 requests per minute |
+| `"100/hour"` | 100 requests per hour |
+| `"1000/day"` | 1000 requests per day |
+| `"5 per minute"` | 5 requests per minute |
+
+Multiple limits can be combined on a single route:
+
+```python
+@router.get("/api/data")
+@limiter.limit("2/second")
+@limiter.limit("100/hour")
+async def get_data(request: Request):
+    ...
+```
+
+### Response Headers
+
+When `RATE_LIMIT_HEADERS_ENABLED=true` (default), responses include standard
+rate limit headers:
+
+| Header | Description |
+|---|---|
+| `X-RateLimit-Limit` | Maximum requests allowed in the window |
+| `X-RateLimit-Remaining` | Requests remaining in the current window |
+| `X-RateLimit-Reset` | Seconds until the window resets |
+| `Retry-After` | Seconds to wait before retrying (on 429 responses) |
+
+### 429 Response
+
+When a client exceeds the limit, a `429 Too Many Requests` JSON response is
+returned:
+
+```json
+{"error": "Rate limit exceeded: 10 per 1 minute"}
+```
+
+## Configuration
+
+All settings are configurable via environment variables with the `RATE_LIMIT_`
+prefix:
+
+| Variable | Default | Description |
+|---|---|---|
+| `RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting globally |
+| `RATE_LIMIT_DEFAULT_LIMITS` | `[]` | Default limits for all routes (JSON list) |
+| `RATE_LIMIT_HEADERS_ENABLED` | `true` | Include `X-RateLimit-*` response headers |
+| `RATE_LIMIT_STRATEGY` | `fixed-window` | Rate limiting strategy |
+| `RATE_LIMIT_SWALLOW_ERRORS` | `true` | Swallow storage errors instead of crashing |
+
+### Strategies
+
+| Strategy | Description |
+|---|---|
+| `fixed-window` | Simple fixed time windows (default, lowest overhead) |
+| `moving-window` | Sliding window for smoother rate limiting |
+| `sliding-window-counter` | Approximation between fixed and moving window |
+
+### Storage
+
+- **With Redis** (`REDIS_URL` set): Limits are stored in Redis, shared across
+  all workers. If Redis becomes unavailable, automatically falls back to
+  in-memory storage.
+- **Without Redis**: Limits use in-memory storage (per-process). Suitable for
+  development but not for production with multiple workers.
+
+## Advanced Usage
+
+### Custom Key Functions
+
+Rate limit by something other than IP address (e.g., authenticated user):
+
+```python
+from fastapi import Request
+from vibetuner.ratelimit import limiter
+
+def key_by_user(request: Request) -> str:
+    if request.user.is_authenticated:
+        return str(request.user.identity)
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0]
+    return request.client.host if request.client else "127.0.0.1"
+
+@router.get("/api/premium")
+@limiter.limit("1000/hour", key_func=key_by_user)
+async def premium_endpoint(request: Request):
+    ...
+```
+
+### Shared Limits
+
+Apply the same limit across multiple routes:
+
+```python
+from vibetuner.ratelimit import limiter
+
+shared_api_limit = limiter.shared_limit("100/hour", scope="api")
+
+@router.get("/api/users")
+@shared_api_limit
+async def list_users(request: Request):
+    ...
+
+@router.get("/api/posts")
+@shared_api_limit
+async def list_posts(request: Request):
+    ...
+```
+
+### Conditional Exemption
+
+Exempt certain requests dynamically:
+
+```python
+@router.get("/api/data")
+@limiter.limit(
+    "10/minute",
+    exempt_when=lambda: request.user.is_authenticated,
+)
+async def get_data(request: Request):
+    ...
+```
+
+### Dynamic Limits
+
+Use a callable to determine the limit at runtime:
+
+```python
+def get_limit_for_user(request: Request) -> str:
+    if request.user.is_authenticated:
+        return "100/minute"
+    return "10/minute"
+
+@router.get("/api/search")
+@limiter.limit(get_limit_for_user)
+async def search(request: Request):
+    ...
+```
+
+## Disabling Rate Limiting
+
+### Globally
+
+```bash
+RATE_LIMIT_ENABLED=false
+```
+
+### For Development
+
+Rate limiting is enabled even in development mode. To disable it locally:
+
+```bash
+# .env.local
+RATE_LIMIT_ENABLED=false
+```
+
+## Troubleshooting
+
+### Rate Limits Not Shared Across Workers
+
+Ensure `REDIS_URL` is set. Without Redis, each worker process tracks limits
+independently.
+
+### "No request argument" Error
+
+Every rate-limited route must accept a `request: Request` parameter:
+
+```python
+# GOOD
+@router.get("/api/data")
+@limiter.limit("10/minute")
+async def get_data(request: Request):
+    ...
+
+# BAD - will raise an error
+@router.get("/api/data")
+@limiter.limit("10/minute")
+async def get_data():
+    ...
+```
+
+### Limits Not Applying
+
+1. Check that `RATE_LIMIT_ENABLED` is not set to `false`
+2. Verify the decorator order — `@limiter.limit()` should come after
+   `@router.get()`:
+
+    ```python
+    @router.get("/endpoint")   # First: route decorator
+    @limiter.limit("10/minute")  # Second: rate limit
+    async def endpoint(request: Request):
+        ...
+    ```
+
+3. Run `vibetuner doctor` to verify Redis connectivity
+
+## Next Steps
+
+- [Background Tasks](background-tasks.md) — Redis-backed task queue
+- [Authentication](authentication.md) — Protect routes with auth
+- [Deployment](deployment.md) — Production configuration

--- a/vibetuner-docs/mkdocs.yml
+++ b/vibetuner-docs/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - User Guide:
       - Development: development-guide.md
       - Background Tasks: background-tasks.md
+      - Rate Limiting: rate-limiting.md
       - Authentication: authentication.md
       - Runtime Configuration: runtime-config.md
       - Deployment: deployment.md

--- a/vibetuner-py/AGENTS.md
+++ b/vibetuner-py/AGENTS.md
@@ -123,7 +123,15 @@ The main CLI entry point using Typer. Commands:
 ### `config.py`
 
 Framework configuration using Pydantic Settings. This is the **immutable** config that all projects
-inherit. User-specific config goes in the scaffolded `src/app/config.py`.
+inherit. User-specific config goes in the scaffolded `src/app/config.py`. Includes nested settings
+classes: `SecurityHeadersSettings`, `RateLimitSettings`, `LocaleDetectionSettings`.
+
+### `ratelimit.py`
+
+Rate limiting module using slowapi. Exports a pre-configured `limiter` singleton that auto-uses
+the project's Redis connection (with in-memory fallback). Configuration via `RateLimitSettings`
+in `config.py` with `RATE_LIMIT_` env prefix. The middleware (`SlowAPIASGIMiddleware`) and
+exception handler are wired in `frontend/middleware.py` and `frontend/__init__.py`.
 
 ### `frontend/lifespan.py`
 

--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "pyyaml>=6.0.3",
   "redis[hiredis]>=7.2.1",
   "rich>=14.3.3",
+  "slowapi>=0.1.9",
   "starlette-babel>=1.0.3",
   "starlette-htmx>=0.1.1",
   "streaq[web]>=6.2.1,<7.0.0",

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -75,6 +75,28 @@ class SecurityHeadersSettings(BaseSettings):
     )
 
 
+class RateLimitSettings(BaseSettings):
+    """Settings for rate limiting middleware.
+
+    Rate limit strings follow the format: "X per Y" or "X/Y"
+    where X is the number and Y is the period (second, minute, hour, day).
+    Examples: "10/minute", "100/hour", "5 per second"
+    """
+
+    enabled: bool = True
+    default_limits: list[str] = []
+    headers_enabled: bool = True
+    strategy: str = "fixed-window"
+    swallow_errors: bool = True
+
+    model_config = SettingsConfigDict(
+        case_sensitive=False,
+        extra="ignore",
+        env_prefix="RATE_LIMIT_",
+        env_file=(".env", ".env.local"),
+    )
+
+
 class LocaleDetectionSettings(BaseSettings):
     """Settings for locale detection selectors.
 
@@ -237,6 +259,9 @@ class CoreConfiguration(BaseSettings):
         from vibetuner.versioning import get_version
 
         return get_version()
+
+    # Rate limiting settings
+    rate_limit: RateLimitSettings = Field(default_factory=RateLimitSettings)
 
     # Locale detection settings
     locale_detection: LocaleDetectionSettings = Field(

--- a/vibetuner-py/src/vibetuner/frontend/AGENTS.md
+++ b/vibetuner-py/src/vibetuner/frontend/AGENTS.md
@@ -52,6 +52,7 @@ These are imported by user code for route protection.
 
 Request/response middleware:
 
+- Rate limiting middleware (slowapi, ASGI-native, first in stack)
 - HTMX middleware (request/response helpers)
 - Session middleware (secure cookie-based sessions)
 - i18n middleware (internationalization)

--- a/vibetuner-py/src/vibetuner/frontend/__init__.py
+++ b/vibetuner-py/src/vibetuner/frontend/__init__.py
@@ -42,6 +42,16 @@ app = FastAPI(
     dependencies=dependencies,
 )
 
+# Rate limiting setup (slowapi requires app.state.limiter)
+if settings.rate_limit.enabled:
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    from vibetuner.ratelimit import limiter
+
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
 # Static files
 app.mount(f"/static/v{ctx.v_hash}/css", StaticFiles(directory=paths.css), name="css")
 app.mount(f"/static/v{ctx.v_hash}/img", StaticFiles(directory=paths.img), name="img")

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -286,6 +286,11 @@ def _build_locale_selectors() -> list:
 
 middlewares: list[Middleware] = []
 
+if settings.rate_limit.enabled:
+    from slowapi.middleware import SlowAPIASGIMiddleware
+
+    middlewares.append(Middleware(SlowAPIASGIMiddleware))
+
 if settings.security_headers.enabled:
     middlewares.append(Middleware(SecurityHeadersMiddleware))
 

--- a/vibetuner-py/src/vibetuner/ratelimit.py
+++ b/vibetuner-py/src/vibetuner/ratelimit.py
@@ -1,0 +1,47 @@
+# ABOUTME: Rate limiting support for vibetuner routes using slowapi.
+# ABOUTME: Auto-configures with vibetuner's Redis connection and provides a clean decorator API.
+from slowapi import Limiter
+from slowapi.middleware import SlowAPIASGIMiddleware
+from slowapi.util import get_remote_address
+
+from vibetuner.config import settings
+from vibetuner.logging import logger
+
+
+def _get_storage_uri() -> str | None:
+    if settings.redis_url is None:
+        return None
+    return str(settings.redis_url)
+
+
+def _build_limiter() -> Limiter:
+    storage_uri = _get_storage_uri()
+
+    kwargs: dict = {
+        "key_func": get_remote_address,
+        "enabled": settings.rate_limit.enabled,
+        "headers_enabled": settings.rate_limit.headers_enabled,
+        "key_prefix": f"{settings.redis_key_prefix}ratelimit:",
+        "strategy": settings.rate_limit.strategy,
+        "swallow_errors": settings.rate_limit.swallow_errors,
+        "config_filename": None,
+    }
+
+    if storage_uri:
+        kwargs["storage_uri"] = storage_uri
+        kwargs["in_memory_fallback_enabled"] = True
+        logger.debug("Rate limiter using Redis storage: {}", storage_uri)
+    else:
+        kwargs["storage_uri"] = "memory://"
+        logger.debug("Rate limiter using in-memory storage (no Redis configured)")
+
+    default_limits = settings.rate_limit.default_limits
+    if default_limits:
+        kwargs["default_limits"] = default_limits
+
+    return Limiter(**kwargs)
+
+
+limiter: Limiter = _build_limiter()
+
+__all__ = ["limiter", "SlowAPIASGIMiddleware"]

--- a/vibetuner-py/tests/unit/test_ratelimit.py
+++ b/vibetuner-py/tests/unit/test_ratelimit.py
@@ -1,0 +1,190 @@
+# ABOUTME: Unit tests for vibetuner rate limiting module
+# ABOUTME: Tests limiter construction, middleware integration, and decorator behavior
+# ruff: noqa: S101
+
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIASGIMiddleware
+from slowapi.util import get_remote_address
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+
+def _make_app(limiter: Limiter | None = None, default_limits: list[str] | None = None):
+    """Create a minimal Starlette app with rate limiting wired up."""
+    if limiter is None:
+        limiter = Limiter(
+            key_func=get_remote_address,
+            storage_uri="memory://",
+            default_limits=default_limits or [],
+            strategy="fixed-window",
+            headers_enabled=True,
+            config_filename=None,
+        )
+
+    async def homepage(request: Request):
+        return PlainTextResponse("OK")
+
+    @limiter.limit("3/minute")
+    async def limited_route(request: Request):
+        return PlainTextResponse("limited")
+
+    @limiter.limit("1/minute")
+    async def strict_route(request: Request):
+        return PlainTextResponse("strict")
+
+    @limiter.exempt
+    async def exempt_route(request: Request):
+        return PlainTextResponse("exempt")
+
+    app = Starlette(
+        routes=[
+            Route("/", homepage),
+            Route("/limited", limited_route),
+            Route("/strict", strict_route),
+            Route("/exempt", exempt_route),
+        ],
+    )
+
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_middleware(SlowAPIASGIMiddleware)
+    return app
+
+
+class TestRateLimitDecorator:
+    """Test per-route rate limiting with @limiter.limit decorator."""
+
+    def test_under_limit_returns_200(self):
+        app = _make_app()
+        client = TestClient(app)
+        resp = client.get("/limited")
+        assert resp.status_code == 200
+        assert resp.text == "limited"
+
+    def test_exceeding_limit_returns_429(self):
+        app = _make_app()
+        client = TestClient(app)
+        for _ in range(3):
+            resp = client.get("/limited")
+            assert resp.status_code == 200
+        resp = client.get("/limited")
+        assert resp.status_code == 429
+
+    def test_different_routes_have_separate_limits(self):
+        app = _make_app()
+        client = TestClient(app)
+        # Hit strict route limit (1/min)
+        resp = client.get("/strict")
+        assert resp.status_code == 200
+        resp = client.get("/strict")
+        assert resp.status_code == 429
+        # Limited route should still work
+        resp = client.get("/limited")
+        assert resp.status_code == 200
+
+    def test_exempt_route_is_not_limited(self):
+        app = _make_app(default_limits=["1/minute"])
+        client = TestClient(app)
+        for _ in range(5):
+            resp = client.get("/exempt")
+            assert resp.status_code == 200
+
+
+class TestRateLimitHeaders:
+    """Test rate limit response headers."""
+
+    def test_rate_limit_headers_present(self):
+        app = _make_app()
+        client = TestClient(app)
+        resp = client.get("/limited")
+        assert "X-RateLimit-Limit" in resp.headers
+        assert "X-RateLimit-Remaining" in resp.headers
+        assert "X-RateLimit-Reset" in resp.headers
+
+    def test_remaining_decreases(self):
+        app = _make_app()
+        client = TestClient(app)
+        resp1 = client.get("/limited")
+        resp2 = client.get("/limited")
+        remaining1 = int(resp1.headers["X-RateLimit-Remaining"])
+        remaining2 = int(resp2.headers["X-RateLimit-Remaining"])
+        assert remaining2 < remaining1
+
+    def test_429_response_has_retry_after(self):
+        app = _make_app()
+        client = TestClient(app)
+        for _ in range(3):
+            client.get("/limited")
+        resp = client.get("/limited")
+        assert resp.status_code == 429
+        assert "Retry-After" in resp.headers
+
+
+class TestDefaultLimits:
+    """Test global default rate limits."""
+
+    def test_default_limits_apply_to_undecorated_routes(self):
+        app = _make_app(default_limits=["2/minute"])
+        client = TestClient(app)
+        for _ in range(2):
+            resp = client.get("/")
+            assert resp.status_code == 200
+        resp = client.get("/")
+        assert resp.status_code == 429
+
+    def test_decorated_route_overrides_default(self):
+        app = _make_app(default_limits=["1/minute"])
+        client = TestClient(app)
+        # /limited has 3/minute, should override the 1/minute default
+        resp = client.get("/limited")
+        assert resp.status_code == 200
+        resp = client.get("/limited")
+        assert resp.status_code == 200
+
+
+class TestRateLimitConfig:
+    """Test rate limit configuration from vibetuner settings."""
+
+    def test_settings_defaults(self):
+        from vibetuner.config import RateLimitSettings
+
+        s = RateLimitSettings()
+        assert s.enabled is True
+        assert s.default_limits == []
+        assert s.headers_enabled is True
+        assert s.strategy == "fixed-window"
+        assert s.swallow_errors is True
+
+    def test_settings_custom_values(self):
+        from vibetuner.config import RateLimitSettings
+
+        s = RateLimitSettings(
+            enabled=False,
+            default_limits=["100/hour"],
+            headers_enabled=False,
+            strategy="moving-window",
+            swallow_errors=False,
+        )
+        assert s.enabled is False
+        assert s.default_limits == ["100/hour"]
+        assert s.headers_enabled is False
+        assert s.strategy == "moving-window"
+        assert s.swallow_errors is False
+
+
+class TestLimiterConstruction:
+    """Test that the vibetuner limiter is properly constructed."""
+
+    def test_limiter_is_importable(self):
+        from vibetuner.ratelimit import limiter
+
+        assert isinstance(limiter, Limiter)
+
+    def test_limiter_is_enabled_by_default(self):
+        from vibetuner.ratelimit import limiter
+
+        assert limiter.enabled is True

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -1469,6 +1469,20 @@ wheels = [
 ]
 
 [[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2574,6 +2588,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2990,6 +3016,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "redis", extra = ["hiredis"] },
     { name = "rich" },
+    { name = "slowapi" },
     { name = "sqlmodel" },
     { name = "starlette-babel" },
     { name = "starlette-htmx" },
@@ -3051,6 +3078,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.4" },
     { name = "rumdl", marker = "extra == 'dev'", specifier = ">=0.1.38" },
     { name = "semver", marker = "extra == 'dev'", specifier = ">=3.0.4" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlmodel", specifier = ">=0.0.37" },
     { name = "starlette-babel", specifier = ">=1.0.3" },
     { name = "starlette-htmx", specifier = ">=0.1.1" },

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -611,6 +611,56 @@ app = VibetunerApp(
 )
 ```
 
+### Rate Limiting
+
+Rate limiting is built in and enabled by default. Apply per-route limits with the
+`@limiter.limit()` decorator:
+
+```python
+# src/app/frontend/routes/api.py
+from fastapi import APIRouter, Request
+from vibetuner.ratelimit import limiter
+
+router = APIRouter()
+
+@router.get("/api/search")
+@limiter.limit("10/minute")
+async def search(request: Request):
+    return {"results": []}
+
+@router.post("/api/login")
+@limiter.limit("5/minute")
+async def login(request: Request):
+    ...
+```
+
+**Important**: Every rate-limited route must have a `request: Request` parameter.
+
+Exempt routes from limiting:
+
+```python
+@router.get("/health")
+@limiter.exempt
+async def health(request: Request):
+    return {"status": "ok"}
+```
+
+Set global default limits via environment variables:
+
+```bash
+# .env
+RATE_LIMIT_DEFAULT_LIMITS='["100/hour", "10/second"]'
+```
+
+Responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`,
+and `Retry-After` headers by default. Exceeded limits return `429 Too Many Requests`.
+
+Configure via `RATE_LIMIT_` prefixed env vars: `RATE_LIMIT_ENABLED`,
+`RATE_LIMIT_HEADERS_ENABLED`, `RATE_LIMIT_STRATEGY`, `RATE_LIMIT_SWALLOW_ERRORS`.
+
+With Redis configured, limits are shared across workers with automatic in-memory
+fallback. Without Redis, limits are per-process (suitable for development).
+
 ### Adding Background Tasks
 
 Create tasks with the `@worker.task()` decorator, then list them in `tune.py`:


### PR DESCRIPTION
## Summary

- Add built-in rate limiting powered by [slowapi](https://github.com/laurents/slowapi) with Redis-backed storage
- Per-route `@limiter.limit("10/minute")` decorator, global defaults via env vars, `@limiter.exempt` for exclusions
- Auto-configured from vibetuner's existing Redis connection with automatic in-memory fallback
- `X-RateLimit-*` and `Retry-After` response headers enabled by default
- `RateLimitSettings` with `RATE_LIMIT_` env prefix for all configuration
- Full user-facing documentation page added to docs site
- Template AGENTS.md updated with rate limiting usage guide

Closes #1362

## Test plan

- [x] 13 unit tests covering decorator behavior, 429 responses, headers, default limits, exemptions, config
- [x] Full test suite passes (422 tests)
- [x] Linting passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)