### PR TITLE
fix: prevent browser password manager on OAuth app form

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_app_form.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_app_form.html.jinja
@@ -44,6 +44,7 @@
             <div class="card bg-base-100 shadow-xl mb-6">
                 <div class="card-body">
                     <form method="post"
+                          autocomplete="off"
                           action="{{ url_for('debug_oauth_app_update', app_id=app.id) if app else url_for('debug_oauth_app_store') }}">
                         <!-- Provider -->
                         <div class="form-control w-full mb-4">


### PR DESCRIPTION
## Summary
- Add `autocomplete="off"` to the `<form>` element in the OAuth app create/edit template
- Prevents browsers from detecting the `client_secret` field as login credentials and
  triggering the password manager save prompt

Closes #1491

## Test plan
- [ ] Navigate to `/debug/oauth-apps/create`, fill in form, submit
- [ ] Verify browser does not prompt to save password

🤖 Generated with [Claude Code](https://claude.com/claude-code)