### PR TITLE
fix: revert to SlowAPIMiddleware to fix streaming response crash

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -368,9 +368,13 @@ middlewares: list[Middleware] = [
 ]
 
 if settings.rate_limit.enabled:
-    from slowapi.middleware import SlowAPIASGIMiddleware
+    # SlowAPIASGIMiddleware has a bug where it re-sends http.response.start on
+    # every body chunk, crashing streaming responses (FileResponse).
+    # Using SlowAPIMiddleware (BaseHTTPMiddleware-based) as workaround.
+    # See: https://github.com/laurentS/slowapi/issues/XXX
+    from slowapi.middleware import SlowAPIMiddleware
 
-    middlewares.append(Middleware(SlowAPIASGIMiddleware))
+    middlewares.append(Middleware(SlowAPIMiddleware))
 
 if settings.security_headers.enabled:
     middlewares.append(Middleware(SecurityHeadersMiddleware))


### PR DESCRIPTION
## Summary

- Reverts from `SlowAPIASGIMiddleware` to `SlowAPIMiddleware` to fix streaming response crashes
- `SlowAPIASGIMiddleware` re-sends `http.response.start` on every body chunk, which crashes `FileResponse` and other streaming responses

## Test plan

- [ ] Verify rate limiting still works
- [ ] Verify file downloads / streaming responses no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)