### PR TITLE
fix: suppress browser password save prompt on OAuth app secret field

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_app_form.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_app_form.html.jinja
@@ -101,6 +101,7 @@
                                    name="client_secret"
                                    value=""
                                    class="input input-bordered w-full font-mono"
+                                   autocomplete="off"
                                    placeholder="{{ '(unchanged)' if app else '' }}"
                                    {{ '' if app else 'required' }} />
                             {% if app %}


### PR DESCRIPTION
## Summary
- Add `autocomplete="off"` to the `client_secret` input in the OAuth app debug form
- Prevents Safari (and other browsers) from offering to save the OAuth client secret as a login password

Fixes #1477

## Test plan
- [ ] Open `/debug/oauth-apps` create form in Safari, fill in client_secret, submit - no password save prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)