### PR TITLE
refactor: remove managed_by label from compose.prod.yml

### DIFF
--- a/vibetuner-template/compose.prod.yml
+++ b/vibetuner-template/compose.prod.yml
@@ -6,7 +6,6 @@ services:
       - .env
     command: ["prod", "worker"]
     labels:
-      managed_by: ${COMPOSE_PROJECT_NAME}
       com.centurylinklabs.watchtower.enable: "${ENABLE_WATCHTOWER:-false}"
   frontend:
     build:
@@ -42,5 +41,4 @@ services:
     env_file:
       - .env
     labels:
-      managed_by: ${COMPOSE_PROJECT_NAME}
       com.centurylinklabs.watchtower.enable: "${ENABLE_WATCHTOWER:-false}"


### PR DESCRIPTION
## Summary

- Remove `managed_by` label from both services in `compose.prod.yml`

## Test plan

- [ ] Verify compose.prod.yml is valid after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)