### PR TITLE
feat: encrypt is_secret config values at rest using EncryptedStr

### DIFF
--- a/vibetuner-docs/docs/runtime-config.md
+++ b/vibetuner-docs/docs/runtime-config.md
@@ -147,7 +147,7 @@ register_config_value(
     value_type: str,       # "str", "int", "float", "bool", "json"
     description: str = None,  # Human-readable description
     category: str = "general",  # Category for grouping in debug UI
-    is_secret: bool = False,    # Mask value in UI, prevent editing
+    is_secret: bool = False,    # Encrypt at rest, mask in UI, prevent editing
 )
 ```
 
@@ -353,9 +353,28 @@ Config values from MongoDB are cached for 60 seconds to reduce database load:
 
 Mark sensitive values with `is_secret=True`:
 
+- Values are **encrypted at rest** in MongoDB using Fernet (symmetric encryption)
 - Values are masked (`*****`) in the debug UI
 - Values cannot be edited via the debug UI
-- Values are still accessible programmatically
+- Values are still accessible programmatically (decrypted transparently on load)
+
+Encryption requires the `FIELD_ENCRYPTION_KEY` environment variable. When set, secret config
+values are stored in an encrypted field (`secret_value`) rather than the plaintext `value`
+field. This uses the same `EncryptedFieldsMixin` / `EncryptedStr` mechanism used by other
+models (e.g., OAuth client secrets). When the key is not set, secret values are stored as
+plaintext.
+
+```python
+# Register a secret config value (encrypted at rest when FIELD_ENCRYPTION_KEY is set)
+register_config_value(
+    key="integrations.api_key",
+    default="",
+    value_type="str",
+    category="integrations",
+    description="Third-party API key",
+    is_secret=True,
+)
+```
 
 ### Debug UI Access
 
@@ -380,7 +399,8 @@ The debug routes at `/debug/*` are protected:
 
 3. **Document everything** with clear descriptions so other developers understand each setting
 
-4. **Mark secrets appropriately** to prevent accidental exposure in debug UI
+4. **Mark secrets appropriately** with `is_secret=True` to encrypt at rest and prevent exposure
+   in debug UI
 
 5. **Use appropriate types** for proper validation and UI rendering
 

--- a/vibetuner-py/src/vibetuner/models/config_entry.py
+++ b/vibetuner-py/src/vibetuner/models/config_entry.py
@@ -1,21 +1,26 @@
 # ABOUTME: MongoDB model for runtime configuration entries.
 # ABOUTME: Stores key-value config that can be changed at runtime and persists to MongoDB.
 
+import json
 from typing import Any, Literal
 
 from beanie import Document, Indexed
 from pydantic import Field
 
-from .mixins import TimeStampMixin
+from .mixins import EncryptedFieldsMixin, EncryptedStr, TimeStampMixin
 
 
 ConfigValueType = Literal["str", "int", "float", "bool", "json"]
 
 
-class ConfigEntryModel(Document, TimeStampMixin):
+class ConfigEntryModel(Document, TimeStampMixin, EncryptedFieldsMixin):
     """Runtime configuration entry stored in MongoDB.
 
     Supports typed values with validation and optional secret masking.
+    When ``is_secret=True``, the value is JSON-serialized into
+    ``secret_value`` (an ``EncryptedStr`` field) and encrypted at rest
+    via ``EncryptedFieldsMixin``.  The ``value`` field is set to ``None``
+    for secret entries so plaintext never reaches the database.
     """
 
     key: Indexed(str, unique=True) = Field(  # type: ignore[valid-type]
@@ -34,12 +39,23 @@ class ConfigEntryModel(Document, TimeStampMixin):
     )
     is_secret: bool = Field(
         default=False,
-        description="Whether to mask this value in debug UI and prevent editing",
+        description="Whether to encrypt at rest, mask in debug UI, and prevent editing",
     )
     category: str = Field(
         default="general",
         description="Category for grouping config entries in debug UI",
     )
+    secret_value: EncryptedStr | None = Field(
+        default=None,
+        description="Encrypted JSON-serialized value, populated when is_secret=True",
+    )
+
+    @property
+    def effective_value(self) -> Any:
+        """Return the actual config value, deserializing from secret_value when needed."""
+        if self.secret_value is not None:
+            return json.loads(self.secret_value)
+        return self.value
 
     class Settings:
         name = "config_entries"

--- a/vibetuner-py/src/vibetuner/runtime_config.py
+++ b/vibetuner-py/src/vibetuner/runtime_config.py
@@ -13,6 +13,11 @@ from vibetuner.logging import logger
 from vibetuner.time import now
 
 
+def _to_secret_value(value: Any) -> str:
+    """JSON-serialize a config value for encrypted storage."""
+    return json.dumps(value)
+
+
 ConfigValueType = Literal["str", "int", "float", "bool", "json"]
 
 # TTL for config cache in seconds
@@ -87,7 +92,7 @@ class RuntimeConfig:
 
                 entries = await ConfigEntryModel.find_all().to_list()
                 for entry in entries:
-                    cls._config_cache[entry.key] = entry.value
+                    cls._config_cache[entry.key] = entry.effective_value
                 logger.debug(f"Config cache refreshed with {len(entries)} entries")
             except Exception as e:
                 logger.warning(f"Failed to refresh config cache from MongoDB: {e}")
@@ -158,8 +163,16 @@ class RuntimeConfig:
             # Try to find existing entry
             existing = await ConfigEntryModel.find_one(ConfigEntryModel.key == key)
 
+            if is_secret:
+                stored_value = None
+                stored_secret = _to_secret_value(validated_value)
+            else:
+                stored_value = validated_value
+                stored_secret = None
+
             if existing:
-                existing.value = validated_value
+                existing.value = stored_value
+                existing.secret_value = stored_secret
                 existing.value_type = value_type
                 if description is not None:
                     existing.description = description
@@ -170,7 +183,8 @@ class RuntimeConfig:
             else:
                 entry = ConfigEntryModel(
                     key=key,
-                    value=validated_value,
+                    value=stored_value,
+                    secret_value=stored_secret,
                     value_type=value_type,
                     description=description,
                     category=category,
@@ -283,7 +297,7 @@ def register_config_value(
         value_type: Type for validation ('str', 'int', 'float', 'bool', 'json')
         description: Human-readable description
         category: Category for grouping in debug UI
-        is_secret: If True, value is masked in debug UI and cannot be edited
+        is_secret: If True, value is encrypted at rest, masked in debug UI, and cannot be edited
     """
     RuntimeConfig._config_registry[key] = ConfigRegistryEntry(
         default=default,

--- a/vibetuner-py/tests/unit/test_config_entry_encryption.py
+++ b/vibetuner-py/tests/unit/test_config_entry_encryption.py
@@ -1,0 +1,161 @@
+# ABOUTME: Tests for at-rest encryption of secret config entries.
+# ABOUTME: Validates that ConfigEntryModel encrypts secret_value via EncryptedFieldsMixin.
+# ruff: noqa: S101, S105, S106
+
+import json
+from typing import Any
+
+from pydantic import Field
+from vibetuner.config import settings
+from vibetuner.crypto import encrypt_value, is_encrypted
+from vibetuner.models.config_entry import ConfigEntryModel, ConfigValueType
+from vibetuner.models.mixins import EncryptedFieldsMixin, EncryptedStr
+
+
+PASSPHRASE = "test-encryption-key"
+
+
+class FakeConfigEntry(EncryptedFieldsMixin):
+    """Mirrors ConfigEntryModel fields without requiring Beanie initialization."""
+
+    key: str = Field(default="test.key")
+    value: Any = Field(default=None)
+    value_type: ConfigValueType = Field(default="str")
+    is_secret: bool = Field(default=False)
+    secret_value: EncryptedStr | None = Field(default=None)
+
+    @property
+    def effective_value(self) -> Any:
+        """Return the real value, deserializing from secret_value when needed."""
+        if self.secret_value is not None:
+            return json.loads(self.secret_value)
+        return self.value
+
+
+class TestConfigEntryModelShape:
+    """Tests that ConfigEntryModel has the expected fields and mixins."""
+
+    def test_has_secret_value_field(self):
+        """ConfigEntryModel has a secret_value field."""
+        assert "secret_value" in ConfigEntryModel.model_fields
+
+    def test_has_encrypted_fields_mixin(self):
+        """ConfigEntryModel uses EncryptedFieldsMixin."""
+        assert issubclass(ConfigEntryModel, EncryptedFieldsMixin)
+
+
+class TestConfigEntryEncryption:
+    """Tests for encrypting secret config values at rest."""
+
+    def test_non_secret_entry_has_no_secret_value(self):
+        """Non-secret entries store value normally with secret_value=None."""
+        entry = FakeConfigEntry(key="app.name", value="my-app", value_type="str")
+        assert entry.value == "my-app"
+        assert entry.secret_value is None
+
+    def test_secret_value_encrypted_on_insert(self, monkeypatch):
+        """secret_value is encrypted before database insert."""
+        monkeypatch.setattr(settings, "field_encryption_key", PASSPHRASE)
+        entry = FakeConfigEntry(
+            key="api.key",
+            value=None,
+            value_type="str",
+            is_secret=True,
+            secret_value="super-secret-key",
+        )
+        entry._encrypt_on_insert()
+        assert is_encrypted(entry.secret_value)
+
+    def test_secret_value_decrypted_on_load(self, monkeypatch):
+        """secret_value is decrypted when loading from database."""
+        monkeypatch.setattr(settings, "field_encryption_key", PASSPHRASE)
+        ciphertext = encrypt_value("super-secret-key", PASSPHRASE)
+        entry = FakeConfigEntry(
+            key="api.key",
+            value=None,
+            value_type="str",
+            is_secret=True,
+            secret_value=ciphertext,
+        )
+        assert entry.secret_value == "super-secret-key"
+
+    def test_secret_value_none_when_not_secret(self, monkeypatch):
+        """Non-secret entries leave secret_value as None after encryption."""
+        monkeypatch.setattr(settings, "field_encryption_key", PASSPHRASE)
+        entry = FakeConfigEntry(
+            key="app.name", value="my-app", value_type="str", is_secret=False
+        )
+        entry._encrypt_on_insert()
+        assert entry.secret_value is None
+        assert entry.value == "my-app"
+
+    def test_no_encryption_when_key_unset(self, monkeypatch):
+        """secret_value stays plaintext when no encryption key is configured."""
+        monkeypatch.setattr(settings, "field_encryption_key", None)
+        entry = FakeConfigEntry(
+            key="api.key",
+            value=None,
+            value_type="str",
+            is_secret=True,
+            secret_value="plain-secret",
+        )
+        entry._encrypt_on_insert()
+        assert entry.secret_value == "plain-secret"
+
+
+class TestEffectiveValue:
+    """Tests for the effective_value property."""
+
+    def test_returns_secret_value_when_secret(self, monkeypatch):
+        """effective_value returns deserialized secret_value for secret entries."""
+        monkeypatch.setattr(settings, "field_encryption_key", PASSPHRASE)
+        entry = FakeConfigEntry(
+            key="api.key",
+            value=None,
+            value_type="str",
+            is_secret=True,
+            secret_value=json.dumps("super-secret"),
+        )
+        assert entry.effective_value == "super-secret"
+
+    def test_returns_value_when_not_secret(self):
+        """effective_value returns value for non-secret entries."""
+        entry = FakeConfigEntry(key="app.name", value="my-app", value_type="str")
+        assert entry.effective_value == "my-app"
+
+    def test_deserializes_int(self, monkeypatch):
+        """effective_value deserializes JSON integer from secret_value."""
+        monkeypatch.setattr(settings, "field_encryption_key", PASSPHRASE)
+        entry = FakeConfigEntry(
+            key="api.max_retries",
+            value=None,
+            value_type="int",
+            is_secret=True,
+            secret_value=json.dumps(42),
+        )
+        assert entry.effective_value == 42
+
+    def test_deserializes_bool(self, monkeypatch):
+        """effective_value deserializes JSON boolean from secret_value."""
+        monkeypatch.setattr(settings, "field_encryption_key", PASSPHRASE)
+        entry = FakeConfigEntry(
+            key="api.enabled",
+            value=None,
+            value_type="bool",
+            is_secret=True,
+            secret_value=json.dumps(True),
+        )
+        assert entry.effective_value is True
+
+    def test_deserializes_json(self, monkeypatch):
+        """effective_value deserializes JSON object from secret_value."""
+        monkeypatch.setattr(settings, "field_encryption_key", PASSPHRASE)
+        data = {"host": "example.com", "port": 443}
+        entry = FakeConfigEntry(
+            key="api.config",
+            value=None,
+            value_type="json",
+            is_secret=True,
+            secret_value=json.dumps(data),
+        )
+        assert entry.effective_value == data

--- a/vibetuner-py/tests/unit/test_runtime_config.py
+++ b/vibetuner-py/tests/unit/test_runtime_config.py
@@ -1,6 +1,6 @@
 # ABOUTME: Tests for the RuntimeConfig service.
 # ABOUTME: Validates layered config resolution, caching, and MongoDB persistence.
-# ruff: noqa: S101
+# ruff: noqa: S101, S105
 """Tests for the RuntimeConfig service."""
 
 from datetime import timedelta
@@ -383,6 +383,73 @@ class TestMongoDBIntegration:
 
         # Cache should still be updated
         assert RuntimeConfig._config_cache["test.key"] == "test_value"
+
+
+    @pytest.mark.asyncio
+    async def test_set_value_stores_secret_in_secret_value(self):
+        """set_value passes secret_value (not value) when is_secret=True."""
+        from vibetuner.runtime_config import RuntimeConfig
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        mock_model = MagicMock()
+        mock_instance = MagicMock()
+        mock_model.find_one = AsyncMock(return_value=None)
+        mock_instance.insert = AsyncMock()
+
+        with (
+            patch("vibetuner.runtime_config.settings") as mock_settings,
+            patch("vibetuner.models.config_entry.ConfigEntryModel", mock_model),
+        ):
+            mock_settings.mongodb_url = "mongodb://localhost:27017"
+            mock_model.return_value = mock_instance
+
+            await RuntimeConfig.set_value(
+                key="api.secret",
+                value="my-api-key",
+                value_type="str",
+                is_secret=True,
+            )
+
+        # Model should be constructed with value=None and secret_value set
+        call_kwargs = mock_model.call_args[1]
+        assert call_kwargs["value"] is None
+        assert call_kwargs["secret_value"] == '"my-api-key"'
+        assert call_kwargs["is_secret"] is True
+
+    @pytest.mark.asyncio
+    async def test_set_value_non_secret_has_no_secret_value(self):
+        """set_value passes value (not secret_value) when is_secret=False."""
+        from vibetuner.runtime_config import RuntimeConfig
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        mock_model = MagicMock()
+        mock_instance = MagicMock()
+        mock_model.find_one = AsyncMock(return_value=None)
+        mock_instance.insert = AsyncMock()
+
+        with (
+            patch("vibetuner.runtime_config.settings") as mock_settings,
+            patch("vibetuner.models.config_entry.ConfigEntryModel", mock_model),
+        ):
+            mock_settings.mongodb_url = "mongodb://localhost:27017"
+            mock_model.return_value = mock_instance
+
+            await RuntimeConfig.set_value(
+                key="app.name",
+                value="my-app",
+                value_type="str",
+                is_secret=False,
+            )
+
+        call_kwargs = mock_model.call_args[1]
+        assert call_kwargs["value"] == "my-app"
+        assert call_kwargs["secret_value"] is None
 
 
 class TestValueTypeValidation:


### PR DESCRIPTION
## Summary

- Secret runtime config entries (`is_secret=True`) now encrypt their value at rest using `EncryptedFieldsMixin` / `EncryptedStr`
- Adds `secret_value: EncryptedStr | None` field to `ConfigEntryModel`; when `is_secret=True`, the value is JSON-serialized into `secret_value` and `value` is set to `None`
- `effective_value` property transparently returns the deserialized value from whichever field holds it
- Updates `RuntimeConfig.refresh_cache()` and `set_value()` to use the new field

Closes #1556

## Test plan

- [x] 12 new tests in `test_config_entry_encryption.py` covering encryption on insert, decryption on load, effective_value deserialization for all value types
- [x] 2 new tests in `test_runtime_config.py` verifying `set_value` routes secret/non-secret values to the correct field
- [x] All 617 existing tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)