### PR TITLE
feat: add Conductor and Superset workspace support

### DIFF
--- a/vibetuner-template/.hooks/conductor-setup.sh
+++ b/vibetuner-template/.hooks/conductor-setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# ABOUTME: Conductor workspace setup wrapper.
+# ABOUTME: Normalizes Conductor env vars and delegates to workspace-setup.sh.
+set -euo pipefail
+
+export ROOT_PATH="$CONDUCTOR_ROOT_PATH"
+exec "$(dirname "$0")/workspace-setup.sh"

--- a/vibetuner-template/.hooks/superset-setup.sh
+++ b/vibetuner-template/.hooks/superset-setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# ABOUTME: Superset workspace setup wrapper.
+# ABOUTME: Normalizes Superset env vars and delegates to workspace-setup.sh.
+set -euo pipefail
+
+export ROOT_PATH="$SUPERSET_ROOT_PATH"
+exec "$(dirname "$0")/workspace-setup.sh"

--- a/vibetuner-template/.hooks/workspace-setup.sh
+++ b/vibetuner-template/.hooks/workspace-setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ABOUTME: Shared workspace setup script for all worktree-based tools.
+# ABOUTME: Called by tool-specific wrappers that set ROOT_PATH.
+set -euo pipefail
+
+if [ -z "${ROOT_PATH:-}" ]; then
+    echo "ERROR: ROOT_PATH must be set by the calling wrapper script"
+    exit 1
+fi
+
+# --- .env symlink ---
+for envfile in .env .env.local; do
+    if [ -f "$ROOT_PATH/$envfile" ] && [ ! -e "$envfile" ]; then
+        ln -sf "$ROOT_PATH/$envfile" "$envfile"
+        echo "✓ Symlinked $envfile"
+    fi
+done
+
+# --- Dependencies ---
+if [ -f "bun.lock" ] || [ -f "package.json" ]; then
+    bun install --frozen-lockfile
+    echo "✓ Bun dependencies installed"
+fi
+
+if [ -f "pyproject.toml" ]; then
+    uv sync --all-extras --all-groups --frozen
+    echo "✓ Python dependencies installed"
+fi
+
+# --- Pre-commit hooks (prek) ---
+if [ -f ".pre-commit-config.yaml" ] && command -v uv >/dev/null 2>&1; then
+    if git config --get core.hooksPath >/dev/null 2>&1; then
+        git config --local --unset-all core.hooksPath 2>/dev/null || true
+    fi
+    uv tool run prek install
+    echo "✓ Pre-commit hooks installed"
+fi
+
+# --- Tailwind sources ---
+if command -v bun >/dev/null 2>&1 && bun run --silent setup-tw-sources 2>/dev/null; then
+    echo "✓ Tailwind sources configured"
+fi

--- a/vibetuner-template/.hooks/worktree-create.sh
+++ b/vibetuner-template/.hooks/worktree-create.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# ABOUTME: Claude Code project-level worktree-create hook.
+# ABOUTME: Normalizes Claude env vars and delegates to workspace-setup.sh.
+set -euo pipefail
+
+# The global hook doesn't export CLAUDE_PROJECT_DIR to subprocesses,
+# so resolve the main worktree path via git.
+export ROOT_PATH
+ROOT_PATH="$(git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
+exec "$(dirname "$0")/workspace-setup.sh"

--- a/vibetuner-template/.superset/config.json
+++ b/vibetuner-template/.superset/config.json
@@ -1,0 +1,4 @@
+{
+  "setup": [".hooks/superset-setup.sh"],
+  "teardown": []
+}

--- a/vibetuner-template/conductor.json
+++ b/vibetuner-template/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": ".hooks/conductor-setup.sh",
+    "run": "just local-all"
+  }
+}


### PR DESCRIPTION
## Summary
- Add config files for [Conductor](https://www.conductor.build/) and [Superset](https://superset.sh/) so scaffolded projects work out of the box with parallel-agent workflows
- Shared `.hooks/workspace-setup.sh` handles .env symlinking, dependency installation, pre-commit hooks, and Tailwind setup
- Each tool gets a thin wrapper script that normalizes its env vars (`CONDUCTOR_ROOT_PATH`, `SUPERSET_ROOT_PATH`, git common dir) into `ROOT_PATH`

## Files added
| File | Purpose |
|---|---|
| `conductor.json` | Conductor config (setup + run scripts) |
| `.superset/config.json` | Superset config (setup + teardown) |
| `.hooks/workspace-setup.sh` | Shared setup logic |
| `.hooks/conductor-setup.sh` | Conductor wrapper |
| `.hooks/superset-setup.sh` | Superset wrapper |
| `.hooks/worktree-create.sh` | Claude Code project-level hook wrapper |

## Test plan
- [ ] Verify `conductor.json` is picked up by Conductor app
- [ ] Verify `.superset/config.json` is picked up by Superset app
- [ ] Test workspace-setup.sh runs correctly in a fresh worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)