### PR TITLE
feat: add repo icon convention for Conductor integration

### DIFF
--- a/vibetuner-template/assets/AGENTS.md
+++ b/vibetuner-template/assets/AGENTS.md
@@ -1,0 +1,37 @@
+# Assets Directory
+
+Place project icons and branding assets here.
+
+## Conductor Integration
+
+[Conductor](https://conductor.build) displays a repo icon in its sidebar.
+It searches for icon files at the repository root in a fixed order
+([docs](https://docs.conductor.build/faq#where-does-conductor-get-the-repo-icon)).
+
+A `favicon.svg` symlink at the repo root points here. To enable the
+Conductor icon, place your `favicon.svg` in this directory:
+
+```text
+assets/favicon.svg    <-- your icon goes here
+favicon.svg           <-- symlink (already set up)
+```
+
+### Supported filenames (checked in order)
+
+1. `public/apple-touch-icon.png`
+2. `apple-touch-icon.png`
+3. `public/favicon.svg`
+4. `favicon.svg`
+5. `public/favicon.png`
+6. `public/icon.png`
+7. `public/logo.png`
+8. `favicon.png`
+9. `app/icon.png`
+10. `src/app/icon.png`
+11. `public/favicon.ico`
+12. `favicon.ico`
+13. `app/favicon.ico`
+14. `static/favicon.ico`
+15. `src-tauri/icons/icon.png`
+16. `assets/icon.png`
+17. `src/assets/icon.png`

--- a/vibetuner-template/assets/CLAUDE.md
+++ b/vibetuner-template/assets/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/vibetuner-template/favicon.svg
+++ b/vibetuner-template/favicon.svg
@@ -1,0 +1,1 @@
+assets/favicon.svg


### PR DESCRIPTION
## Summary

- Add `favicon.svg` symlink at template root pointing to `assets/favicon.svg` (dangling by
  design; users drop their icon in `assets/` to activate)
- Add `assets/AGENTS.md` documenting the Conductor icon convention and supported filenames
- Add `assets/CLAUDE.md` symlink to `AGENTS.md`

Closes #1437

## Test plan

- [ ] Verify symlinks are correct (`ls -la vibetuner-template/favicon.svg`,
  `vibetuner-template/assets/CLAUDE.md`)
- [ ] Scaffold a new project and confirm the symlinks are present
- [ ] Drop a `favicon.svg` into `assets/` in a scaffolded project and verify Conductor picks
  it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)