### PR TITLE
fix: remove .venv and node_modules before worktree cleanup in deps-pr

### DIFF
--- a/vibetuner-template/.justfiles/deps.justfile
+++ b/vibetuner-template/.justfiles/deps.justfile
@@ -44,6 +44,7 @@ deps-scaffolding-pr:
 
     cleanup() {
         cd /
+        rm -rf "$WORKTREE_DIR/.venv" "$WORKTREE_DIR/node_modules"
         if ! git worktree remove --force "$WORKTREE_DIR" 2>/dev/null; then
             echo "Warning: could not remove worktree at $WORKTREE_DIR"
             echo "Clean up manually: rm -rf $WORKTREE_DIR && git worktree prune"


### PR DESCRIPTION
## Summary
- `deps-scaffolding-pr` creates a worktree, runs `uv sync` and `bun install` inside it, then fails to remove it because `.venv` and `node_modules` block `git worktree remove --force`
- Fix: nuke those dirs before attempting worktree removal

## Test plan
- [ ] Run `just deps-scaffolding-pr` on a downstream project and verify worktree is cleaned up without the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)