### PR TITLE
fix: add localhost:5050 default for DOCKER_REGISTRY and drop copier question

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -70,13 +70,6 @@ supported_languages:
   multiline: true
   default: []
 
-docker_registry:
-  type: str
-  help: Docker registry hostname for pushing/pulling images (e.g., registry.example.com:5000)
-  placeholder: registry.example.com:5000
-  default: "localhost:5050"
-  when: "{{ fqdn }}"
-
 enable_watchtower:
   type: bool
   help: Do you want to enable watchtower (containers self-reload on update)?

--- a/vibetuner-template/.justfiles/helpers.justfile
+++ b/vibetuner-template/.justfiles/helpers.justfile
@@ -34,7 +34,7 @@ _project-vars:
     print(f"export COMPOSE_PROJECT_NAME={answers.get('project_slug', 'scaffolding').strip()}")
     print(f"export FQDN={answers.get('fqdn', '').strip()}")
     print(f"export ENABLE_WATCHTOWER={str(answers.get('enable_watchtower', False)).lower()}")
-    registry = os.environ.get('DOCKER_REGISTRY') or answers.get('docker_registry')
+    registry = os.environ.get('DOCKER_REGISTRY')
     if registry:
         print(f"export DOCKER_REGISTRY={registry.strip()}")
     PYEOF

--- a/vibetuner-template/compose.prod.yml
+++ b/vibetuner-template/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   worker:
-    image: ${DOCKER_REGISTRY}/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
+    image: ${DOCKER_REGISTRY:-localhost:5050}/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
     restart: unless-stopped
     env_file:
       - .env
@@ -20,9 +20,9 @@ services:
           - linux/arm64
         push: true
         tags:
-          - ${DOCKER_REGISTRY}/${COMPOSE_PROJECT_NAME}:${VERSION:-0.0.0}
-          - ${DOCKER_REGISTRY}/${COMPOSE_PROJECT_NAME}:latest
-    image: ${DOCKER_REGISTRY}/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
+          - ${DOCKER_REGISTRY:-localhost:5050}/${COMPOSE_PROJECT_NAME}:${VERSION:-0.0.0}
+          - ${DOCKER_REGISTRY:-localhost:5050}/${COMPOSE_PROJECT_NAME}:latest
+    image: ${DOCKER_REGISTRY:-localhost:5050}/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
     depends_on:
       - worker
     healthcheck:


### PR DESCRIPTION
## Summary

- Add `localhost:5050` default for `DOCKER_REGISTRY` in `compose.prod.yml` to prevent malformed image refs
- Remove `docker_registry` copier question (`.env` is the idiomatic place for this)
- Clean up `_project-vars` to stop checking copier answers for registry

## Test plan

- [ ] Verify compose.prod.yml works without `DOCKER_REGISTRY` set (falls back to `localhost:5050`)
- [ ] Verify `DOCKER_REGISTRY` in `.env` overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)