### PR TITLE
fix: make decrypt_or_passthrough resilient to decryption failures

### DIFF
--- a/vibetuner-py/src/vibetuner/crypto.py
+++ b/vibetuner-py/src/vibetuner/crypto.py
@@ -8,6 +8,8 @@ from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
+from vibetuner.logging import logger
+
 
 FERNET_PREFIX = "gAAAAA"
 
@@ -47,24 +49,26 @@ def is_encrypted(value: str) -> bool:
 def decrypt_or_passthrough(value: str, passphrase: str | None) -> str:
     """Decrypt if the value is encrypted, otherwise pass through.
 
-    Raises ValueError if the value looks encrypted but no key is provided
-    or decryption fails.
+    When decryption fails (missing key, wrong key, corrupted data), logs a
+    warning and returns the raw ciphertext so that queries don't crash.
     """
     if not is_encrypted(value):
         return value
 
     if passphrase is None:
-        raise ValueError(
+        logger.warning(
             "Value appears encrypted but no encryption key is configured. "
             "Set FIELD_ENCRYPTION_KEY in your environment."
         )
+        return value
 
     try:
         return decrypt_value(value, passphrase)
     except InvalidToken:
-        raise ValueError(
+        logger.warning(
             "Failed to decrypt value. The encryption key may be incorrect."
-        ) from None
+        )
+        return value
 
 
 def write_env_var(env_file: Path, key: str, value: str) -> None:

--- a/vibetuner-py/tests/conftest.py
+++ b/vibetuner-py/tests/conftest.py
@@ -7,6 +7,18 @@ from pathlib import Path
 from typing import Generator
 from unittest.mock import MagicMock
 
+import pytest
+from loguru import logger
+
+
+@pytest.fixture()
+def log_sink():
+    """Capture loguru output for assertion."""
+    messages: list[str] = []
+    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="DEBUG")
+    yield messages
+    logger.remove(sink_id)
+
 
 def pytest_configure(config):
     """Configure pytest markers."""

--- a/vibetuner-py/tests/unit/test_crypto.py
+++ b/vibetuner-py/tests/unit/test_crypto.py
@@ -98,15 +98,19 @@ class TestDecryptOrPassthrough:
         ciphertext = encrypt_value("secret", "my-key")
         assert decrypt_or_passthrough(ciphertext, "my-key") == "secret"
 
-    def test_encrypted_value_without_key_raises(self):
+    def test_encrypted_value_without_key_passes_through(self, log_sink):
+        """When no key is configured, the encrypted value passes through with a warning."""
         ciphertext = encrypt_value("secret", "my-key")
-        with pytest.raises(ValueError, match="encrypted.*no.*key"):
-            decrypt_or_passthrough(ciphertext, None)
+        result = decrypt_or_passthrough(ciphertext, None)
+        assert result == ciphertext
+        assert any("no encryption key" in m.lower() for m in log_sink)
 
-    def test_encrypted_value_with_wrong_key_raises(self):
+    def test_encrypted_value_with_wrong_key_passes_through(self, log_sink):
+        """When the key is wrong, the encrypted value passes through with a warning."""
         ciphertext = encrypt_value("secret", "correct-key")
-        with pytest.raises(ValueError, match="decrypt"):
-            decrypt_or_passthrough(ciphertext, "wrong-key")
+        result = decrypt_or_passthrough(ciphertext, "wrong-key")
+        assert result == ciphertext
+        assert any("failed to decrypt" in m.lower() for m in log_sink)
 
 
 class TestWriteEnvVar:

--- a/vibetuner-py/tests/unit/test_mixins.py
+++ b/vibetuner-py/tests/unit/test_mixins.py
@@ -5,7 +5,6 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
-import pytest
 from pydantic import Field
 from vibetuner.config import settings
 from vibetuner.models.mixins import (
@@ -409,14 +408,15 @@ class TestEncryptedFieldsMixin:
         model = SecretModel(api_key="plain-key")
         assert model.api_key == "plain-key"
 
-    def test_encrypted_without_key_raises_on_load(self, monkeypatch):
-        """Loading an encrypted value with no key raises ValueError."""
+    def test_encrypted_without_key_passes_through_on_load(self, monkeypatch, log_sink):
+        """Loading an encrypted value with no key passes through with a warning."""
         from vibetuner.crypto import encrypt_value
 
         monkeypatch.setattr(settings, "field_encryption_key", None)
         ciphertext = encrypt_value("my-key", self.PASSPHRASE)
-        with pytest.raises(ValueError, match="encrypted.*no.*key"):
-            SecretModel(api_key=ciphertext)
+        model = SecretModel(api_key=ciphertext)
+        assert model.api_key == ciphertext
+        assert any("no encryption key" in m.lower() for m in log_sink)
 
     def test_no_double_encryption(self, monkeypatch):
         """Calling encrypt hook on an already-encrypted value is idempotent."""

--- a/vibetuner-py/tests/unit/test_oauth_app.py
+++ b/vibetuner-py/tests/unit/test_oauth_app.py
@@ -407,19 +407,20 @@ class TestOAuthAppEncryption:
         )
         assert app.client_secret == "plain-secret"
 
-    def test_encrypted_without_key_raises_on_load(self, monkeypatch):
-        """Loading an encrypted value with no key raises ValueError."""
+    def test_encrypted_without_key_passes_through_on_load(self, monkeypatch, log_sink):
+        """Loading an encrypted value with no key passes through with a warning."""
         from vibetuner.crypto import encrypt_value
 
         monkeypatch.setattr(settings, "field_encryption_key", None)
         ciphertext = encrypt_value("my-secret", self.PASSPHRASE)
-        with pytest.raises(ValueError, match="encrypted.*no.*key"):
-            OAuthProviderAppModel(
-                provider="google",
-                name="Test",
-                client_id="id",
-                client_secret=ciphertext,
-            )
+        app = OAuthProviderAppModel(
+            provider="google",
+            name="Test",
+            client_id="id",
+            client_secret=ciphertext,
+        )
+        assert app.client_secret == ciphertext
+        assert any("no encryption key" in m.lower() for m in log_sink)
 
     def test_no_double_encryption(self, monkeypatch):
         """Calling encrypt hook on an already-encrypted value is idempotent."""

--- a/vibetuner-py/tests/unit/test_oauth_registration.py
+++ b/vibetuner-py/tests/unit/test_oauth_registration.py
@@ -4,7 +4,6 @@
 import copy
 
 import pytest
-from loguru import logger
 from pydantic import SecretStr
 from vibetuner.config import settings
 from vibetuner.frontend.oauth import (
@@ -26,15 +25,6 @@ def clean_provider_registry():
     yield
     _PROVIDERS.clear()
     PROVIDER_IDENTIFIERS.clear()
-
-
-@pytest.fixture()
-def log_sink():
-    """Capture loguru output for assertion."""
-    messages: list[str] = []
-    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="DEBUG")
-    yield messages
-    logger.remove(sink_id)
 
 
 class TestBuiltinProviders:


### PR DESCRIPTION
## Summary

- `decrypt_or_passthrough()` now logs a warning and returns the raw ciphertext instead of
  raising `ValueError` when decryption fails (missing key, wrong key, corrupted data)
- Prevents a single undecryptable document from crashing entire Beanie queries
  (e.g. `find_all()` on `/debug/oauth-apps`)
- Consolidates duplicate `log_sink` test fixture into shared `conftest.py`

Closes #1564

## Test plan

- [x] Existing tests updated to verify passthrough + warning behavior
- [x] All 617 unit tests pass
- [x] Lint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)