### PR TITLE
fix: document CSP nonce auto-injection and expose csp_nonce template variable

### DIFF
--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -58,6 +58,14 @@ Important notes:
   inject variables into every template render
 - **Service DI**: `get_email_service()`, `get_blob_service()`, `get_runtime_config()`
   FastAPI dependency wrappers
+- **CSP Nonce Auto-Injection**: `SecurityHeadersMiddleware` generates a unique CSP nonce
+  per request and auto-injects it into all `<script>` tags in HTML responses. Do NOT
+  manually add `nonce=` attributes to `<script>` tags in templates, the middleware handles
+  this automatically. For `<style>` tags or other elements that need the nonce, use the
+  `{{ csp_nonce }}` template variable (available in all templates via context provider).
+  In debug mode, CSP uses `Content-Security-Policy-Report-Only` (violations reported but
+  not enforced); in production, CSP is fully enforced. Configure extra sources via
+  `CSP_*` environment variables (e.g., `CSP_EXTRA_SCRIPT_SRC`)
 - **Health Checks**: `/health`, `/health/ping`, `/health/ready`, `/health/id` endpoints
   with service connectivity checks
 - **Robust Tasks**: `@robust_task()` decorator with exponential backoff retries and

--- a/vibetuner-py/src/vibetuner/frontend/AGENTS.md
+++ b/vibetuner-py/src/vibetuner/frontend/AGENTS.md
@@ -54,9 +54,21 @@ Request/response middleware:
 
 - Rate limiting middleware (slowapi, ASGI-native, first in stack)
 - HTMX middleware (request/response helpers)
+- Security headers middleware (CSP with nonce, X-Frame-Options, etc.)
 - Session middleware (secure cookie-based sessions)
 - i18n middleware (internationalization)
 - Context middleware (request context variables)
+
+#### CSP Nonce Auto-Injection
+
+`SecurityHeadersMiddleware` generates a unique CSP nonce per request and automatically injects it
+into all `<script>` tags in HTML responses. **Do NOT manually add `nonce=` attributes to `<script>`
+tags** in templates. The middleware handles this. Adding `nonce="{{ csp_nonce }}"` to a script tag
+causes the middleware to skip injection (it sees `nonce=` already present), resulting in an empty
+nonce that silently breaks scripts in production while appearing to work in dev mode.
+
+For `<style>` tags or other elements that need the nonce, use `{{ csp_nonce }}` (available in all
+templates via context provider). Configure extra CSP sources via `CSP_*` env vars.
 
 ### oauth.py
 

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import secrets
 
@@ -106,7 +107,10 @@ class HtmxMiddleware:
         await self.app(scope, receive, send)
 
 
+_logger = logging.getLogger("vibetuner.security")
+
 _SCRIPT_WITHOUT_NONCE_RE = re.compile(rb"<script(?![^>]*\snonce=)", re.IGNORECASE)
+_EMPTY_NONCE_RE = re.compile(rb'<script[^>]*\snonce=""\s*', re.IGNORECASE)
 
 
 class SecurityHeadersMiddleware:
@@ -177,6 +181,12 @@ class SecurityHeadersMiddleware:
 
     @staticmethod
     def _inject_nonces(body: bytes, nonce: str) -> bytes:
+        if _EMPTY_NONCE_RE.search(body):
+            _logger.warning(
+                "Found <script> tag with empty nonce attribute. "
+                "CSP nonces are auto-injected by SecurityHeadersMiddleware; "
+                "do not add nonce= attributes manually in templates."
+            )
         replacement = f'<script nonce="{nonce}"'.encode()
         return _SCRIPT_WITHOUT_NONCE_RE.sub(replacement, body)
 

--- a/vibetuner-py/src/vibetuner/rendering.py
+++ b/vibetuner-py/src/vibetuner/rendering.py
@@ -739,6 +739,14 @@ def _datetime_context() -> dict[str, Any]:
 
 register_context_provider(_datetime_context)
 
+
+def _csp_nonce_context(request: Request) -> dict[str, Any]:
+    """Expose the CSP nonce so templates can use it for ``<style>`` tags or other elements."""
+    return {"csp_nonce": getattr(request.state, "csp_nonce", "")}
+
+
+register_context_provider(_csp_nonce_context)
+
 # Global Vars
 jinja_env.globals.update({"DEBUG": data_ctx.DEBUG})
 

--- a/vibetuner-py/tests/unit/test_security_headers_middleware.py
+++ b/vibetuner-py/tests/unit/test_security_headers_middleware.py
@@ -2,6 +2,7 @@
 # ABOUTME: Verifies nonce generation, CSP directives, report-only mode, and bypass paths
 # ruff: noqa: S101
 
+import logging
 import re
 import secrets
 from dataclasses import dataclass, field
@@ -32,6 +33,9 @@ class _Settings:
 
 
 _SCRIPT_WITHOUT_NONCE_RE = re.compile(rb"<script(?![^>]*\snonce=)", re.IGNORECASE)
+_EMPTY_NONCE_RE = re.compile(rb'<script[^>]*\snonce=""\s*', re.IGNORECASE)
+
+_logger = logging.getLogger("vibetuner.security")
 
 
 class SecurityHeadersMiddleware:
@@ -101,6 +105,12 @@ class SecurityHeadersMiddleware:
 
     @staticmethod
     def _inject_nonces(body: bytes, nonce: str) -> bytes:
+        if _EMPTY_NONCE_RE.search(body):
+            _logger.warning(
+                "Found <script> tag with empty nonce attribute. "
+                "CSP nonces are auto-injected by SecurityHeadersMiddleware; "
+                "do not add nonce= attributes manually in templates."
+            )
         replacement = f'<script nonce="{nonce}"'.encode()
         return _SCRIPT_WITHOUT_NONCE_RE.sub(replacement, body)
 
@@ -389,3 +399,23 @@ class TestCspNonceAutoInjection:
         client = TestClient(app)
         resp = client.get("/")
         assert int(resp.headers["content-length"]) == len(resp.content)
+
+    def test_warns_on_empty_nonce_attribute(self, caplog):
+        """A <script nonce=""> triggers a warning about manual nonce usage."""
+        app = _make_app(
+            html_body='<html><script nonce="" src="app.js"></script></html>'
+        )
+        client = TestClient(app)
+        with caplog.at_level(logging.WARNING, logger="vibetuner.security"):
+            client.get("/")
+        assert any("empty nonce" in r.message for r in caplog.records)
+
+    def test_no_warning_for_valid_nonce(self, caplog):
+        """A <script nonce="real"> does not trigger a warning."""
+        app = _make_app(
+            html_body='<html><script nonce="real" src="app.js"></script></html>'
+        )
+        client = TestClient(app)
+        with caplog.at_level(logging.WARNING, logger="vibetuner.security"):
+            client.get("/")
+        assert not any("empty nonce" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- **Warning log**: `SecurityHeadersMiddleware` now logs a warning when it encounters `<script nonce="">` (empty nonce), catching the common mistake of manually adding nonce attributes that render as empty strings
- **Template variable**: Exposed `csp_nonce` as a template context variable via `register_context_provider`, so developers can use `{{ csp_nonce }}` for `<style>` tags or other elements that need the nonce
- **Documentation**: Documented the CSP nonce auto-injection behavior in `llms.txt` and `frontend/CLAUDE.md`, explaining the dev/prod divergence trap

## Test plan

- [x] Existing 21 security middleware tests pass
- [x] New test: `test_warns_on_empty_nonce_attribute` — verifies warning is emitted for `<script nonce="">`
- [x] New test: `test_no_warning_for_valid_nonce` — verifies no false positive for `<script nonce="real">`
- [x] All 603 unit tests pass
- [x] Pre-commit hooks pass (ruff, rumdl, taplo, etc.)

Closes #1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)