### PR TITLE
docs: document HTMX 4 event handling breaking changes and disable view transitions

### DIFF
--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -162,6 +162,97 @@ import "htmx-ext-preload";
 import "htmx.org/dist/ext/hx-preload.js";
 ```
 
+## Event Names Changed from camelCase to Colon-Separated
+
+All htmx event names switched from camelCase to colon-separated format.
+
+**Before (v2):**
+
+```javascript
+document.addEventListener("htmx:afterRequest", handler);
+document.addEventListener("htmx:beforeSwap", handler);
+document.addEventListener("htmx:afterSettle", handler);
+```
+
+**After (v4):**
+
+```javascript
+element.addEventListener("htmx:after:request", handler);
+element.addEventListener("htmx:before:swap", handler);
+element.addEventListener("htmx:after:settle", handler);
+```
+
+!!! warning
+    Events no longer bubble to `document.body` in v4. You must attach listeners
+    directly to the element or use `hx-on` attributes. Delegation patterns like
+    `document.body.addEventListener('htmx:after:request', ...)` do not work.
+
+## Event Handler Attributes (`hx-on`)
+
+The `hx-on::` shorthand (e.g., `hx-on::after-request`) is broken in htmx 4.0.0-alpha8.
+It registers a listener for `:after-request`, but the dispatched event is
+`htmx:after:request`. Use the explicit long form instead.
+
+**Before (v2):**
+
+```html
+<form hx-on::after-request="if(event.detail.successful) this.reset()">
+```
+
+**After (v4):**
+
+```html
+<form hx-on:htmx:after:request="this.reset()">
+```
+
+!!! note
+    The `hx-on::` shorthand may be fixed in a future htmx release, but the long
+    form `hx-on:htmx:after:request` works reliably and is the recommended approach.
+
+## Event Detail Structure Changed
+
+The `event.detail` object was restructured. Properties that existed at the top level
+are now nested under `event.detail.ctx`.
+
+**Before (v2):**
+
+```javascript
+event.detail.successful   // boolean
+event.detail.elt          // the triggering element
+event.detail.xhr          // XMLHttpRequest object
+```
+
+**After (v4):**
+
+```javascript
+event.detail.ctx                // context object
+event.detail.ctx.sourceElement  // the triggering element
+event.detail.ctx.response       // response object
+event.detail.ctx.status         // request status string
+```
+
+!!! danger
+    `event.detail.successful` is `undefined` in v4, which is falsy. Any code
+    checking `if(event.detail.successful)` silently skips the handler body
+    without errors.
+
+## View Transitions Disabled
+
+htmx v4 initially shipped with CSS view transitions enabled by default, which
+caused ~500ms UI blocking after each request
+([htmx#3566](https://github.com/bigskysoftware/htmx/issues/3566)). The htmx
+team disabled transitions as the default in a later release.
+
+Vibetuner's skeleton template includes a `<meta>` tag that explicitly disables
+them for compatibility with alpha8:
+
+```html
+<meta name="htmx-config" content='{"globalViewTransitions": false}' />
+```
+
+If you want view transitions, remove this tag and add CSS transition rules
+per the [htmx view transitions docs](https://four.htmx.org).
+
 ## Common Migration Issues
 
 ### SSE elements stop updating after upgrade
@@ -234,6 +325,10 @@ hx-vals='js:{"token": getToken()}'
 
 ## Migration Checklist
 
+- [ ] Replace `hx-on::` shorthand with `hx-on:htmx:` long form
+- [ ] Replace `event.detail.successful` with `event.detail.ctx.response`
+- [ ] Replace camelCase event names with colon-separated (e.g., `afterRequest` → `after:request`)
+- [ ] Move `document.body` event listeners to the element or use `hx-on` attributes
 - [ ] Remove all `hx-ext="sse"` attributes from SSE elements
 - [ ] Remove all other `hx-ext="..."` attributes (extensions auto-register)
 - [ ] Replace `hx-vars` with `hx-vals` using `js:` prefix

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -6,6 +6,7 @@
         <meta name="description" content="{{ meta_description | default('') }}" />
         <meta name="keywords" content="{{ meta_keywords | default('') }}" />
         <meta name="color-scheme" content="light" />
+        <meta name="htmx-config" content='{"globalViewTransitions": false}' />
         <title>
             {% block title %}
             {% endblock title %}

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -287,6 +287,37 @@ From `vibetuner.htmx`: `hx_redirect(url)`,
 `hx_replace_url`, `hx_reswap`, `hx_retarget`, `hx_refresh`,
 `hx_trigger_after_settle`, `hx_trigger_after_swap`.
 
+### HTMX 4 Event Handling
+
+htmx 4 changed event handling significantly. Key differences:
+
+**Event names** use colon-separated format (not camelCase):
+`htmx:after:request`, `htmx:before:swap`, `htmx:after:settle`.
+
+**`hx-on` attributes** — the `hx-on::` shorthand is broken in
+alpha8. Use the explicit long form:
+
+```html
+<!-- BROKEN: hx-on::after-request="..." -->
+<!-- WORKS: -->
+<form hx-on:htmx:after:request="this.reset()">
+```
+
+**`event.detail`** was restructured. `event.detail.successful` no
+longer exists. Use `event.detail.ctx.response` instead:
+
+```javascript
+// v2: event.detail.successful, event.detail.elt, event.detail.xhr
+// v4: event.detail.ctx.response, event.detail.ctx.sourceElement,
+//     event.detail.ctx.status
+```
+
+**Events do not bubble** to `document.body` in v4. Attach listeners
+directly to elements or use `hx-on` attributes.
+
+See the [HTMX migration guide](https://vibetuner.alltuner.com/htmx-migration/)
+for full details.
+
 ### Response Caching (Server-Side)
 
 `from vibetuner.cache import cache, invalidate, invalidate_pattern`.


### PR DESCRIPTION
## Summary

- Document HTMX 4 breaking changes in event handling: event name format change
  (camelCase → colon-separated), broken `hx-on::` shorthand in alpha8, restructured
  `event.detail` object, and loss of event bubbling to `document.body`
- Disable `globalViewTransitions` in skeleton template via `<meta>` tag to prevent
  ~500ms UI blocking per request (htmx#3566 workaround for alpha8)
- Add HTMX 4 event handling quick-reference to agent guide (AGENTS.md)
- Extend migration checklist with event-related items

Closes #1505

## Test plan

- [ ] Verify migration guide renders correctly on docs site (`just docs-serve`)
- [ ] Verify skeleton meta tag is present in a scaffolded project
- [ ] Verify AGENTS.md section is clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)