### PR TITLE
refactor: remove alltuner-specific infrastructure from compose.prod.yml

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -45,7 +45,7 @@ project_description:
 
 fqdn:
   type: str
-  help: What's the fqdn of your website? (leaving empty disables all deployment and caddy stuff)
+  help: What's the fqdn of your website? (leaving empty disables deployment configuration)
   placeholder: subdomain.example.com
   default: ""
 
@@ -69,6 +69,13 @@ supported_languages:
   help: List of 2-letter lang codes of additional supported languages
   multiline: true
   default: []
+
+docker_registry:
+  type: str
+  help: Docker registry hostname for pushing/pulling images (e.g., registry.example.com:5000)
+  placeholder: registry.example.com:5000
+  default: "localhost:5050"
+  when: "{{ fqdn }}"
 
 enable_watchtower:
   type: bool

--- a/vibetuner-template/.justfiles/cicd.justfile
+++ b/vibetuner-template/.justfiles/cicd.justfile
@@ -1,3 +1,6 @@
+# ABOUTME: CI/CD recipes for building, releasing, and deploying Docker images.
+# ABOUTME: PUSH_REGISTRY overrides DOCKER_REGISTRY for fast local pushes.
+
 import 'helpers.justfile'
 
 # Builds the dev image with COMPOSE_BAKE set
@@ -25,17 +28,21 @@ build-prod: _check-clean _check-last-commit-tagged install-deps
     eval "$(just _project-vars)"
     ENVIRONMENT=prod docker buildx bake -f compose.prod.yml
 
-# Builds and pushes the prod image (only if on a clean, tagged commit)
+# Builds and pushes the prod image (only if on a clean, tagged commit).
+# PUSH_REGISTRY overrides DOCKER_REGISTRY for fast local pushes.
 [group('CI/CD')]
 release: _check-clean _check-last-commit-tagged
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(just _project-vars)"
+    if [ -n "${PUSH_REGISTRY:-}" ]; then
+        export DOCKER_REGISTRY="$PUSH_REGISTRY"
+    fi
     ENVIRONMENT=prod docker buildx bake -f compose.prod.yml --push
 
-# Releases and deploys to a remote host
+# Deploys to a remote host, pulling from the configured registry.
 [group('CI/CD')]
-deploy-latest HOST: release
+deploy-latest HOST:
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(just _project-vars)"

--- a/vibetuner-template/.justfiles/helpers.justfile
+++ b/vibetuner-template/.justfiles/helpers.justfile
@@ -34,4 +34,7 @@ _project-vars:
     print(f"export COMPOSE_PROJECT_NAME={answers.get('project_slug', 'scaffolding').strip()}")
     print(f"export FQDN={answers.get('fqdn', '').strip()}")
     print(f"export ENABLE_WATCHTOWER={str(answers.get('enable_watchtower', False)).lower()}")
+    registry = os.environ.get('DOCKER_REGISTRY') or answers.get('docker_registry')
+    if registry:
+        print(f"export DOCKER_REGISTRY={registry.strip()}")
     PYEOF

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -118,6 +118,45 @@ Key commands: `just format` (all code), `just lint` (all code),
 
 ---
 
+## Deployment
+
+### Docker Registry
+
+`DOCKER_REGISTRY` controls where images are pushed and pulled.
+Set via environment variable, `.copier-answers.yml`, or defaults
+to `localhost:5050` (for use with a local registry proxy).
+
+```bash
+# Build and push to the configured registry
+just release
+
+# Push to a local registry proxy instead (e.g., Switchyard)
+PUSH_REGISTRY=localhost:5050 just release
+```
+
+`PUSH_REGISTRY` overrides `DOCKER_REGISTRY` for the push target
+only. This is useful when a local registry proxy syncs to the
+central registry asynchronously, giving you fast local pushes.
+
+### Deploying
+
+`deploy-latest` pulls and runs the image on a remote host via SSH.
+It is decoupled from `release`, so you can push and deploy separately.
+
+```bash
+just deploy-latest user@myhost
+```
+
+### CI/CD Recipes
+
+- `just build-dev` - Build the dev Docker image
+- `just test-build-prod` - Test-build the prod image locally
+- `just build-prod` - Build the prod image (requires clean, tagged commit)
+- `just release` - Build and push (requires clean, tagged commit)
+- `just deploy-latest HOST` - Pull and run on a remote host
+
+---
+
 ## Architecture
 
 ```text

--- a/vibetuner-template/compose.prod.yml
+++ b/vibetuner-template/compose.prod.yml
@@ -1,19 +1,12 @@
-networks:
-  alltuner-network:
-    external: true
-    name: alltuner-network
 services:
   worker:
-    image: alltuner-docker-registry.long-python.ts.net/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
+    image: ${DOCKER_REGISTRY}/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
     restart: unless-stopped
     env_file:
       - .env
-    networks:
-      - default
-      - alltuner-network
     command: ["prod", "worker"]
     labels:
-      managed_by: "all-tuner"
+      managed_by: ${COMPOSE_PROJECT_NAME}
       com.centurylinklabs.watchtower.enable: "${ENABLE_WATCHTOWER:-false}"
   frontend:
     build:
@@ -28,9 +21,9 @@ services:
           - linux/arm64
         push: true
         tags:
-          - alltuner-docker-registry.long-python.ts.net/${COMPOSE_PROJECT_NAME}:${VERSION:-0.0.0}
-          - alltuner-docker-registry.long-python.ts.net/${COMPOSE_PROJECT_NAME}:latest
-    image: alltuner-docker-registry.long-python.ts.net/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
+          - ${DOCKER_REGISTRY}/${COMPOSE_PROJECT_NAME}:${VERSION:-0.0.0}
+          - ${DOCKER_REGISTRY}/${COMPOSE_PROJECT_NAME}:latest
+    image: ${DOCKER_REGISTRY}/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
     depends_on:
       - worker
     healthcheck:
@@ -48,15 +41,6 @@ services:
     restart: unless-stopped
     env_file:
       - .env
-    networks:
-      - default
-      - alltuner-network
     labels:
-      managed_by: "all-tuner"
+      managed_by: ${COMPOSE_PROJECT_NAME}
       com.centurylinklabs.watchtower.enable: "${ENABLE_WATCHTOWER:-false}"
-      caddy_0: ${FQDN:-default.example.com}
-      caddy_0.reverse_proxy: "{{upstreams 8000}}"
-      caddy_0.tls.dns: cloudflare ${CF_API_TOKEN}
-      caddy_0.log.output: file /var/log/caddy/${FQDN:-default}.log
-      caddy_0.log.output.import: log-rotation
-      caddy_0.import: umami


### PR DESCRIPTION
## Summary

- Replace hardcoded `alltuner-docker-registry.long-python.ts.net` with configurable `DOCKER_REGISTRY` env var
- Remove `alltuner-network` external network, caddy reverse proxy labels, and hardcoded `managed_by` label
- Add `PUSH_REGISTRY` override in `just release` for local registry proxy workflows (e.g., Switchyard)
- Decouple `deploy-latest` from `release` so push and deploy are independent steps
- Add `docker_registry` copier question (conditional on `fqdn`)
- Document deployment workflow in AGENTS.md

## Test plan

- [ ] Scaffold a new project and verify `compose.prod.yml` uses `${DOCKER_REGISTRY}` variables
- [ ] Verify `just release` works with `DOCKER_REGISTRY` set in `.env`
- [ ] Verify `PUSH_REGISTRY` override redirects push to a different registry
- [ ] Verify `just deploy-latest` pulls from `DOCKER_REGISTRY` independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)