### PR TITLE
feat: add public set_config() and support runtime config registration in VibetunerApp

### DIFF
--- a/vibetuner-py/src/vibetuner/app_config.py
+++ b/vibetuner-py/src/vibetuner/app_config.py
@@ -52,5 +52,8 @@ class VibetunerApp(BaseModel):
     tasks: list[Callable[..., Any]] = []
     worker_lifespan: Callable[..., Any] | None = None
 
+    # Runtime config entries to register during startup
+    runtime_config: dict[str, dict[str, Any]] = {}
+
     # CLI extensions
     cli: Typer | None = None

--- a/vibetuner-py/src/vibetuner/loader.py
+++ b/vibetuner-py/src/vibetuner/loader.py
@@ -6,6 +6,7 @@ from importlib import import_module
 from vibetuner.app_config import VibetunerApp
 from vibetuner.logging import logger
 from vibetuner.pyproject import get_project_name
+from vibetuner.runtime_config import register_config_value
 
 
 class ConfigurationError(Exception):
@@ -69,5 +70,19 @@ def load_app_config() -> VibetunerApp:
             f"got {type(app_config).__name__}"
         )
 
+    register_runtime_config(app_config)
     logger.info(f"Loaded app config from {package_name}.tune")
     return app_config
+
+
+def register_runtime_config(app: VibetunerApp) -> None:
+    """Register all runtime config entries declared in a VibetunerApp."""
+    for key, entry in app.runtime_config.items():
+        register_config_value(
+            key=key,
+            default=entry["default"],
+            value_type=entry["value_type"],
+            description=entry.get("description"),
+            category=entry.get("category", "general"),
+            is_secret=entry.get("is_secret", False),
+        )

--- a/vibetuner-py/src/vibetuner/runtime_config.py
+++ b/vibetuner-py/src/vibetuner/runtime_config.py
@@ -294,6 +294,30 @@ def register_config_value(
     )
 
 
+async def set_config(key: str, value: Any) -> None:
+    """Persist a config value, inferring metadata from the registry.
+
+    Args:
+        key: Config key (must have been registered via register_config_value)
+        value: Value to persist
+
+    Raises:
+        KeyError: If key is not registered
+    """
+    if key not in RuntimeConfig._config_registry:
+        raise KeyError(f"Config key '{key}' is not registered")
+
+    entry = RuntimeConfig._config_registry[key]
+    await RuntimeConfig.set_value(
+        key=key,
+        value=value,
+        value_type=entry["value_type"],
+        description=entry["description"],
+        category=entry["category"],
+        is_secret=entry["is_secret"],
+    )
+
+
 async def get_config(key: str, default: Any = None) -> Any:
     """Convenience function to get a config value.
 

--- a/vibetuner-py/tests/unit/test_runtime_config.py
+++ b/vibetuner-py/tests/unit/test_runtime_config.py
@@ -612,3 +612,133 @@ class TestConfigGroup:
 
         entry = RuntimeConfig._config_registry["secrets.api_key"]
         assert entry["is_secret"] is True
+
+
+class TestSetConfig:
+    """Tests for the public set_config() convenience function."""
+
+    @pytest.mark.asyncio
+    async def test_set_config_persists_value(self):
+        """set_config persists a value using metadata from the registry."""
+        from vibetuner.runtime_config import (
+            RuntimeConfig,
+            register_config_value,
+            set_config,
+        )
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        register_config_value(
+            key="crm.default_region",
+            default="",
+            value_type="str",
+            description="Default region",
+            category="crm",
+        )
+
+        with patch("vibetuner.runtime_config.settings") as mock_settings:
+            mock_settings.mongodb_url = None
+            await set_config("crm.default_region", "US")
+
+        assert RuntimeConfig._config_cache["crm.default_region"] == "US"
+
+    @pytest.mark.asyncio
+    async def test_set_config_infers_value_type_from_registry(self):
+        """set_config uses the value_type from the registered entry."""
+        from vibetuner.runtime_config import (
+            RuntimeConfig,
+            register_config_value,
+            set_config,
+        )
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        register_config_value(
+            key="feature.max_items",
+            default=10,
+            value_type="int",
+            category="feature",
+        )
+
+        with patch("vibetuner.runtime_config.settings") as mock_settings:
+            mock_settings.mongodb_url = None
+            await set_config("feature.max_items", "42")
+
+        # Should be converted to int via the registered value_type
+        assert RuntimeConfig._config_cache["feature.max_items"] == 42
+
+    @pytest.mark.asyncio
+    async def test_set_config_raises_for_unregistered_key(self):
+        """set_config raises KeyError for keys not in the registry."""
+        from vibetuner.runtime_config import RuntimeConfig, set_config
+
+        RuntimeConfig._config_registry.clear()
+
+        with pytest.raises(KeyError, match="not registered"):
+            await set_config("unknown.key", "value")
+
+
+class TestVibetunerAppRuntimeConfig:
+    """Tests for VibetunerApp runtime_config parameter."""
+
+    def test_vibetuner_app_accepts_runtime_config(self):
+        """VibetunerApp accepts a runtime_config dict."""
+        from vibetuner.app_config import VibetunerApp
+
+        app = VibetunerApp(
+            runtime_config={
+                "crm.default_region": {
+                    "default": "",
+                    "value_type": "str",
+                    "description": "Default region",
+                    "category": "crm",
+                },
+            },
+        )
+
+        assert "crm.default_region" in app.runtime_config
+
+    def test_vibetuner_app_runtime_config_defaults_to_empty(self):
+        """VibetunerApp runtime_config defaults to empty dict."""
+        from vibetuner.app_config import VibetunerApp
+
+        app = VibetunerApp()
+        assert app.runtime_config == {}
+
+    def test_register_runtime_config_from_app(self):
+        """register_runtime_config registers all entries from app config."""
+        from vibetuner.app_config import VibetunerApp
+        from vibetuner.loader import register_runtime_config
+        from vibetuner.runtime_config import RuntimeConfig
+
+        RuntimeConfig._config_registry.clear()
+
+        app = VibetunerApp(
+            runtime_config={
+                "crm.default_region": {
+                    "default": "US",
+                    "value_type": "str",
+                    "description": "Default phone region",
+                    "category": "crm",
+                },
+                "crm.max_contacts": {
+                    "default": 100,
+                    "value_type": "int",
+                    "description": "Max contacts",
+                    "category": "crm",
+                },
+            },
+        )
+
+        register_runtime_config(app)
+
+        assert "crm.default_region" in RuntimeConfig._config_registry
+        assert RuntimeConfig._config_registry["crm.default_region"]["default"] == "US"
+        assert RuntimeConfig._config_registry["crm.default_region"]["value_type"] == "str"
+
+        assert "crm.max_contacts" in RuntimeConfig._config_registry
+        assert RuntimeConfig._config_registry["crm.max_contacts"]["default"] == 100


### PR DESCRIPTION
## Summary
- Adds `set_config()` public convenience function to `runtime_config.py` that infers `value_type`, `category`, and other metadata from the registered config entry, symmetric with the existing `get_config()`
- Adds `runtime_config` dict parameter to `VibetunerApp` so config values can be registered declaratively in `tune.py` instead of via side-effect imports
- Adds `register_runtime_config()` in `loader.py` to wire up registration during app config loading

Closes #1507

## Test plan
- [x] 3 new tests for `set_config()` (persists value, infers value_type, raises on unregistered key)
- [x] 3 new tests for `VibetunerApp.runtime_config` (accepts param, defaults empty, registers entries)
- [x] All 580 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)