### PR TITLE
fix: prevent orphaned granian workers on local-all shutdown

### DIFF
--- a/vibetuner-template/.justfiles/localdev.justfile
+++ b/vibetuner-template/.justfiles/localdev.justfile
@@ -12,17 +12,17 @@ dev:
 # Runs the dev environment locally without Docker
 [group('Local Development')]
 local-dev host="0.0.0.0":
-    @DEBUG=true uv run --frozen vibetuner run dev --host {{ host }}
+    @exec env DEBUG=true uv run --frozen vibetuner run dev --host {{ host }}
 
 # Runs the task worker locally without Docker
 [group('Local Development')]
 worker-dev:
-    @DEBUG=true uv run --frozen vibetuner run dev worker
+    @exec env DEBUG=true uv run --frozen vibetuner run dev worker
 
 # Runs local dev server and assets in parallel
 [group('Local Development')]
 local-all host="0.0.0.0": install-deps
-    bun run concurrently --kill-others \
+    bun run concurrently --kill-others --kill-signal SIGINT \
         --names "web,assets" \
         --prefix-colors "blue,green" \
         "just local-dev {{ host }}" \
@@ -31,7 +31,7 @@ local-all host="0.0.0.0": install-deps
 # Runs local dev server, assets, and worker in parallel (requires Redis)
 [group('Local Development')]
 local-all-with-worker: install-deps
-    bun run concurrently --kill-others \
+    bun run concurrently --kill-others --kill-signal SIGINT \
         --names "web,assets,worker" \
         --prefix-colors "blue,green,yellow" \
         "just local-dev" \


### PR DESCRIPTION
## Summary

- Use `exec` in `local-dev`/`worker-dev` justfile recipes to replace the shell process with
  `uv`, eliminating an intermediate process layer that can exit before granian finishes cleanup
- Use `--kill-signal SIGINT` in concurrently so Python receives KeyboardInterrupt instead of
  SIGTERM, giving granian a cleaner shutdown path

## Context

When running `just local-all`, granian worker processes can be left behind as orphans.
The root cause is a race between `concurrently`'s `tree-kill` cleanup and granian's internal
shutdown sequence. Granian spawns workers as non-daemon `multiprocessing.Process` instances,
so if parent processes exit before `shutdown()` → `_stop_workers()` completes, workers survive.

These two changes reduce the likelihood by:
1. Fewer process layers = less chance of a parent dying before cleanup propagates
2. SIGINT triggers Python's KeyboardInterrupt which granian handles more reliably than SIGTERM

See #1441 for full analysis of the upstream granian issue.

## Test plan

- [ ] Run `just local-all` in a scaffolded project, stop with Ctrl+C, verify no orphaned
      granian processes (`pgrep -f granian`)
- [ ] Run `just local-all`, kill the `bun dev` process separately, verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)