### PR TITLE
fix: allow CLI to run outside a project directory

### DIFF
--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -160,12 +160,7 @@ class MailSettings(BaseSettings):
 
 
 def _load_project_config() -> "ProjectConfiguration":
-    if config_vars_path is None:
-        raise RuntimeError(
-            "Project root not detected. Cannot load project configuration. "
-            "Ensure you're running from within a project directory with .copier-answers.yml"
-        )
-    if not config_vars_path.exists():
+    if config_vars_path is None or not config_vars_path.exists():
         return ProjectConfiguration()
 
     yaml_data = yaml.safe_load(config_vars_path.read_text(encoding="utf-8"))

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -160,6 +160,19 @@ class TestLocaleDetectionSettings:
         assert settings.accept_language is False
 
 
+class TestLoadProjectConfig:
+    """Test _load_project_config behavior outside a project directory."""
+
+    def test_returns_defaults_when_no_project_root(self):
+        """Config loading returns defaults when config_vars_path is None."""
+        with patch("vibetuner.config.config_vars_path", None):
+            from vibetuner.config import _load_project_config
+
+            result = _load_project_config()
+            assert isinstance(result, ProjectConfiguration)
+            assert result.project_slug == "default_project"
+
+
 class TestCoreConfigurationLocaleDetection:
     """Test locale_detection field in CoreConfiguration."""
 


### PR DESCRIPTION
## Summary
- `_load_project_config()` raised `RuntimeError` when `config_vars_path` was `None` (no project root detected), preventing commands like `uvx vibetuner scaffold new` from running outside an existing project
- Changed to return default `ProjectConfiguration()` instead, consistent with existing behavior when the config file doesn't exist
- Added unit test for the no-project-root case

## Test plan
- [x] New unit test `TestLoadProjectConfig::test_returns_defaults_when_no_project_root` passes
- [x] All 601 existing unit tests pass
- [ ] Verify `uvx vibetuner scaffold new /tmp/test-project` works from a non-project directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)