### PR TITLE
feat: show DB-backed OAuth apps on the login page

### DIFF
--- a/vibetuner-docs/docs/authentication.md
+++ b/vibetuner-docs/docs/authentication.md
@@ -242,6 +242,18 @@ client with the app's credentials, and returns the client name.
 The built-in login and callback routes accept an optional `app_id` query
 parameter that flows through this resolution automatically.
 
+#### Login Page
+
+Active database-backed OAuth apps appear on the login page as additional
+sign-in buttons alongside env-var providers. Each button shows the
+provider name and the app's human-readable `name` field (e.g.,
+"Continue with Google · Acme Corp").
+
+Only apps whose `provider` references a registered provider with
+`login_routes=True` are displayed. Inactive apps (`is_active=False`)
+are excluded. No extra configuration is needed; creating an active
+`OAuthProviderAppModel` for a registered provider is enough.
+
 #### App-to-Account Linking
 
 When a user authenticates through a database-backed OAuth app, the `app_id`

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -886,7 +886,10 @@ client_name = await resolve_oauth_client("linkedin", app_id="6801...")
 ```
 
 The built-in login and callback routes accept an optional `app_id` query parameter
-that flows through this resolution automatically.
+that flows through this resolution automatically. Active database-backed apps
+appear on the login page as additional sign-in buttons (e.g., "Continue with
+Google · Acme Corp") alongside env-var providers, for any registered provider
+with `login_routes=True`.
 
 #### Protecting Routes
 

--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -116,6 +116,20 @@ def _register_app_client(app: "OAuthProviderAppModel") -> str:
     return client_name
 
 
+async def get_db_oauth_apps() -> list["OAuthProviderAppModel"]:
+    """Return active DB-backed OAuth apps for providers with login routes."""
+    from vibetuner.models.oauth_app import OAuthProviderAppModel
+
+    providers_with_routes = {
+        name for name, config in _PROVIDERS.items() if config.login_routes
+    }
+    if not providers_with_routes:
+        return []
+
+    apps = await OAuthProviderAppModel.get_all_active()
+    return [app for app in apps if app.provider in providers_with_routes]
+
+
 async def resolve_oauth_client(provider_name: str, app_id: str | None) -> str:
     """Resolve the Authlib client name, optionally loading a DB-backed app.
 

--- a/vibetuner-py/src/vibetuner/frontend/routes/auth.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/auth.py
@@ -19,6 +19,7 @@ from ..email import send_magic_link_email
 from ..oauth import (
     _create_auth_handler,
     _create_auth_login_handler,
+    get_db_oauth_apps,
     get_registered_providers,
 )
 from ..templates import render_template
@@ -61,13 +62,15 @@ async def auth_login(
         for name, config in get_registered_providers().items()
         if config.login_routes
     ]
+    db_apps = await get_db_oauth_apps()
     return render_template(
         "login.html.jinja",
         request=request,
         ctx={
             "providers": oauth_providers,
+            "db_apps": db_apps,
             "next": next,
-            "has_oauth": bool(oauth_providers),
+            "has_oauth": bool(oauth_providers) or bool(db_apps),
             "has_email": True,
         },
     )

--- a/vibetuner-py/src/vibetuner/models/oauth_app.py
+++ b/vibetuner-py/src/vibetuner/models/oauth_app.py
@@ -54,6 +54,10 @@ class OAuthProviderAppModel(Document, TimeStampMixin):
         ]
 
     @classmethod
+    async def get_all_active(cls) -> list[Self]:
+        return await cls.find(Eq(cls.is_active, True)).to_list()
+
+    @classmethod
     async def get_active_by_provider(cls, provider: str) -> list[Self]:
         return await cls.find(
             Eq(cls.provider, provider),

--- a/vibetuner-py/src/vibetuner/templates/frontend/login.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/login.html.jinja
@@ -13,7 +13,7 @@
                     <p class="text-base-content/70">{{ _("Choose your preferred sign-in method") }}</p>
                 </div>
                 <!-- OAuth Providers -->
-                {% if has_oauth and providers %}
+                {% if has_oauth %}
                     <div class="space-y-3 mb-6">
                         {% for provider in providers %}
                             {% set login_url = url_for('login_with_' + provider) %}
@@ -25,10 +25,20 @@
                                 <span>{{ _("Continue with %(provider)s") | format(provider=provider.title()) }}</span>
                             </a>
                         {% endfor %}
+                        {% for app in db_apps %}
+                            {% set login_url = url_for('login_with_' + app.provider) ~ '?app_id=' ~ app.id %}
+                            {% if next %}
+                                {% set login_url = login_url ~ '&next=' ~ next %}
+                            {% endif %}
+                            <a href="{{ login_url }}"
+                               class="btn btn-outline btn-block justify-start gap-3 hover:btn-primary group transition-all duration-300 hover:scale-[1.02]">
+                                <span>{{ _("Continue with %(provider)s") | format(provider=app.provider.title()) }} · {{ app.name }}</span>
+                            </a>
+                        {% endfor %}
                     </div>
                 {% endif %}
                 <!-- Divider -->
-                {% if has_oauth and providers and has_email %}<div class="divider text-base-content/50">{{ _("OR") }}</div>{% endif %}
+                {% if has_oauth and has_email %}<div class="divider text-base-content/50">{{ _("OR") }}</div>{% endif %}
                 <!-- Email Magic Link -->
                 {% if has_email %}
                     <div class="bg-base-200/50 rounded-2xl p-6 border border-base-300/50">

--- a/vibetuner-py/tests/unit/test_login_db_apps.py
+++ b/vibetuner-py/tests/unit/test_login_db_apps.py
@@ -1,0 +1,143 @@
+# ABOUTME: Tests for DB-backed OAuth apps appearing on the login page.
+# ABOUTME: Verifies that active apps for providers with login routes are surfaced.
+# ruff: noqa: S101
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+from vibetuner.config import settings
+from vibetuner.frontend.oauth import (
+    _PROVIDERS,
+    PROVIDER_IDENTIFIERS,
+    auto_register_providers,
+    get_db_oauth_apps,
+    register_oauth_provider,
+)
+from vibetuner.models.oauth import OauthProviderModel
+
+
+@pytest.fixture(autouse=True)
+def clean_provider_registry():
+    """Clear provider registry before and after each test."""
+    _PROVIDERS.clear()
+    PROVIDER_IDENTIFIERS.clear()
+    yield
+    _PROVIDERS.clear()
+    PROVIDER_IDENTIFIERS.clear()
+
+
+def _fake_app(provider: str, name: str) -> MagicMock:
+    """Create a fake OAuthProviderAppModel-like object for testing."""
+    app = MagicMock()
+    app.provider = provider
+    app.name = name
+    return app
+
+
+class TestGetDbOauthApps:
+    """Tests for get_db_oauth_apps()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_apps_for_registered_providers(self, monkeypatch):
+        """Active apps for providers with login routes appear in the result."""
+        monkeypatch.setattr(settings, "google_client_id", SecretStr("test-id"))
+        monkeypatch.setattr(settings, "google_client_secret", SecretStr("test-secret"))
+        auto_register_providers(["google"])
+
+        app = _fake_app("google", "Acme Corp")
+
+        with patch("vibetuner.models.oauth_app.OAuthProviderAppModel") as mock_model:
+            mock_model.get_all_active = AsyncMock(return_value=[app])
+            result = await get_db_oauth_apps()
+
+        assert len(result) == 1
+        assert result[0].name == "Acme Corp"
+        assert result[0].provider == "google"
+
+    @pytest.mark.asyncio
+    async def test_excludes_apps_for_unregistered_providers(self, monkeypatch):
+        """Apps for providers not in the registry are excluded."""
+        monkeypatch.setattr(settings, "google_client_id", SecretStr("test-id"))
+        monkeypatch.setattr(settings, "google_client_secret", SecretStr("test-secret"))
+        auto_register_providers(["google"])
+
+        google_app = _fake_app("google", "My App")
+        linkedin_app = _fake_app("linkedin", "Other App")
+
+        with patch("vibetuner.models.oauth_app.OAuthProviderAppModel") as mock_model:
+            mock_model.get_all_active = AsyncMock(
+                return_value=[google_app, linkedin_app]
+            )
+            result = await get_db_oauth_apps()
+
+        assert len(result) == 1
+        assert result[0].provider == "google"
+
+    @pytest.mark.asyncio
+    async def test_excludes_apps_for_providers_without_login_routes(self):
+        """Apps for providers with login_routes=False are excluded."""
+        register_oauth_provider(
+            "linkedin",
+            OauthProviderModel(
+                identifier="sub",
+                params={"authorize_url": "https://example.com/auth"},
+                client_kwargs={"scope": "openid"},
+                config={
+                    "LINKEDIN_CLIENT_ID": "id",
+                    "LINKEDIN_CLIENT_SECRET": "secret",
+                },
+                login_routes=False,
+            ),
+        )
+
+        app = _fake_app("linkedin", "LinkedIn App")
+
+        with patch("vibetuner.models.oauth_app.OAuthProviderAppModel") as mock_model:
+            mock_model.get_all_active = AsyncMock(return_value=[app])
+            result = await get_db_oauth_apps()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_apps(self, monkeypatch):
+        """No active apps in the database means empty result."""
+        monkeypatch.setattr(settings, "google_client_id", SecretStr("test-id"))
+        monkeypatch.setattr(settings, "google_client_secret", SecretStr("test-secret"))
+        auto_register_providers(["google"])
+
+        with patch("vibetuner.models.oauth_app.OAuthProviderAppModel") as mock_model:
+            mock_model.get_all_active = AsyncMock(return_value=[])
+            result = await get_db_oauth_apps()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_providers_registered(self):
+        """No registered providers means no apps shown, even if DB has apps."""
+        app = _fake_app("google", "Some App")
+
+        with patch("vibetuner.models.oauth_app.OAuthProviderAppModel") as mock_model:
+            mock_model.get_all_active = AsyncMock(return_value=[app])
+            result = await get_db_oauth_apps()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_apps_for_same_provider(self, monkeypatch):
+        """Multiple apps for the same provider are all returned."""
+        monkeypatch.setattr(settings, "google_client_id", SecretStr("test-id"))
+        monkeypatch.setattr(settings, "google_client_secret", SecretStr("test-secret"))
+        auto_register_providers(["google"])
+
+        apps = [
+            _fake_app("google", "Personal"),
+            _fake_app("google", "Work"),
+        ]
+
+        with patch("vibetuner.models.oauth_app.OAuthProviderAppModel") as mock_model:
+            mock_model.get_all_active = AsyncMock(return_value=apps)
+            result = await get_db_oauth_apps()
+
+        assert len(result) == 2
+        names = {a.name for a in result}
+        assert names == {"Personal", "Work"}


### PR DESCRIPTION
## Summary
- Active `OAuthProviderAppModel` entries now appear as additional sign-in buttons on the login page
- Each button displays "Continue with {Provider} · {App Name}" and links to the existing login route with `?app_id=`
- Only apps for registered providers with `login_routes=True` are shown; inactive apps are excluded

## Changes
- **`oauth_app.py`**: Added `get_all_active()` class method
- **`oauth.py`**: Added `get_db_oauth_apps()` to query eligible apps
- **`auth.py`**: Login handler now passes `db_apps` to the template
- **`login.html.jinja`**: Renders DB-backed apps as additional buttons
- **`authentication.md` / `llms-full.txt`**: Documented the login page behavior
- **`test_login_db_apps.py`**: 6 unit tests covering filtering logic

## Test plan
- [x] All 511 unit tests pass
- [x] Jinja lint passes
- [x] Pre-commit hooks pass
- [ ] Manual verification: create an `OAuthProviderAppModel` and confirm it appears on `/auth/login`

Closes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)