### PR TITLE
refactor: use vibetuner.logging instead of stdlib logging in middleware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,22 @@ doc = await MyDocument.get(PydanticObjectId(some_id))
 `PydanticObjectId` is still useful as a FastAPI path parameter type annotation (for request
 validation) and in explicit query filters, but `.get()` handles the conversion internally.
 
+## Logging
+
+All code in `vibetuner-py/src/vibetuner/` must use the project's Loguru-based logger:
+
+```python
+from vibetuner.logging import logger
+```
+
+Do **not** use `import logging` or `logging.getLogger(...)` directly. The only exception is
+`vibetuner/logging.py` itself, which defines the logging facility and necessarily imports the
+stdlib `logging` module.
+
+The `InterceptHandler` in `vibetuner/logging.py` routes stdlib logging through Loguru, so
+third-party libraries still work. But framework code should always use the Loguru `logger`
+directly for consistent formatting, request-ID injection, and log-level control.
+
 ## Markdown Line Length
 
 This project enforces a **120 character line limit** for markdown files using `rumdl`.

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import secrets
 
@@ -24,6 +23,7 @@ from starlette_htmx.middleware import HtmxDetails
 
 from vibetuner.config import settings
 from vibetuner.context import ctx
+from vibetuner.logging import logger
 from vibetuner.paths import locales as locales_path
 
 from .oauth import WebUser
@@ -107,8 +107,6 @@ class HtmxMiddleware:
         await self.app(scope, receive, send)
 
 
-_logger = logging.getLogger("vibetuner.security")
-
 _SCRIPT_WITHOUT_NONCE_RE = re.compile(rb"<script(?![^>]*\snonce=)", re.IGNORECASE)
 _EMPTY_NONCE_RE = re.compile(rb'<script[^>]*\snonce=""\s*', re.IGNORECASE)
 
@@ -182,7 +180,7 @@ class SecurityHeadersMiddleware:
     @staticmethod
     def _inject_nonces(body: bytes, nonce: str) -> bytes:
         if _EMPTY_NONCE_RE.search(body):
-            _logger.warning(
+            logger.warning(
                 "Found <script> tag with empty nonce attribute. "
                 "CSP nonces are auto-injected by SecurityHeadersMiddleware; "
                 "do not add nonce= attributes manually in templates."


### PR DESCRIPTION
## Summary
- Replace `import logging` / `logging.getLogger()` with `from vibetuner.logging import logger` in `frontend/middleware.py`
- Document the logging convention in CLAUDE.md so all framework code consistently uses the Loguru-based logger

## Test plan
- [x] Pre-commit hooks pass (ruff check, rumdl)
- [ ] Verify middleware warning still fires on empty-nonce `<script>` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)