### PR TITLE
fix: preserve language settings during scaffolding updates

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -63,14 +63,12 @@ default_language:
   type: str
   help: Default language for your project (2-letter ISO 639-1 code)
   default: "en"
-  when: false
 
 supported_languages:
   type: yaml
   help: List of 2-letter lang codes of additional supported languages
   multiline: true
   default: []
-  when: false
 
 enable_watchtower:
   type: bool


### PR DESCRIPTION
## Summary

- `when: false` on `default_language` and `supported_languages` in `copier.yml` caused copier to reset them to defaults on every update, wiping user-configured values
- Removing `when: false` lets copier preserve previous answers during updates while still allowing users to change them if needed

## Test plan

- [ ] Run `copier update` on a project with custom language settings and verify they're preserved in `.copier-answers.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)