### PR TITLE
fix: rename underscore-prefixed Beanie event hooks so they actually fire

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,22 @@ doc = await MyDocument.get(PydanticObjectId(some_id))
 `PydanticObjectId` is still useful as a FastAPI path parameter type annotation (for request
 validation) and in explicit query filters, but `.get()` handles the conversion internally.
 
+### Event hook methods must NOT start with an underscore
+
+Beanie's `init_actions()` skips any method whose name starts with `_` when registering
+`@before_event` / `@after_event` hooks. A hook named `_encrypt_on_save` will silently
+never fire. Always use public names:
+
+```python
+# Correct - Beanie discovers and registers this hook
+@before_event(Insert)
+def encrypt_on_insert(self) -> None: ...
+
+# Wrong - silently ignored by Beanie's action registry
+@before_event(Insert)
+def _encrypt_on_insert(self) -> None: ...
+```
+
 ### Ad-hoc collection access uses PyMongo, not Motor
 
 The project uses `pymongo` (not `motor`). For direct collection access, use

--- a/vibetuner-py/src/vibetuner/cli/crypto.py
+++ b/vibetuner-py/src/vibetuner/cli/crypto.py
@@ -23,7 +23,7 @@ async def _set_key_impl(passphrase: str, env_file: Path) -> None:
 
     await init_mongodb()
 
-    # Set the key in memory so _decrypt_on_load / _encrypt_on_update hooks
+    # Set the key in memory so decrypt/encrypt hooks
     # can use it when Beanie validates documents during load and save.
     settings.field_encryption_key = passphrase
 

--- a/vibetuner-py/src/vibetuner/models/mixins.py
+++ b/vibetuner-py/src/vibetuner/models/mixins.py
@@ -42,13 +42,13 @@ class TimeStampMixin(BaseModel):
 
     # ── Beanie hooks ────────────────────────────────────────────
     @before_event(Insert)
-    def _touch_on_insert(self) -> None:
+    def touch_on_insert(self) -> None:
         _now = now()
         self.db_insert_dt = _now
         self.db_update_dt = _now
 
     @before_event(Update, SaveChanges, Save, Replace)
-    def _touch_on_update(self) -> None:
+    def touch_on_update(self) -> None:
         self.db_update_dt = now()
 
     # ── Public helpers ──────────────────────────────────────────
@@ -154,11 +154,11 @@ class EncryptedFieldsMixin(BaseModel):
         return self
 
     @before_event(Insert)
-    def _encrypt_on_insert(self) -> None:
+    def encrypt_on_insert(self) -> None:
         self._encrypt_fields()
 
     @before_event(Update, SaveChanges, Save, Replace)
-    def _encrypt_on_update(self) -> None:
+    def encrypt_on_update(self) -> None:
         self._encrypt_fields()
 
     def _encrypt_fields(self) -> None:

--- a/vibetuner-py/tests/unit/test_config_entry_encryption.py
+++ b/vibetuner-py/tests/unit/test_config_entry_encryption.py
@@ -63,7 +63,7 @@ class TestConfigEntryEncryption:
             is_secret=True,
             secret_value="super-secret-key",
         )
-        entry._encrypt_on_insert()
+        entry.encrypt_on_insert()
         assert is_encrypted(entry.secret_value)
 
     def test_secret_value_decrypted_on_load(self, monkeypatch):
@@ -85,7 +85,7 @@ class TestConfigEntryEncryption:
         entry = FakeConfigEntry(
             key="app.name", value="my-app", value_type="str", is_secret=False
         )
-        entry._encrypt_on_insert()
+        entry.encrypt_on_insert()
         assert entry.secret_value is None
         assert entry.value == "my-app"
 
@@ -99,7 +99,7 @@ class TestConfigEntryEncryption:
             is_secret=True,
             secret_value="plain-secret",
         )
-        entry._encrypt_on_insert()
+        entry.encrypt_on_insert()
         assert entry.secret_value == "plain-secret"
 
 

--- a/vibetuner-py/tests/unit/test_mixins.py
+++ b/vibetuner-py/tests/unit/test_mixins.py
@@ -52,30 +52,30 @@ class TestTimeStampMixin:
 
     @patch("vibetuner.models.mixins.now")
     def test_touch_on_insert(self, mock_now):
-        """Test that _touch_on_insert sets both timestamps."""
+        """Test that touch_on_insert sets both timestamps."""
         fixed_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
         mock_now.return_value = fixed_time
 
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         assert doc.db_insert_dt == fixed_time
         assert doc.db_update_dt == fixed_time
 
     @patch("vibetuner.models.mixins.now")
     def test_touch_on_update(self, mock_now):
-        """Test that _touch_on_update only updates db_update_dt."""
+        """Test that touch_on_update only updates db_update_dt."""
         insert_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
         update_time = datetime(2025, 1, 15, 13, 0, 0, tzinfo=UTC)
 
         # Create doc with fixed insert time
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         # Update with different time
         mock_now.return_value = update_time
-        doc._touch_on_update()
+        doc.touch_on_update()
 
         assert doc.db_insert_dt == insert_time  # Should not change
         assert doc.db_update_dt == update_time  # Should be updated
@@ -89,7 +89,7 @@ class TestTimeStampMixin:
         # Create doc
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         # Calculate age
         mock_now.return_value = current_time
@@ -108,10 +108,10 @@ class TestTimeStampMixin:
         # Create and update doc
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = update_time
-        doc._touch_on_update()
+        doc.touch_on_update()
 
         # Calculate age since update
         mock_now.return_value = current_time
@@ -127,7 +127,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         age = doc.age()  # No 'since' parameter
@@ -144,7 +144,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         age = doc.age_in(Unit.SECONDS)
@@ -159,7 +159,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         age = doc.age_in(Unit.MINUTES)
@@ -174,7 +174,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         age = doc.age_in(Unit.HOURS)
@@ -189,7 +189,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         age = doc.age_in(Unit.DAYS)
@@ -204,7 +204,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         age = doc.age_in(Unit.WEEKS)
@@ -219,7 +219,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         age = doc.age_in()  # No unit parameter
@@ -235,10 +235,10 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = update_time
-        doc._touch_on_update()
+        doc.touch_on_update()
 
         mock_now.return_value = current_time
         age = doc.age_in(Unit.MINUTES, since=Since.UPDATE)
@@ -253,7 +253,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         is_older = doc.is_older_than(timedelta(hours=1))
@@ -268,7 +268,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         is_older = doc.is_older_than(timedelta(hours=1))
@@ -285,7 +285,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = current_time
         is_older = doc.is_older_than(timedelta(hours=1))
@@ -301,10 +301,10 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = update_time
-        doc._touch_on_update()
+        doc.touch_on_update()
 
         mock_now.return_value = current_time
         is_older = doc.is_older_than(timedelta(minutes=20), since=Since.UPDATE)
@@ -319,7 +319,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = touch_time
         result = doc.touch()
@@ -336,7 +336,7 @@ class TestTimeStampMixin:
 
         mock_now.return_value = insert_time
         doc = SampleModel()
-        doc._touch_on_insert()
+        doc.touch_on_insert()
 
         mock_now.return_value = touch_time
         returned_doc = doc.touch()
@@ -371,7 +371,7 @@ class TestEncryptedFieldsMixin:
         """before_event(Insert) encrypts plaintext fields when key is set."""
         monkeypatch.setattr(settings, "field_encryption_key", self.PASSPHRASE)
         model = SecretModel(api_key="my-key")
-        model._encrypt_on_insert()
+        model.encrypt_on_insert()
 
         from vibetuner.crypto import is_encrypted
 
@@ -381,7 +381,7 @@ class TestEncryptedFieldsMixin:
         """before_event(Update/Save/...) encrypts plaintext fields."""
         monkeypatch.setattr(settings, "field_encryption_key", self.PASSPHRASE)
         model = SecretModel(api_key="my-key")
-        model._encrypt_on_update()
+        model.encrypt_on_update()
 
         from vibetuner.crypto import is_encrypted
 
@@ -400,7 +400,7 @@ class TestEncryptedFieldsMixin:
         """Plaintext stays plaintext when no encryption key is configured."""
         monkeypatch.setattr(settings, "field_encryption_key", None)
         model = SecretModel(api_key="my-key")
-        model._encrypt_on_insert()
+        model.encrypt_on_insert()
         assert model.api_key == "my-key"
 
     def test_plaintext_passthrough_on_load(self, monkeypatch):
@@ -426,14 +426,14 @@ class TestEncryptedFieldsMixin:
         ciphertext = encrypt_value("my-key", self.PASSPHRASE)
         model = SecretModel(api_key="placeholder")
         model.api_key = ciphertext
-        model._encrypt_on_insert()
+        model.encrypt_on_insert()
         assert decrypt_value(model.api_key, self.PASSPHRASE) == "my-key"
 
     def test_multiple_fields_encrypted(self, monkeypatch):
         """All EncryptedStr fields are encrypted, not just the first one."""
         monkeypatch.setattr(settings, "field_encryption_key", self.PASSPHRASE)
         model = SecretModel(api_key="key-1", optional_token="token-2")
-        model._encrypt_on_insert()
+        model.encrypt_on_insert()
 
         from vibetuner.crypto import is_encrypted
 
@@ -444,7 +444,7 @@ class TestEncryptedFieldsMixin:
         """None values in optional EncryptedStr fields are left alone."""
         monkeypatch.setattr(settings, "field_encryption_key", self.PASSPHRASE)
         model = SecretModel(api_key="my-key", optional_token=None)
-        model._encrypt_on_insert()
+        model.encrypt_on_insert()
 
         from vibetuner.crypto import is_encrypted
 
@@ -455,7 +455,7 @@ class TestEncryptedFieldsMixin:
         """Non-EncryptedStr fields are never encrypted."""
         monkeypatch.setattr(settings, "field_encryption_key", self.PASSPHRASE)
         model = SecretModel(api_key="my-key", plain_field="visible")
-        model._encrypt_on_insert()
+        model.encrypt_on_insert()
         assert model.plain_field == "visible"
 
     def test_encrypted_with_wrong_key_raises_on_load(self, monkeypatch):

--- a/vibetuner-py/tests/unit/test_oauth_app.py
+++ b/vibetuner-py/tests/unit/test_oauth_app.py
@@ -351,7 +351,7 @@ class TestOAuthAppEncryption:
             client_id="id",
             client_secret="my-secret",
         )
-        app._encrypt_on_insert()
+        app.encrypt_on_insert()
         from vibetuner.crypto import is_encrypted
 
         assert is_encrypted(app.client_secret)
@@ -365,7 +365,7 @@ class TestOAuthAppEncryption:
             client_id="id",
             client_secret="my-secret",
         )
-        app._encrypt_on_update()
+        app.encrypt_on_update()
         from vibetuner.crypto import is_encrypted
 
         assert is_encrypted(app.client_secret)
@@ -393,7 +393,7 @@ class TestOAuthAppEncryption:
             client_id="id",
             client_secret="my-secret",
         )
-        app._encrypt_on_insert()
+        app.encrypt_on_insert()
         assert app.client_secret == "my-secret"
 
     def test_plaintext_passthrough_on_load(self, monkeypatch):
@@ -435,7 +435,7 @@ class TestOAuthAppEncryption:
             client_secret="placeholder",
         )
         app.client_secret = ciphertext
-        app._encrypt_on_insert()
+        app.encrypt_on_insert()
         # Should still be the same ciphertext (not double-encrypted)
         from vibetuner.crypto import decrypt_value
 


### PR DESCRIPTION
## Summary

- Beanie's `init_actions()` silently skips methods starting with `_` when registering
  `@before_event`/`@after_event` hooks. All four hook methods in `TimeStampMixin` and
  `EncryptedFieldsMixin` were invisible to Beanie's action registry, meaning timestamps
  and encryption hooks never fired on database operations.
- Renamed `_touch_on_insert` -> `touch_on_insert`, `_touch_on_update` -> `touch_on_update`,
  `_encrypt_on_insert` -> `encrypt_on_insert`, `_encrypt_on_update` -> `encrypt_on_update`
- Added guidance to AGENTS.md documenting this Beanie gotcha
- No other `before_event`/`after_event` hooks exist in the codebase

Closes #1565

## Test plan

- [x] All 620 existing tests pass
- [x] Pre-commit hooks (ruff, rumdl, taplo) all pass
- [ ] Verify encryption works end-to-end on a scaffolded project with `.save()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)