### PR TITLE
fix: handle pre-encrypted data and missing in-memory key in crypto set-key

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/crypto.py
+++ b/vibetuner-py/src/vibetuner/cli/crypto.py
@@ -14,12 +14,30 @@ crypto_app = typer.Typer(
 
 
 async def _set_key_impl(passphrase: str, env_file: Path) -> None:
+    from pydantic import ValidationError
+
+    from vibetuner.config import settings
     from vibetuner.crypto import encrypt_value, is_encrypted, write_env_var
     from vibetuner.models.oauth_app import OAuthProviderAppModel
     from vibetuner.mongo import init_mongodb
 
     await init_mongodb()
-    apps = await OAuthProviderAppModel.find_all().to_list()
+
+    # Set the key in memory so _decrypt_on_load / _encrypt_on_update hooks
+    # can use it when Beanie validates documents during load and save.
+    settings.field_encryption_key = passphrase
+
+    try:
+        apps = await OAuthProviderAppModel.find_all().to_list()
+    except (ValidationError, ValueError):
+        typer.echo(
+            "Error: The database contains fields encrypted with a different key.\n"
+            "Use 'vibetuner crypto set-key --key <existing-key>' to provide the "
+            "correct key, or 'vibetuner crypto rotate-key' if you already have "
+            "a working key configured.",
+            err=True,
+        )
+        raise typer.Exit(1) from None
 
     encrypted_count = 0
     for app in apps:

--- a/vibetuner-py/tests/unit/test_crypto_cli.py
+++ b/vibetuner-py/tests/unit/test_crypto_cli.py
@@ -1,0 +1,89 @@
+# ABOUTME: Tests for vibetuner.cli.crypto CLI commands.
+# ABOUTME: Verifies set-key and rotate-key error handling without requiring MongoDB.
+# ruff: noqa: S101
+from unittest.mock import AsyncMock, patch
+
+from pydantic import Field
+from typer.testing import CliRunner
+from vibetuner.cli import app
+from vibetuner.config import settings
+from vibetuner.crypto import encrypt_value
+from vibetuner.models.mixins import EncryptedFieldsMixin, EncryptedStr
+
+
+runner = CliRunner()
+
+
+class TestSetKeyEncryptedDataHandling:
+    """set-key must handle pre-encrypted data gracefully (#1559, #1561)."""
+
+    def test_set_key_with_pre_encrypted_data_shows_helpful_error(
+        self, monkeypatch, tmp_path
+    ):
+        """When DB has data encrypted with an unknown key, print a clear error instead of crashing."""
+        monkeypatch.setattr(settings, "field_encryption_key", None)
+
+        ciphertext = encrypt_value("secret", "original-key")
+
+        async def mock_to_list():
+            """Simulate what Beanie does: model_validate triggers _decrypt_on_load."""
+
+            class FakeDoc(EncryptedFieldsMixin):
+                client_secret: EncryptedStr = Field(default="x")
+
+            # This triggers _decrypt_on_load, which will raise because the
+            # auto-generated key doesn't match the one used to encrypt
+            FakeDoc(client_secret=ciphertext)
+
+        env_file = tmp_path / ".env"
+
+        with (
+            patch("vibetuner.mongo.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.models.oauth_app.OAuthProviderAppModel.find_all"
+            ) as mock_find_all,
+        ):
+            mock_find_all.return_value.to_list = mock_to_list
+            result = runner.invoke(
+                app, ["crypto", "set-key", "--env-file", str(env_file)]
+            )
+
+        assert result.exit_code == 1
+        assert "encrypted" in result.output.lower()
+
+    def test_set_key_updates_in_memory_settings_before_loading(
+        self, monkeypatch, tmp_path
+    ):
+        """set-key must set settings.field_encryption_key in memory before loading documents (#1561)."""
+        monkeypatch.setattr(settings, "field_encryption_key", None)
+
+        key_during_load = {}
+
+        async def mock_to_list():
+            key_during_load["value"] = settings.field_encryption_key
+            return []
+
+        env_file = tmp_path / ".env"
+
+        with (
+            patch("vibetuner.mongo.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.models.oauth_app.OAuthProviderAppModel.find_all"
+            ) as mock_find_all,
+            patch("vibetuner.crypto.write_env_var"),
+        ):
+            mock_find_all.return_value.to_list = mock_to_list
+            result = runner.invoke(
+                app,
+                [
+                    "crypto",
+                    "set-key",
+                    "--key",
+                    "my-test-key",
+                    "--env-file",
+                    str(env_file),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert key_during_load["value"] == "my-test-key"

--- a/vibetuner-py/tests/unit/test_mixins.py
+++ b/vibetuner-py/tests/unit/test_mixins.py
@@ -457,3 +457,12 @@ class TestEncryptedFieldsMixin:
         model = SecretModel(api_key="my-key", plain_field="visible")
         model._encrypt_on_insert()
         assert model.plain_field == "visible"
+
+    def test_encrypted_with_wrong_key_raises_on_load(self, monkeypatch):
+        """Loading an encrypted value with the wrong key raises ValueError."""
+        from vibetuner.crypto import encrypt_value
+
+        ciphertext = encrypt_value("my-key", self.PASSPHRASE)
+        monkeypatch.setattr(settings, "field_encryption_key", "wrong-key")
+        with pytest.raises(ValueError, match="decrypt"):
+            SecretModel(api_key=ciphertext)


### PR DESCRIPTION
## Summary

- **#1559**: `crypto set-key` crashed with a raw `ValidationError` when the DB had
  pre-encrypted fields and no local key. Now catches the error and prints a clear message
  directing the user to provide the existing key via `--key`.
- **#1561**: `settings.field_encryption_key` stayed `None` in memory during `set-key`,
  so Beanie's `_decrypt_on_load` on `save()` would crash. Now set before loading documents.

Closes #1559, closes #1561

## Test plan

- [x] New test: `set-key` with pre-encrypted data shows helpful error (not a raw traceback)
- [x] New test: `set-key` updates in-memory settings before loading documents
- [x] New test: `_decrypt_on_load` with wrong key raises `ValueError`
- [x] Full test suite passes (620 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)