### PR TITLE
fix: always clean up existing worktree in deps-scaffolding-pr

### DIFF
--- a/vibetuner-template/.justfiles/deps.justfile
+++ b/vibetuner-template/.justfiles/deps.justfile
@@ -23,20 +23,13 @@ deps-scaffolding-pr:
     BRANCH="chore/deps-scaffolding-$(date +%Y-%m-%d-%H%M)"
     WORKTREE_DIR="$(pwd)/.tmp/deps-scaffolding"
 
-    # Handle leftover worktree from a previous run
+    # Clean up leftover worktree from a previous run
     if [ -d "$WORKTREE_DIR" ]; then
-        MTIME=$(stat -f %m "$WORKTREE_DIR" 2>/dev/null || stat -c %Y "$WORKTREE_DIR")
-        AGE_HOURS=$(( ($(date +%s) - MTIME) / 3600 ))
-        if [ "$AGE_HOURS" -ge 36 ]; then
-            echo "Removing stale worktree ($AGE_HOURS hours old)..."
-            if ! git worktree remove --force "$WORKTREE_DIR" 2>/dev/null; then
-                echo "Error: failed to remove stale worktree at $WORKTREE_DIR"
-                echo "Try manually: rm -rf $WORKTREE_DIR && git worktree prune"
-                exit 1
-            fi
-        else
-            echo "Error: $WORKTREE_DIR already exists (${AGE_HOURS}h old, <36h)."
-            echo "Resolve or remove it first: git worktree remove $WORKTREE_DIR"
+        echo "Removing existing worktree..."
+        rm -rf "$WORKTREE_DIR/.venv" "$WORKTREE_DIR/node_modules"
+        if ! git worktree remove --force "$WORKTREE_DIR" 2>/dev/null; then
+            echo "Error: failed to remove worktree at $WORKTREE_DIR"
+            echo "Try manually: rm -rf $WORKTREE_DIR && git worktree prune"
             exit 1
         fi
     fi


### PR DESCRIPTION
## Summary
- Removes the 36-hour age gate that blocked re-runs of `deps-scaffolding-pr` when a leftover worktree existed
- Each invocation creates a unique timestamped branch, so there's no reason to preserve old worktrees
- Cleans up `.venv` and `node_modules` before removal (consistent with existing cleanup function)

## Test plan
- [ ] Run `just deps-scaffolding-pr` twice in succession, verify second run cleans up and proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)