### PR TITLE
fix: use bundled htmx 4 preload extension instead of htmx-ext-preload

### DIFF
--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -26,7 +26,6 @@
     "concurrently": "^9.2.1",
     "daisyui": "^5.5.19",
     "htmx.org": "4.0.0-alpha8",
-    "htmx-ext-preload": "^2.1.2",
     "tailwindcss": "^4.2.1",
     "@tailwindcss/cli": "^4.2.1",
     "@tailwindcss/typography": "^0.5.19"

--- a/vibetuner-template/config.js
+++ b/vibetuner-template/config.js
@@ -2,6 +2,6 @@
 // Do not change anything between this comment and the next comment
 import htmx from "htmx.org";
 window.htmx = htmx;
-import "htmx-ext-preload";
+import "./node_modules/htmx.org/dist/ext/hx-preload.js";
 // Do not change anything between this comment and the previous one
 // End of File: do not remove this comment (do not add anything after)


### PR DESCRIPTION
## Summary

Fixes the htmx preload import from #1472. The previous PR incorrectly added
`htmx-ext-preload` (an htmx 2.x npm package). Per the [htmx 4 docs](https://four.htmx.org/docs/extensions/preload)
and [migration guide](https://four.htmx.org/docs/get-started/migration), preload is a **core extension**
bundled with htmx 4 at `dist/ext/hx-preload.js`.

- Remove `htmx-ext-preload` dependency from `vibetuner-js/package.json`
- Use `./node_modules/htmx.org/dist/ext/hx-preload.js` relative path to bypass the `exports` map

## Test plan

- [ ] Verify `bun build config.js` resolves the preload extension in a scaffolded project

🤖 Generated with [Claude Code](https://claude.com/claude-code)