### PR TITLE
fix: prevent workspace-setup hooks from blocking worktree creation

### DIFF
--- a/.hooks/workspace-setup.sh
+++ b/.hooks/workspace-setup.sh
@@ -10,14 +10,14 @@ fi
 
 # --- Python dependencies ---
 if [ -f "pyproject.toml" ]; then
-    uv sync --frozen
+    uv sync --frozen || echo "⚠ uv sync failed, continuing anyway"
     echo "✓ Python dependencies installed"
 fi
 
 # --- JavaScript dependencies ---
 for dir in vibetuner-js vibetuner-template; do
     if [ -f "$dir/bun.lock" ] || [ -f "$dir/package.json" ]; then
-        (cd "$dir" && bun install --frozen-lockfile)
+        (cd "$dir" && bun install) || echo "⚠ bun install failed in $dir, continuing anyway"
         echo "✓ Bun dependencies installed in $dir"
     fi
 done
@@ -27,6 +27,6 @@ if [ -f ".pre-commit-config.yaml" ] && command -v uv >/dev/null 2>&1; then
     if git config --get core.hooksPath >/dev/null 2>&1; then
         git config --local --unset-all core.hooksPath 2>/dev/null || true
     fi
-    uv tool run prek install
+    uv tool run prek install || echo "⚠ prek install failed, continuing anyway"
     echo "✓ Pre-commit hooks installed"
 fi

--- a/vibetuner-template/.hooks/workspace-setup.sh
+++ b/vibetuner-template/.hooks/workspace-setup.sh
@@ -18,12 +18,12 @@ done
 
 # --- Dependencies ---
 if [ -f "bun.lock" ] || [ -f "package.json" ]; then
-    bun install --frozen-lockfile
+    bun install --frozen-lockfile || echo "⚠ bun install failed, continuing anyway"
     echo "✓ Bun dependencies installed"
 fi
 
 if [ -f "pyproject.toml" ]; then
-    uv sync --all-extras --all-groups --frozen
+    uv sync --all-extras --all-groups --frozen || echo "⚠ uv sync failed, continuing anyway"
     echo "✓ Python dependencies installed"
 fi
 
@@ -32,7 +32,7 @@ if [ -f ".pre-commit-config.yaml" ] && command -v uv >/dev/null 2>&1; then
     if git config --get core.hooksPath >/dev/null 2>&1; then
         git config --local --unset-all core.hooksPath 2>/dev/null || true
     fi
-    uv tool run prek install
+    uv tool run prek install || echo "⚠ prek install failed, continuing anyway"
     echo "✓ Pre-commit hooks installed"
 fi
 


### PR DESCRIPTION
## Summary

- `claude -w` was hanging at "Running project hook..." because `workspace-setup.sh` used
  `set -euo pipefail` with no error handling on dependency install commands
- Root cause: `bun install --frozen-lockfile` failed in `vibetuner-template/` (stale
  gitignored lockfile after 9.4.0 release), causing the script to exit before the global
  hook could output the worktree path
- Added `|| echo "⚠ ..."` fallbacks to all install commands in both monorepo and template
  workspace-setup scripts (matching the pattern used by the global hook)
- Removed `--frozen-lockfile` from the monorepo's vibetuner-template bun install since
  that lockfile is gitignored

## Test plan

- [x] Verified `workspace-setup.sh` completes successfully (exit 0) with current state
- [x] Verified script continues gracefully when bun install fails (corrupted lockfile test)
- [ ] Test `claude -w` in vibetuner repo creates worktree without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)