### PR TITLE
feat: link OAuthAccountModel to OAuthProviderApp via app_id

### DIFF
--- a/vibetuner-py/src/vibetuner/models/oauth.py
+++ b/vibetuner-py/src/vibetuner/models/oauth.py
@@ -1,6 +1,6 @@
 from typing import Self
 
-from beanie import Document
+from beanie import Document, PydanticObjectId
 from beanie.operators import Eq
 from pydantic import Field
 
@@ -29,6 +29,10 @@ class OAuthAccountModel(Document, TimeStampMixin):
     picture: str | None = Field(
         default=None,
         description="Profile picture URL retrieved from OAuth provider",
+    )
+    app_id: PydanticObjectId | None = Field(
+        default=None,
+        description="References the OAuthProviderAppModel used during the OAuth flow",
     )
 
     class Settings:

--- a/vibetuner-py/tests/unit/test_oauth_account.py
+++ b/vibetuner-py/tests/unit/test_oauth_account.py
@@ -1,0 +1,43 @@
+# ABOUTME: Tests for the OAuthAccountModel.
+# ABOUTME: Covers model fields, defaults, and the app_id reference to OAuthProviderAppModel.
+# ruff: noqa: S101
+from unittest.mock import MagicMock
+
+import pytest
+from bson import ObjectId
+from vibetuner.models.oauth import OAuthAccountModel
+
+
+@pytest.fixture(autouse=True)
+def mock_document_settings():
+    """Allow OAuthAccountModel instantiation without MongoDB."""
+    OAuthAccountModel._document_settings = MagicMock()
+    yield
+    OAuthAccountModel._document_settings = None
+
+
+class TestOAuthAccountModel:
+    def test_app_id_defaults_to_none(self):
+        account = OAuthAccountModel(
+            provider="google",
+            provider_user_id="123",
+        )
+        assert account.app_id is None
+
+    def test_app_id_accepts_object_id(self):
+        oid = ObjectId()
+        account = OAuthAccountModel(
+            provider="google",
+            provider_user_id="123",
+            app_id=oid,
+        )
+        assert account.app_id == oid
+
+    def test_app_id_accepts_string_as_object_id(self):
+        oid = ObjectId()
+        account = OAuthAccountModel(
+            provider="google",
+            provider_user_id="123",
+            app_id=str(oid),
+        )
+        assert account.app_id == oid


### PR DESCRIPTION
## Summary
- Adds optional `app_id: PydanticObjectId | None` field to `OAuthAccountModel` referencing the `OAuthProviderAppModel` used during the OAuth flow
- Enables tracking which app credentials were used to obtain tokens (for refresh, API calls, etc.)
- Fully backward-compatible: defaults to `None`, no migration needed

## Test plan
- [x] New unit tests for `app_id` field (default `None`, accepts `ObjectId`, coerces string)
- [x] All 494 existing tests pass

Closes #1463

🤖 Generated with [Claude Code](https://claude.com/claude-code)