### PR TITLE
feat: add auto-generated admin panel with starlette-admin

### DIFF
--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -53,6 +53,8 @@ dependencies = [
   "greenlet>=3.3.2",
   "sqlmodel>=0.0.37",
   "gitpython>=3.1.46",
+  "starlette-admin>=0.16.0",
+  "starlette-admin-beanie-backend>=0.1.1",
 ]
 
 [project.scripts]

--- a/vibetuner-py/src/vibetuner/frontend/__init__.py
+++ b/vibetuner-py/src/vibetuner/frontend/__init__.py
@@ -130,4 +130,15 @@ if settings.workers_available:
     except ImportError:
         pass
 
+# Mount admin panel (starlette-admin with Beanie backend)
+if settings.mongodb_url is not None:
+    try:
+        from .admin import create_admin
+
+        admin = create_admin()
+        admin.mount_to(app)
+        logger.debug("Admin panel mounted at /admin")
+    except Exception as exc:
+        logger.warning(f"Failed to mount admin panel: {exc}")
+
 app.include_router(health.router)

--- a/vibetuner-py/src/vibetuner/frontend/admin.py
+++ b/vibetuner-py/src/vibetuner/frontend/admin.py
@@ -1,0 +1,71 @@
+# ABOUTME: Auto-generated admin panel using starlette-admin with Beanie backend.
+# ABOUTME: Discovers Beanie models from tune.py and creates CRUD views automatically.
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+from starlette_admin.auth import AuthProvider
+
+from vibetuner.context import ctx
+from vibetuner.frontend.deps import MAGIC_COOKIE_NAME
+from vibetuner.logging import logger
+
+
+class DebugAuthProvider(AuthProvider):
+    """Auth provider that reuses the existing debug access mechanism.
+
+    In DEBUG mode, access is always granted. In production, the debug
+    magic cookie must be present (set via /_unlock-debug).
+    """
+
+    async def is_authenticated(self, request: Request) -> bool:
+        if ctx.DEBUG:
+            return True
+        return request.cookies.get(MAGIC_COOKIE_NAME) == "granted"
+
+    def get_admin_config(self, request: Request):
+        from starlette_admin.auth import AdminConfig
+
+        return AdminConfig(app_title="Admin")
+
+    def get_admin_user(self, request: Request):
+        from starlette_admin.auth import AdminUser
+
+        return AdminUser(username="developer")
+
+    async def login(
+        self,
+        username: str,
+        password: str,
+        remember_me: bool,
+        request: Request,
+        response: Response,
+    ) -> Response:
+        # Redirect to the debug unlock flow instead of handling login here
+        return RedirectResponse(url="/_unlock-debug", status_code=302)
+
+    async def logout(self, request: Request, response: Response) -> Response:
+        return RedirectResponse(url="/debug", status_code=302)
+
+
+def create_admin():
+    """Create and configure the starlette-admin instance with Beanie model views."""
+    from starlette_admin_beanie_backend import Admin, ModelView
+
+    from vibetuner.mongo import get_all_models
+    from vibetuner.pyproject import get_project_name
+
+    project_name = get_project_name() or "Vibetuner"
+
+    admin = Admin(
+        title=f"{project_name} Admin",
+        base_url="/admin",
+        auth_provider=DebugAuthProvider(),
+    )
+
+    for model in get_all_models():
+        try:
+            admin.add_view(ModelView(model))
+            logger.debug(f"Admin: registered model {model.__name__}")
+        except Exception as exc:
+            logger.warning(f"Admin: failed to register {model.__name__}: {exc}")
+
+    return admin

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
@@ -68,5 +68,16 @@
             </svg>
             Health Check
         </a>
+        {# djlint:off J018 #}
+        <a href="/admin"
+           class="btn btn-outline btn-warning gap-2">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4">
+                </path>
+            </svg>
+            Admin Panel
+        </a>
+        {# djlint:on J018 #}
     </div>
 </nav>

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/index.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/index.html.jinja
@@ -110,6 +110,27 @@
                     </div>
                 </div>
             </div>
+            <!-- Admin Panel -->
+            <div class="card bg-base-100 shadow-xl border border-base-200 hover:shadow-2xl transition-shadow">
+                <div class="card-body">
+                    <h2 class="card-title text-warning flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4">
+                            </path>
+                        </svg>
+                        Admin Panel
+                    </h2>
+                    <p class="text-base-content/70 mb-4">Browse, search, create, edit, and delete database records</p>
+                    <div class="card-actions justify-end">
+                        {# djlint:off J018 #}
+                        <a href="/admin" class="btn btn-warning btn-sm">Open Admin</a>
+                        {# djlint:on J018 #}
+                    </div>
+                </div>
+            </div>
         </div>
         <!-- Debug Navigation Footer -->
         {% include "debug/components/debug_nav.html.jinja" %}

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2710,6 +2710,33 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette-admin"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "python-multipart" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/5e/2487c92a3239d01cf1cb7db5d8455454b231c49a7576c06f3241050e8813/starlette_admin-0.16.0.tar.gz", hash = "sha256:e706a1582a22a69202d3165d8c626d5868822c229353a81e1d189666d8418f64", size = 2104304, upload-time = "2025-12-13T21:49:40.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/85/f3950e95771e92079ad2c6f8d52ce4c04a0e2e47cedc989ae465d9cfbd9c/starlette_admin-0.16.0-py3-none-any.whl", hash = "sha256:9b7ee51cc275684ba75dda5eafc650e0c8afa1d2b7e99e4d1c83fe7d1e83de9e", size = 2175927, upload-time = "2025-12-13T21:49:42.272Z" },
+]
+
+[[package]]
+name = "starlette-admin-beanie-backend"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beanie" },
+    { name = "starlette-admin" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/e5/fd37252e86e32acb9d730b3eacd301ed396a4b3f41c7573e8575618c57b8/starlette_admin_beanie_backend-0.1.1.tar.gz", hash = "sha256:2e734f600aa03109300c58dc606a6957aa4255bb1bd4772169ab918d132b4a76", size = 8992, upload-time = "2026-01-04T09:52:07.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/7d/5a362faaf56a1fca2c80c855394846b0af1babff95ce9747161a15d383c0/starlette_admin_beanie_backend-0.1.1-py3-none-any.whl", hash = "sha256:d08ce57cdc562e452852cb755e7e0ede657ef536dfc542eebb675ba7c6b6b72b", size = 9293, upload-time = "2026-01-04T09:52:06.921Z" },
+]
+
+[[package]]
 name = "starlette-babel"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3044,6 +3071,8 @@ dependencies = [
     { name = "rich" },
     { name = "slowapi" },
     { name = "sqlmodel" },
+    { name = "starlette-admin" },
+    { name = "starlette-admin-beanie-backend" },
     { name = "starlette-babel" },
     { name = "starlette-context" },
     { name = "starlette-htmx" },
@@ -3108,6 +3137,8 @@ requires-dist = [
     { name = "semver", marker = "extra == 'dev'", specifier = ">=3.0.4" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlmodel", specifier = ">=0.0.37" },
+    { name = "starlette-admin", specifier = ">=0.16.0" },
+    { name = "starlette-admin-beanie-backend", specifier = ">=0.1.1" },
     { name = "starlette-babel", specifier = ">=1.0.3" },
     { name = "starlette-context", specifier = ">=0.5.1" },
     { name = "starlette-htmx", specifier = ">=0.1.1" },


### PR DESCRIPTION
## Summary

- Adds an auto-generated admin panel at `/admin` using [starlette-admin](https://github.com/jowilf/starlette-admin) with the [Beanie backend](https://arnabj.github.io/starlette-admin-beanie-backend/)
- Auto-discovers all Beanie models (core + user models from `tune.py`) and creates CRUD views
- Access gated behind the existing debug cookie mechanism (`DebugAuthProvider`)
- Adds link from the debug dashboard and nav to the admin panel

Closes #1364

## Test plan

- [ ] Start dev server with MongoDB configured, verify `/admin` loads
- [ ] Verify all registered Beanie models appear as admin views
- [ ] Test CRUD operations (list, create, edit, delete) on a model
- [ ] Verify unauthenticated access in production mode redirects to `/_unlock-debug`
- [ ] Verify DEBUG mode grants automatic access
- [ ] Verify the admin card and nav link appear on `/debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)