### PR TITLE
fix: disable djlint CSS/JS formatting to preserve Jinja delimiters

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/base/favicons.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/favicons.html.jinja
@@ -1,8 +1,20 @@
-<link rel="icon" type="image/svg+xml" href="{{ url_for('favicons', path='favicon.svg').path }}" />
-<link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('favicons', path='favicon-32x32.png').path }}" />
-<link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('favicons', path='favicon-16x16.png').path }}" />
-<link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('favicons', path='apple-touch-icon.png').path }}" />
+<link rel="icon"
+      type="image/svg+xml"
+      href="{{ url_for('favicons', path='favicon.svg').path }}" />
+<link rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="{{ url_for('favicons', path='favicon-32x32.png').path }}" />
+<link rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="{{ url_for('favicons', path='favicon-16x16.png').path }}" />
+<link rel="apple-touch-icon"
+      sizes="180x180"
+      href="{{ url_for('favicons', path='apple-touch-icon.png').path }}" />
 <link rel="manifest" href="{{ url_for('site_webmanifest').path }}" />
-<link rel="mask-icon" href="{{ url_for('favicons', path='safari-pinned-tab.svg').path }}" color="#5b2333" />
+<link rel="mask-icon"
+      href="{{ url_for('favicons', path='safari-pinned-tab.svg').path }}"
+      color="#5b2333" />
 <meta name="msapplication-TileColor" content="#5b2333" />
 <meta name="theme-color" content="#ffffff" />

--- a/vibetuner-template/djlint.toml
+++ b/vibetuner-template/djlint.toml
@@ -16,11 +16,10 @@ profile = "jinja"
 # Blank line after load/extends/include tags
 blank_line_after_tag = "load,extends,include"
 
-# Format CSS
-format_css = true
-
-# Format JS
-format_js = true
+# Disable CSS/JS formatting: djlint's formatters don't understand Jinja
+# delimiters ({{ }}) and will mangle them into nested braces.
+format_css = false
+format_js = false
 
 # Preserve leading spaces on text
 preserve_leading_space = false


### PR DESCRIPTION
## Summary
- Disables `format_js` and `format_css` in `djlint.toml` — djlint's underlying `js-beautify`/`css-beautify` formatters don't understand Jinja `{{ }}` delimiters and mangle them into nested brace expressions
- djlint's own docs acknowledge this: "Template syntax is not fully supported"
- Includes a minor cosmetic reformat of `favicons.html.jinja` (attribute line wrapping) caused by the config change

Closes #1440

## Test plan
- [x] Verified `just lint-jinja` passes (0 errors, 21 files)
- [x] Verified `just format-jinja` produces no unexpected changes
- [x] Tested with a Jinja+JS snippet — `{{ editor_html | default("") | tojson }}` is preserved intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)