### PR TITLE
feat: add Emdash ADE integration

### DIFF
--- a/.emdash.json
+++ b/.emdash.json
@@ -1,0 +1,5 @@
+{
+  "setupScript": ".hooks/emdash-setup.sh",
+  "runScript": "DEV_PORT=$EMDASH_PORT just local-all",
+  "preservePatterns": [".env", ".env.local", ".env.*.local", ".envrc"]
+}

--- a/.hooks/emdash-setup.sh
+++ b/.hooks/emdash-setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# ABOUTME: Emdash workspace setup wrapper.
+# ABOUTME: Normalizes Emdash env vars and delegates to workspace-setup.sh.
+set -euo pipefail
+
+export ROOT_PATH="$EMDASH_ROOT_PATH"
+exec "$(dirname "$0")/workspace-setup.sh"

--- a/vibetuner-template/.emdash.json
+++ b/vibetuner-template/.emdash.json
@@ -1,0 +1,5 @@
+{
+  "setupScript": ".hooks/emdash-setup.sh",
+  "runScript": "DEV_PORT=$EMDASH_PORT just local-all",
+  "preservePatterns": [".env", ".env.local", ".env.*.local", ".envrc"]
+}

--- a/vibetuner-template/.hooks/emdash-setup.sh
+++ b/vibetuner-template/.hooks/emdash-setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# ABOUTME: Emdash workspace setup wrapper.
+# ABOUTME: Normalizes Emdash env vars and delegates to workspace-setup.sh.
+set -euo pipefail
+
+export ROOT_PATH="$EMDASH_ROOT_PATH"
+exec "$(dirname "$0")/workspace-setup.sh"


### PR DESCRIPTION
## Summary

- Add `.emdash.json` project config and `.hooks/emdash-setup.sh` workspace setup hook for
  [Emdash](https://docs.emdash.sh) integration, following the existing Conductor/Superset pattern
- Port management via `DEV_PORT=$EMDASH_PORT` in the run script (no framework changes needed)
- Same files added to `vibetuner-template/` so scaffolded projects get Emdash support out of the box

## Test plan

- [ ] Verify `.hooks/emdash-setup.sh` is executable and delegates to `workspace-setup.sh`
- [ ] Verify `.emdash.json` is valid JSON with correct script paths
- [ ] Confirm template versions match repo root versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)