### PR TITLE
feat: soft delete support via Beanie's DocumentWithSoftDelete

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -237,6 +237,55 @@ For SQL databases, create tables with: `vibetuner db create-schema`
     Projects that only use SQLModel/Postgres do not need `MONGODB_URL`.
     The framework silently skips MongoDB initialization when the URL is not set.
 
+#### Soft Delete
+
+Instead of permanently removing documents, soft delete marks them with a `deleted_at` timestamp.
+Soft-deleted documents stay in the database but are automatically excluded from queries.
+
+Use `DocumentWithSoftDelete` instead of `Document` as your base class:
+
+```python
+# src/app/models/post.py
+from vibetuner.models import DocumentWithSoftDelete
+from vibetuner.models.mixins import TimeStampMixin
+
+class Post(DocumentWithSoftDelete, TimeStampMixin):
+    title: str
+    content: str
+
+    class Settings:
+        name = "posts"
+```
+
+This adds an optional `deleted_at` field to your document automatically.
+
+**Deleting and querying:**
+
+```python
+post = await Post.find_one(Post.title == "Draft")
+
+await post.delete()          # sets deleted_at, document stays in DB
+post.is_deleted()            # True
+
+await Post.find_all().to_list()          # excludes soft-deleted documents
+await Post.find_many_in_all().to_list()  # includes soft-deleted documents
+
+await post.hard_delete()     # permanently removes the document
+```
+
+`find()`, `find_one()`, and `get()` all automatically filter out soft-deleted documents.
+Use `find_many_in_all()` when you need to access them (e.g., admin views, audit logs).
+
+**Restoring a soft-deleted document:**
+
+```python
+post.deleted_at = None
+await post.save()
+```
+
+**CRUD factory:** The `DELETE` endpoint automatically performs a soft delete for models
+that use `DocumentWithSoftDelete`. No configuration needed.
+
 ### Creating Templates
 
 Add templates in `templates/frontend/`:

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -283,6 +283,27 @@ __all__ = ["Post"]
 
 The model will be automatically registered with the database on startup.
 
+**Soft Delete (MongoDB)**
+
+Use `DocumentWithSoftDelete` instead of `Document` to mark documents as deleted instead of removing them:
+
+```python
+from vibetuner.models import DocumentWithSoftDelete
+from vibetuner.models.mixins import TimeStampMixin
+
+class Post(DocumentWithSoftDelete, TimeStampMixin):
+    title: str
+    content: str
+
+    class Settings:
+        name = "posts"
+```
+
+Soft-deleted documents are automatically excluded from `find()`, `find_one()`, and `get()` queries.
+Use `find_many_in_all()` to include them. `delete()` sets `deleted_at` instead of removing the document.
+`hard_delete()` permanently removes it. To restore: `doc.deleted_at = None; await doc.save()`.
+The CRUD factory's DELETE endpoint automatically performs a soft delete for these models.
+
 #### Creating Templates
 
 Add templates in `templates/`:

--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -159,7 +159,7 @@ def _register_create_route(
                 logger.error(f"Hook execution failed: pre_create: {exc}")
                 raise HTTPException(
                     status_code=500, detail="Hook execution failed: pre_create"
-                )
+                ) from exc
 
         doc = model(**data.model_dump())
         await doc.insert()
@@ -173,7 +173,7 @@ def _register_create_route(
                 logger.error(f"Hook execution failed: post_create: {exc}")
                 raise HTTPException(
                     status_code=500, detail="Hook execution failed: post_create"
-                )
+                ) from exc
 
         return _serialize_one(doc, response_schema)
 
@@ -224,7 +224,7 @@ def _register_update_route(
                 logger.error(f"Hook execution failed: pre_update: {exc}")
                 raise HTTPException(
                     status_code=500, detail="Hook execution failed: pre_update"
-                )
+                ) from exc
 
         update_data = data.model_dump(exclude_unset=True)
         if update_data:
@@ -239,7 +239,7 @@ def _register_update_route(
                 logger.error(f"Hook execution failed: post_update: {exc}")
                 raise HTTPException(
                     status_code=500, detail="Hook execution failed: post_update"
-                )
+                ) from exc
 
         return _serialize_one(doc, response_schema)
 
@@ -266,7 +266,7 @@ def _register_delete_route(
                 logger.error(f"Hook execution failed: pre_delete: {exc}")
                 raise HTTPException(
                     status_code=500, detail="Hook execution failed: pre_delete"
-                )
+                ) from exc
 
         await doc.delete()
 
@@ -279,7 +279,7 @@ def _register_delete_route(
                 logger.error(f"Hook execution failed: post_delete: {exc}")
                 raise HTTPException(
                     status_code=500, detail="Hook execution failed: post_delete"
-                )
+                ) from exc
 
         return None
 
@@ -434,7 +434,7 @@ def _get_collection_name(model: type[Document]) -> str:
 
 def _build_create_schema(model: type[Document]) -> type[BaseModel]:
     """Build a Pydantic create schema from a Beanie Document, excluding id and internal fields."""
-    excluded = {"id", "revision_id", "db_insert_dt", "db_update_dt"}
+    excluded = {"id", "revision_id", "db_insert_dt", "db_update_dt", "deleted_at"}
     fields: dict[str, Any] = {}
     for name, field_info in model.model_fields.items():
         if name in excluded:

--- a/vibetuner-py/src/vibetuner/models/__init__.py
+++ b/vibetuner-py/src/vibetuner/models/__init__.py
@@ -1,4 +1,4 @@
-from beanie import Document, View
+from beanie import Document, DocumentWithSoftDelete, View
 
 from vibetuner.tasks.robust import DeadLetterModel
 
@@ -11,6 +11,7 @@ from .user import UserModel
 
 
 __all__: list[type[Document] | type[View]] = [
+    DocumentWithSoftDelete,
     BlobModel,
     ConfigEntryModel,
     DeadLetterModel,

--- a/vibetuner-py/tests/unit/test_soft_delete.py
+++ b/vibetuner-py/tests/unit/test_soft_delete.py
@@ -1,0 +1,65 @@
+# ABOUTME: Tests for soft delete support.
+# ABOUTME: Verifies re-export of DocumentWithSoftDelete and CRUD schema exclusion of deleted_at.
+# ruff: noqa: S101
+
+from beanie import DocumentWithSoftDelete
+from vibetuner.crud import _build_create_schema, _build_update_schema
+from vibetuner.models.mixins import TimeStampMixin
+
+
+class SoftDeleteProduct(DocumentWithSoftDelete):
+    """Test model using soft delete."""
+
+    name: str
+    price: float
+
+    class Settings:
+        name = "test_soft_delete_products"
+
+
+class SoftDeleteWithTimestamps(DocumentWithSoftDelete, TimeStampMixin):
+    """Test model combining soft delete with timestamps."""
+
+    title: str
+
+    class Settings:
+        name = "test_soft_delete_timestamped"
+
+
+class TestSoftDeleteReExport:
+    """Test that DocumentWithSoftDelete is re-exported from vibetuner.models."""
+
+    def test_importable_from_vibetuner_models(self):
+        from vibetuner.models import DocumentWithSoftDelete as Cls
+
+        assert Cls is DocumentWithSoftDelete
+
+    def test_is_document_subclass(self):
+        from beanie import Document
+
+        assert issubclass(DocumentWithSoftDelete, Document)
+
+
+class TestCrudSchemaExcludesDeletedAt:
+    """Test that CRUD auto-generated schemas exclude deleted_at."""
+
+    def test_create_schema_excludes_deleted_at(self):
+        schema = _build_create_schema(SoftDeleteProduct)
+        assert "deleted_at" not in schema.model_fields
+
+    def test_create_schema_keeps_user_fields(self):
+        schema = _build_create_schema(SoftDeleteProduct)
+        assert "name" in schema.model_fields
+        assert "price" in schema.model_fields
+
+    def test_update_schema_excludes_deleted_at(self):
+        create = _build_create_schema(SoftDeleteProduct)
+        update = _build_update_schema(create)
+        assert "deleted_at" not in update.model_fields
+
+    def test_create_schema_excludes_deleted_at_with_timestamps(self):
+        schema = _build_create_schema(SoftDeleteWithTimestamps)
+        assert "deleted_at" not in schema.model_fields
+        assert "db_insert_dt" not in schema.model_fields
+        assert "db_update_dt" not in schema.model_fields
+        assert "title" in schema.model_fields


### PR DESCRIPTION
## Summary

- Re-export `DocumentWithSoftDelete` from `vibetuner.models` so users can import it directly
- Fix `_build_create_schema` in CRUD factory to exclude `deleted_at` from auto-generated schemas
- Add soft delete documentation to development guide and LLM docs
- Fix pre-existing B904 lint errors in CRUD factory hooks (`raise ... from exc`)

## Test plan

- [x] Unit tests for re-export (`from vibetuner.models import DocumentWithSoftDelete`)
- [x] Unit tests for CRUD schema exclusion of `deleted_at`
- [x] Full unit test suite passes (574 tests)
- [x] Pre-commit hooks pass

Closes #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)