### PR TITLE
docs: document pymongo migration - get_pymongo_collection() replaces get_motor_collection()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,19 @@ doc = await MyDocument.get(PydanticObjectId(some_id))
 `PydanticObjectId` is still useful as a FastAPI path parameter type annotation (for request
 validation) and in explicit query filters, but `.get()` handles the conversion internally.
 
+### Ad-hoc collection access uses PyMongo, not Motor
+
+The project uses `pymongo` (not `motor`). For direct collection access, use
+`get_pymongo_collection()`:
+
+```python
+# Correct
+collection = MyDocument.get_pymongo_collection()
+
+# Wrong - motor was removed, this no longer exists
+collection = MyDocument.get_motor_collection()  # AttributeError
+```
+
 ## Logging
 
 All code in `vibetuner-py/src/vibetuner/` must use the project's Loguru-based logger:

--- a/vibetuner-docs/docs/architecture.md
+++ b/vibetuner-docs/docs/architecture.md
@@ -125,7 +125,7 @@ return templates.TemplateResponse("blog/post.html.jinja", {
 
 ```text
 # MongoDB
-Route → Beanie ODM → Motor (async) → MongoDB
+Route → Beanie ODM → PyMongo (async) → MongoDB
 
 # SQL
 Route → SQLModel → SQLAlchemy (async) → PostgreSQL/MySQL/SQLite


### PR DESCRIPTION
## Summary

- Updated `AGENTS.md` (Beanie section) with guidance on using `get_pymongo_collection()` 
  instead of the removed `get_motor_collection()`
- Fixed stale Motor reference in `vibetuner-docs/docs/architecture.md` data flow diagram

Closes #1560

## Test plan

- [ ] Verify markdown linting passes (confirmed locally)
- [ ] Review that the Beanie section reads clearly with the new subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)