### PR TITLE
feat: add /update-scaffolding Claude Code skill to template

### DIFF
--- a/vibetuner-docs/docs/scaffolding.md
+++ b/vibetuner-docs/docs/scaffolding.md
@@ -114,12 +114,68 @@ There are two supported update flows:
 Both commands update tracked files. Always commit or stash local changes before
 running them, review the results, and resolve any merge prompts Copier surfaces.
 
+## Automated Update with Claude Code
+
+Scaffolded projects ship with an `/update-scaffolding` Claude Code skill that
+automates the entire update-and-PR workflow. It:
+
+1. Checks upstream for a newer template version (stops early if already
+   up to date).
+2. Creates an isolated git worktree so your working tree is untouched.
+3. Updates dependencies (`just update-and-commit-repo-deps`).
+4. Applies the latest scaffolding (`just update-scaffolding`).
+5. Detects and resolves merge conflicts intelligently.
+6. Creates a PR with a summary of changes and any unresolved conflicts.
+
+### Using the Skill Interactively
+
+Open Claude Code in your project and run:
+
+```text
+/update-scaffolding
+```
+
+### Running from the Command Line (Headless)
+
+You can invoke the skill directly from your terminal without entering the
+Claude Code TUI:
+
+```bash
+claude -p "run the /update-scaffolding skill"
+```
+
+This is useful for cron jobs, CI pipelines, or quick one-liners.
+
+### Conflict Resolution
+
+The skill resolves most conflicts automatically:
+
+| File type | Strategy |
+|-----------|----------|
+| `pyproject.toml`, `package.json` | Keep newer upstream deps, preserve project additions |
+| Justfiles, CI workflows, Dockerfiles | Prefer upstream (infrastructure stays current) |
+| Templates (`.html.jinja`) | Prefer upstream structure, keep project content |
+| Source code (`src/app/`) | Prefer project version (user code wins) |
+
+If a conflict cannot be resolved with confidence, the skill leaves the
+conflict markers in place, flags the file in the PR description, and does
+**not** auto-merge. You resolve those files manually and push to the PR branch.
+
 ## Recommended Workflow
+
+### Manual
 
 1. Commit your working tree.
 2. Run either `vibetuner scaffold update` or `just update-scaffolding`.
 3. Re-run tests (`just test-build-prod`, `just dev`) to confirm nothing broke.
 4. Commit the changes produced by the update.
+
+### With Claude Code
+
+1. Run `/update-scaffolding` (or `claude -p "run the /update-scaffolding skill"`).
+2. Review the PR it creates.
+3. Resolve any flagged conflicts if needed.
+4. Merge the PR.
 
 Refer back to this document whenever you need to adjust template answers,
 automate non-interactive scaffolding, or keep existing projects in sync with the

--- a/vibetuner-template/.claude/skills/update-scaffolding/SKILL.md
+++ b/vibetuner-template/.claude/skills/update-scaffolding/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: update-scaffolding
+description: "Update project scaffolding to the latest vibetuner template version. Checks for updates, applies them in an isolated worktree, resolves conflicts, updates dependencies, and creates a PR. Triggers on: update scaffolding, upgrade vibetuner, sync template, update template, scaffolding update."
+---
+
+# Update Scaffolding Skill
+
+Updates this project's scaffolding to the latest vibetuner template version,
+resolves conflicts, updates dependencies, and creates a PR.
+
+---
+
+## Step 1: Check for Updates
+
+Before doing any work, check if there is actually a newer version available.
+
+Read `.copier-answers.yml` in the project root to find the current template
+commit. Then check the upstream repository for newer commits:
+
+```bash
+# Get the current commit from copier answers
+current_commit=$(grep '_commit:' .copier-answers.yml | awk '{print $2}')
+template_url=$(grep '_src_path:' .copier-answers.yml | awk '{print $2}')
+
+# Check latest commit on the template repo's default branch
+latest_commit=$(git ls-remote "$template_url" HEAD | awk '{print $1}')
+
+echo "Current: $current_commit"
+echo "Latest:  $latest_commit"
+```
+
+If the commits match, inform the user that the scaffolding is already
+up to date and stop. Do NOT proceed with the update.
+
+If you cannot determine the upstream state (e.g., private repo, no network),
+warn the user and ask whether to proceed anyway.
+
+---
+
+## Step 2: Run the Update in an Isolated Worktree
+
+Use the **Agent tool** with `isolation: "worktree"` to perform all work in an
+isolated copy of the repository. This prevents interference with the user's
+working tree.
+
+Give the worktree agent the following instructions:
+
+### 2a. Update Dependencies
+
+```bash
+just update-and-commit-repo-deps
+```
+
+If there are no dependency changes, that is fine - continue to the next step.
+
+### 2b. Update Scaffolding
+
+```bash
+just update-scaffolding
+```
+
+This runs `uvx copier update -A --trust` and attempts to install dependencies.
+
+### 2c. Detect and Resolve Conflicts
+
+After the scaffolding update, check ALL files for merge conflict markers:
+
+```bash
+grep -rn '<<<<<<<\|=======\|>>>>>>>' --include='*.py' --include='*.toml' \
+  --include='*.json' --include='*.yml' --include='*.yaml' --include='*.md' \
+  --include='*.html' --include='*.html.jinja' --include='*.css' --include='*.js' \
+  --include='*.just' --include='*.justfile' --include='Dockerfile' \
+  --include='*.cfg' --include='*.txt' . || echo "No conflicts found"
+```
+
+For each conflicted file:
+
+1. **Read the file** to understand both sides of the conflict
+2. **Resolve intelligently:**
+   - For `package.json` / `pyproject.toml` / lock files: keep the newer
+     upstream versions of dependencies, preserve any project-specific additions
+   - For config files (`.yml`, `.toml`, `.cfg`): prefer upstream values for
+     framework settings, keep project-specific customizations
+   - For templates (`.html.jinja`): prefer upstream structure, preserve
+     project-specific content blocks
+   - For source code in `src/app/`: prefer the project's version (user code
+     takes precedence over template defaults)
+   - For justfiles, CI workflows, Dockerfiles: prefer upstream (infrastructure
+     should stay current)
+3. **If a conflict cannot be resolved with confidence**, leave the conflict
+   markers in place and note the file path - these will be flagged in the PR
+
+### 2d. Install Dependencies (if not already done)
+
+After resolving conflicts, ensure dependencies are synced:
+
+```bash
+bun install
+uv sync --all-extras
+```
+
+### 2e. Commit All Changes
+
+```bash
+git add -A
+git commit -m "chore: update scaffolding to latest vibetuner template"
+```
+
+### 2f. Push and Create PR
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+Then create a PR using `gh pr create`:
+
+- **Title:** `chore: update scaffolding to latest vibetuner template`
+- **Body:** Include:
+  - Summary of what was updated (dependencies, template files)
+  - List of files that had conflicts and how they were resolved
+  - If any conflicts could NOT be resolved: clearly list them with
+    instructions for manual resolution
+  - A note that the PR should be reviewed before merging
+
+**If there are unresolved conflicts**, add a PR comment explaining which files
+need manual attention and do NOT merge the PR. Inform the user.
+
+**If everything resolved cleanly**, inform the user that the PR is ready for
+review and can be merged.
+
+---
+
+## Important Notes
+
+- NEVER force-push or modify the main branch directly
+- ALWAYS create a PR for review, even if everything resolved cleanly
+- The PR title MUST use conventional commit format (`chore:` prefix)
+- If `just` commands fail, diagnose the issue - don't retry blindly
+- Report the PR URL back to the user when done

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -8,6 +8,7 @@ FastAPI + MongoDB + HTMX web application scaffolded from AllTuner's template.
 ## Executive Summary
 
 **For frontend work**: Use the `/frontend-design` skill.
+**Update scaffolding**: Use the `/update-scaffolding` skill.
 
 **Key locations**:
 Routes: `src/app/frontend/routes/` | Templates: `templates/frontend/` |
@@ -73,6 +74,26 @@ Use **conventional commits** for PR titles: `feat:`, `fix:`, `docs:`,
 Add `!` for breaking changes (e.g., `feat!:`). PR titles become squash
 commit messages. Release Please auto-generates changelogs. Versioning
 via git tags + `uv-dynamic-versioning`.
+
+---
+
+## Updating Scaffolding
+
+Use the `/update-scaffolding` skill to update to the latest vibetuner
+template. It checks for upstream changes, applies them in an isolated
+worktree, resolves conflicts, and creates a PR.
+
+```bash
+# Interactive: invoke the skill inside Claude Code
+/update-scaffolding
+
+# Headless: run directly from the command line
+claude -p "run the /update-scaffolding skill"
+```
+
+The skill will stop early if the scaffolding is already up to date.
+If conflicts can't be auto-resolved, it leaves them flagged in the PR
+for manual resolution.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a `/update-scaffolding` Claude Code skill that ships with every scaffolded project
- The skill automates the full scaffolding update workflow: checks upstream for new versions, applies updates in an isolated worktree, resolves conflicts intelligently, and creates a PR
- Unresolvable conflicts are flagged in the PR description without auto-merging
- Documents both interactive (`/update-scaffolding`) and headless (`claude -p "run the /update-scaffolding skill"`) usage

## Test plan

- [ ] Scaffold a new project and verify `.claude/skills/update-scaffolding/SKILL.md` is present
- [ ] Confirm `/update-scaffolding` appears as an available skill in Claude Code
- [ ] Test the skill on a project that is behind the latest template version
- [ ] Verify the skill stops early when scaffolding is already up to date
- [ ] Review scaffolding docs render correctly (`just docs-serve`)

Generated with [Claude Code](https://claude.com/claude-code)