### PR TITLE
docs: document env-var registration requirement for login page OAuth apps

### DIFF
--- a/vibetuner-docs/docs/authentication.md
+++ b/vibetuner-docs/docs/authentication.md
@@ -254,6 +254,11 @@ Only apps whose `provider` references a registered provider with
 are excluded. No extra configuration is needed; creating an active
 `OAuthProviderAppModel` for a registered provider is enough.
 
+The provider must be registered via env-var credentials for its login
+route to exist. Database-backed apps for a provider that has no
+env-var registration will not appear on the login page because the
+route they would link to does not exist.
+
 #### App-to-Account Linking
 
 When a user authenticates through a database-backed OAuth app, the `app_id`

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -889,7 +889,9 @@ The built-in login and callback routes accept an optional `app_id` query paramet
 that flows through this resolution automatically. Active database-backed apps
 appear on the login page as additional sign-in buttons (e.g., "Continue with
 Google · Acme Corp") alongside env-var providers, for any registered provider
-with `login_routes=True`.
+with `login_routes=True`. The provider must be registered via env-var
+credentials for its login route to exist; DB-backed apps for unregistered
+providers will not appear on the login page.
 
 #### Protecting Routes
 


### PR DESCRIPTION
## Summary
- Documents the requirement that DB-backed OAuth apps only appear on the login page when the provider is also registered via env-var credentials
- Updated both `authentication.md` and `llms-full.txt`

Follow-up to #1486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)