### PR TITLE
fix: use correct emdash config schema

### DIFF
--- a/.emdash.json
+++ b/.emdash.json
@@ -1,5 +1,8 @@
 {
-  "setupScript": ".hooks/emdash-setup.sh",
-  "runScript": "DEV_PORT=$EMDASH_PORT just local-all",
+  "tmux": true,
+  "scripts": {
+    "setup": ".hooks/emdash-setup.sh",
+    "run": "DEV_PORT=$EMDASH_PORT just local-all"
+  },
   "preservePatterns": []
 }

--- a/vibetuner-template/.emdash.json
+++ b/vibetuner-template/.emdash.json
@@ -1,5 +1,8 @@
 {
-  "setupScript": ".hooks/emdash-setup.sh",
-  "runScript": "DEV_PORT=$EMDASH_PORT just local-all",
+  "tmux": true,
+  "scripts": {
+    "setup": ".hooks/emdash-setup.sh",
+    "run": "DEV_PORT=$EMDASH_PORT just local-all"
+  },
   "preservePatterns": []
 }


### PR DESCRIPTION
## Summary
- Fixed `.emdash.json` config to use the correct schema (`scripts.setup`/`scripts.run` instead of invalid top-level `setupScript`/`runScript`)
- Added `tmux: true` for persistent agent terminal sessions
- Applied to both root and `vibetuner-template/` configs

## Test plan
- [ ] Verify Emdash picks up the `setup` and `run` scripts correctly in a new task
- [ ] Verify tmux session wrapping works for agent terminals

🤖 Generated with [Claude Code](https://claude.com/claude-code)