### PR TITLE
fix: set daemon=True on worker child processes to prevent orphans

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -54,12 +54,14 @@ def _run_worker(mode: Literal["dev", "prod"], port: int, workers: int) -> None:
     web_host = "0.0.0.0"  # noqa: S104
     processes: list[Process] = []
 
-    web_process = Process(target=run_web, args=(web_host, port, worker_path))
+    web_process = Process(target=run_web, args=(web_host, port, worker_path), daemon=True)
     web_process.start()
     processes.append(web_process)
 
     for _ in range(workers - 1):
-        p = Process(target=run_worker, args=(worker_path, False, is_dev, verbose))
+        p = Process(
+            target=run_worker, args=(worker_path, False, is_dev, verbose), daemon=True
+        )
         p.start()
         processes.append(p)
 

--- a/vibetuner-py/tests/unit/test_run.py
+++ b/vibetuner-py/tests/unit/test_run.py
@@ -1,0 +1,87 @@
+# ABOUTME: Tests for the run CLI module
+# ABOUTME: Verifies worker process configuration and lifecycle behavior
+# ruff: noqa: S101
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_streaq():
+    """Provide mock streaq functions that return immediately."""
+    mock_settings = MagicMock()
+    mock_settings.workers_available = True
+    mock_settings.debug = False
+
+    with (
+        patch("vibetuner.config.settings", mock_settings),
+        patch("streaq.cli.run_worker") as mock_run_worker,
+        patch("streaq.ui.run_web") as mock_run_web,
+    ):
+        yield {
+            "settings": mock_settings,
+            "run_worker": mock_run_worker,
+            "run_web": mock_run_web,
+        }
+
+
+class TestWorkerProcessDaemonFlag:
+    """Worker child processes must be daemon so they don't orphan on unclean shutdown."""
+
+    def test_worker_processes_are_daemon(self, mock_streaq):
+        """All child processes spawned by _run_worker should have daemon=True."""
+        created_processes: list[MagicMock] = []
+        original_process = __import__("multiprocessing").Process
+
+        class TrackingProcess(original_process):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_processes.append(self)
+
+            def start(self):
+                pass  # Don't actually start processes
+
+            def terminate(self):
+                pass  # Process was never started
+
+            def join(self, timeout=None):
+                pass  # Process was never started
+
+        with patch("multiprocessing.Process", TrackingProcess):
+            from vibetuner.cli.run import _run_worker
+
+            _run_worker("dev", 9100, 1)
+
+        # At minimum, the web UI process should be spawned
+        assert len(created_processes) >= 1, "Expected at least one child process"
+        for proc in created_processes:
+            assert proc.daemon is True, "Child process must be daemon to prevent orphans"
+
+    def test_multiple_worker_processes_are_daemon(self, mock_streaq):
+        """With multiple workers, all spawned processes should be daemon."""
+        created_processes: list = []
+        original_process = __import__("multiprocessing").Process
+
+        class TrackingProcess(original_process):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                created_processes.append(self)
+
+            def start(self):
+                pass
+
+            def terminate(self):
+                pass
+
+            def join(self, timeout=None):
+                pass
+
+        with patch("multiprocessing.Process", TrackingProcess):
+            from vibetuner.cli.run import _run_worker
+
+            _run_worker("prod", 9100, 3)
+
+        # 1 web UI + 2 extra workers = 3 processes
+        assert len(created_processes) == 3
+        for proc in created_processes:
+            assert proc.daemon is True


### PR DESCRIPTION
## Summary
- Sets `daemon=True` on all child processes spawned by `_run_worker()` (monitoring web UI and extra worker processes)
- Daemon processes are automatically terminated when the main process exits, preventing orphans on unclean shutdown
- Adds tests verifying the daemon flag for both single and multi-worker configurations

Closes #1441

## Notes
- The justfile mitigations (`exec` + `--kill-signal SIGINT`) were already in place
- Granian's internal worker processes still lack `daemon=True` — that requires an upstream fix to granian itself
- The `daemon=True` flag is safe here because these leaf processes (streaq `run_worker` and `run_web`) don't spawn child processes of their own

## Test plan
- [x] New unit tests for daemon flag on single worker
- [x] New unit tests for daemon flag on multiple workers
- [x] Full test suite passes (471 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)