### PR TITLE
feat: add generic OAuth app capability detection interface

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -1,6 +1,6 @@
 # ABOUTME: OAuth provider integration using Authlib.
 # ABOUTME: Handles provider registration, builtin configs, and auth flow handlers.
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.starlette_client import OAuth
@@ -76,6 +76,17 @@ PROVIDER_IDENTIFIERS: dict[str, str] = {}
 
 def get_oauth_providers() -> list[str]:
     return list(_PROVIDERS.keys())
+
+
+async def detect_capabilities(provider_name: str, token: dict[str, Any]) -> list[str]:
+    """Detect capabilities for a provider using its registered detector.
+
+    Returns an empty list when the provider is unknown or has no detector.
+    """
+    provider = _PROVIDERS.get(provider_name)
+    if not provider or not provider.capability_detector:
+        return []
+    return await provider.capability_detector.detect(token)
 
 
 def get_registered_providers() -> dict[str, OauthProviderModel]:

--- a/vibetuner-py/src/vibetuner/provider.py
+++ b/vibetuner-py/src/vibetuner/provider.py
@@ -1,15 +1,39 @@
 # ABOUTME: OAuth provider configuration model (beanie-free).
 # ABOUTME: Lives outside models/ to avoid triggering models/__init__.py import chain.
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+
+
+class CapabilityDetector(ABC):
+    """Detects capabilities available to an OAuth app from its token response."""
+
+    @abstractmethod
+    async def detect(self, token: dict[str, Any]) -> list[str]:
+        """Return capability strings detected from the token or provider APIs."""
+
+
+class ScopeCapabilityDetector(CapabilityDetector):
+    """Extracts granted scopes from the OAuth token response."""
+
+    async def detect(self, token: dict[str, Any]) -> list[str]:
+        scope = token.get("scope", "")
+        if isinstance(scope, list):
+            return list(scope)
+        if isinstance(scope, str):
+            return [s for s in scope.split() if s]
+        return []
 
 
 class OauthProviderModel(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     identifier: str
     params: dict[str, str] = {}
     client_kwargs: dict[str, str]
     config: dict[str, str]
     compliance_fix: Callable[..., Any] | None = None
     login_routes: bool = True
+    capability_detector: CapabilityDetector | None = None

--- a/vibetuner-py/tests/unit/test_capability_detection.py
+++ b/vibetuner-py/tests/unit/test_capability_detection.py
@@ -1,0 +1,178 @@
+# ABOUTME: Tests for OAuth app capability detection interface.
+# ABOUTME: Covers the CapabilityDetector ABC, ScopeCapabilityDetector, and detect_capabilities().
+# ruff: noqa: S101
+import pytest
+from vibetuner.frontend.oauth import (
+    _PROVIDERS,
+    PROVIDER_IDENTIFIERS,
+    detect_capabilities,
+)
+from vibetuner.models.oauth import OauthProviderModel
+from vibetuner.provider import CapabilityDetector, ScopeCapabilityDetector
+
+
+@pytest.fixture(autouse=True)
+def clean_provider_registry():
+    """Clear provider registry before and after each test."""
+    _PROVIDERS.clear()
+    PROVIDER_IDENTIFIERS.clear()
+    yield
+    _PROVIDERS.clear()
+    PROVIDER_IDENTIFIERS.clear()
+
+
+class TestCapabilityDetectorABC:
+    """Tests for the CapabilityDetector abstract base class."""
+
+    def test_cannot_instantiate_directly(self):
+        with pytest.raises(TypeError):
+            CapabilityDetector()
+
+    def test_subclass_must_implement_detect(self):
+        class Incomplete(CapabilityDetector):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_subclass_with_detect_is_valid(self):
+        class Valid(CapabilityDetector):
+            async def detect(self, token):
+                return []
+
+        detector = Valid()
+        assert isinstance(detector, CapabilityDetector)
+
+
+class TestScopeCapabilityDetector:
+    """Tests for the built-in scope-based capability detector."""
+
+    @pytest.fixture()
+    def detector(self):
+        return ScopeCapabilityDetector()
+
+    @pytest.mark.asyncio()
+    async def test_extracts_space_separated_scopes(self, detector):
+        token = {"scope": "openid email profile"}
+        result = await detector.detect(token)
+        assert result == ["openid", "email", "profile"]
+
+    @pytest.mark.asyncio()
+    async def test_empty_scope_string(self, detector):
+        token = {"scope": ""}
+        result = await detector.detect(token)
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_missing_scope_key(self, detector):
+        token = {"access_token": "abc123"}
+        result = await detector.detect(token)
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_scope_as_list(self, detector):
+        token = {"scope": ["read", "write", "admin"]}
+        result = await detector.detect(token)
+        assert result == ["read", "write", "admin"]
+
+    @pytest.mark.asyncio()
+    async def test_single_scope(self, detector):
+        token = {"scope": "user:email"}
+        result = await detector.detect(token)
+        assert result == ["user:email"]
+
+    @pytest.mark.asyncio()
+    async def test_strips_extra_whitespace(self, detector):
+        token = {"scope": "  openid   email  "}
+        result = await detector.detect(token)
+        assert result == ["openid", "email"]
+
+
+class TestOauthProviderModelDetector:
+    """Tests for the capability_detector field on OauthProviderModel."""
+
+    def test_defaults_to_none(self):
+        provider = OauthProviderModel(
+            identifier="id",
+            params={},
+            client_kwargs={"scope": "openid"},
+            config={},
+        )
+        assert provider.capability_detector is None
+
+    def test_accepts_detector_instance(self):
+        detector = ScopeCapabilityDetector()
+        provider = OauthProviderModel(
+            identifier="id",
+            params={},
+            client_kwargs={"scope": "openid"},
+            config={},
+            capability_detector=detector,
+        )
+        assert provider.capability_detector is detector
+
+
+class TestDetectCapabilities:
+    """Tests for the detect_capabilities() utility function."""
+
+    @pytest.mark.asyncio()
+    async def test_returns_empty_for_unknown_provider(self):
+        result = await detect_capabilities("nonexistent", {"scope": "openid"})
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_returns_empty_when_no_detector(self):
+        from vibetuner.frontend.oauth import register_oauth_provider
+
+        provider = OauthProviderModel(
+            identifier="id",
+            params={},
+            client_kwargs={"scope": "openid"},
+            config={"TEST_CLIENT_ID": "id", "TEST_CLIENT_SECRET": "secret"},
+        )
+        register_oauth_provider("test_provider", provider)
+
+        result = await detect_capabilities("test_provider", {"scope": "openid email"})
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_delegates_to_provider_detector(self):
+        from vibetuner.frontend.oauth import register_oauth_provider
+
+        detector = ScopeCapabilityDetector()
+        provider = OauthProviderModel(
+            identifier="id",
+            params={},
+            client_kwargs={"scope": "openid"},
+            config={"TEST_CLIENT_ID": "id", "TEST_CLIENT_SECRET": "secret"},
+            capability_detector=detector,
+        )
+        register_oauth_provider("test_provider", provider)
+
+        result = await detect_capabilities(
+            "test_provider", {"scope": "openid email profile"}
+        )
+        assert result == ["openid", "email", "profile"]
+
+    @pytest.mark.asyncio()
+    async def test_custom_detector(self):
+        from vibetuner.frontend.oauth import register_oauth_provider
+
+        class FixedDetector(CapabilityDetector):
+            async def detect(self, token):
+                return ["post", "read"] if "access_token" in token else []
+
+        provider = OauthProviderModel(
+            identifier="id",
+            params={},
+            client_kwargs={"scope": "openid"},
+            config={"TEST_CLIENT_ID": "id", "TEST_CLIENT_SECRET": "secret"},
+            capability_detector=FixedDetector(),
+        )
+        register_oauth_provider("test_provider", provider)
+
+        result = await detect_capabilities("test_provider", {"access_token": "abc123"})
+        assert result == ["post", "read"]
+
+        result_no_token = await detect_capabilities("test_provider", {})
+        assert result_no_token == []


### PR DESCRIPTION
## Summary

- Adds `CapabilityDetector` ABC and built-in `ScopeCapabilityDetector` to `provider.py`
- Adds optional `capability_detector` field to `OauthProviderModel`
- Adds `detect_capabilities()` utility function to `oauth.py`
- 15 tests covering the ABC contract, scope extraction, model integration, and detection dispatch

## Context

Split from #1465 into generic (#1483) and provider-specific (#1484) parts.

This PR implements the generic framework plumbing. Provider-specific detectors
(LinkedIn, GitHub, Meta, Twitter) are tracked in #1484 for future work.

## Test plan

- [x] `CapabilityDetector` ABC enforces `detect()` implementation
- [x] `ScopeCapabilityDetector` handles space-separated strings, lists, empty/missing values
- [x] `OauthProviderModel` accepts and defaults `capability_detector`
- [x] `detect_capabilities()` dispatches to registered detector or returns empty list
- [x] Custom detector subclasses work end-to-end
- [x] Full suite (520 tests) passes

Closes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)