### PR TITLE
chore: sync workspace hooks with template improvements

### DIFF
--- a/.hooks/conductor-setup.sh
+++ b/.hooks/conductor-setup.sh
@@ -1,7 +1,1 @@
-#!/usr/bin/env bash
-# ABOUTME: Conductor workspace setup wrapper.
-# ABOUTME: Normalizes Conductor env vars and delegates to workspace-setup.sh.
-set -euo pipefail
-
-export ROOT_PATH="$CONDUCTOR_ROOT_PATH"
-exec "$(dirname "$0")/workspace-setup.sh"
+../vibetuner-template/.hooks/conductor-setup.sh

--- a/.hooks/emdash-setup.sh
+++ b/.hooks/emdash-setup.sh
@@ -1,7 +1,1 @@
-#!/usr/bin/env bash
-# ABOUTME: Emdash workspace setup wrapper.
-# ABOUTME: Normalizes Emdash env vars and delegates to workspace-setup.sh.
-set -euo pipefail
-
-export ROOT_PATH="$EMDASH_ROOT_PATH"
-exec "$(dirname "$0")/workspace-setup.sh"
+../vibetuner-template/.hooks/emdash-setup.sh

--- a/.hooks/superset-setup.sh
+++ b/.hooks/superset-setup.sh
@@ -1,7 +1,1 @@
-#!/usr/bin/env bash
-# ABOUTME: Superset workspace setup wrapper.
-# ABOUTME: Normalizes Superset env vars and delegates to workspace-setup.sh.
-set -euo pipefail
-
-export ROOT_PATH="$SUPERSET_ROOT_PATH"
-exec "$(dirname "$0")/workspace-setup.sh"
+../vibetuner-template/.hooks/superset-setup.sh

--- a/.hooks/workspace-setup.sh
+++ b/.hooks/workspace-setup.sh
@@ -25,14 +25,14 @@ done
 
 # --- Python dependencies ---
 if [ -f "pyproject.toml" ]; then
-    uv sync --frozen || echo "⚠ uv sync failed, continuing anyway"
+    uv sync --all-extras --all-groups --frozen || echo "⚠ uv sync failed, continuing anyway"
     echo "✓ Python dependencies installed"
 fi
 
 # --- JavaScript dependencies ---
 for dir in vibetuner-js vibetuner-template; do
     if [ -f "$dir/bun.lock" ] || [ -f "$dir/package.json" ]; then
-        (cd "$dir" && bun install) || echo "⚠ bun install failed in $dir, continuing anyway"
+        (cd "$dir" && bun install --frozen-lockfile) || echo "⚠ bun install failed in $dir, continuing anyway"
         echo "✓ Bun dependencies installed in $dir"
     fi
 done


### PR DESCRIPTION
## Summary
- Symlink identical hook wrappers (conductor, emdash, superset) to `vibetuner-template/.hooks/` so they stay in sync automatically
- Port two improvements to `workspace-setup.sh` from the template: `uv sync --all-extras --all-groups` and `bun install --frozen-lockfile`

## Test plan
- [ ] Verify symlinks resolve correctly in a new worktree
- [ ] Confirm `uv sync` installs dev dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)