### PR TITLE
fix: prevent exit code 128 in deps-pr cleanup trap

### DIFF
--- a/.justfiles/deps.justfile
+++ b/.justfiles/deps.justfile
@@ -57,7 +57,7 @@ deps-pr:
     BRANCH="chore/update-deps-${DATE_STAMP}-$(date +%H%M)"
     WORKTREE_DIR=$(mktemp -d)
 
-    cleanup() { git worktree remove --force "$WORKTREE_DIR" 2>/dev/null; git branch -D "$BRANCH" 2>/dev/null; }
+    cleanup() { cd /; git worktree remove --force "$WORKTREE_DIR" 2>/dev/null; git branch -D "$BRANCH" 2>/dev/null || true; }
     trap cleanup EXIT
 
     git fetch origin main


### PR DESCRIPTION
## Summary
- The `deps-pr` cleanup trap ran after `cd`-ing into the temp worktree directory
- Removing the worktree left git in a non-existent CWD, causing `git branch -D` to fail with exit code 128
- Fix: `cd /` before worktree removal and `|| true` on branch deletion

## Test plan
- [ ] Run `just deps-pr` and verify it exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)