### PR TITLE
docs: update htmx migration guide for 4.0.0-beta1 and remove stale config

### DIFF
--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -1,7 +1,122 @@
 # HTMX v2 to v4 Migration Guide
 
 This guide covers the breaking changes when upgrading from htmx v2 to v4
-in Vibetuner projects.
+in Vibetuner projects. It also documents what changed between htmx 4 alpha
+releases and beta1, so users on any pre-release version can migrate.
+
+## Quick Start
+
+The two biggest behavioral changes from v2 to v4:
+
+1. **Attribute inheritance is explicit** (was implicit in v2)
+2. **Error responses (4xx/5xx) swap by default** (were skipped in v2)
+
+To restore v2 behavior while you migrate incrementally, add this before
+loading htmx:
+
+```html
+<script>
+    htmx.config.implicitInheritance = true;
+    htmx.config.noSwap = [204, 304, '4xx', '5xx'];
+</script>
+```
+
+Or load the `htmx-2-compat` extension, which restores implicit inheritance,
+old event names, and previous error-swapping defaults:
+
+```javascript
+import "htmx.org/dist/ext/htmx-2-compat.js";
+```
+
+## Error Response Swapping
+
+htmx 4 swaps all HTTP responses by default. Only `204` and `304` are skipped.
+
+In v2, `4xx` and `5xx` responses were not swapped. In v4, if your server
+returns HTML with a `422` or `500`, that HTML gets swapped into the target.
+This means your error responses need to produce valid swap content.
+
+**Options:**
+
+- Design error responses as HTML fragments suitable for swapping
+- Use the new [`hx-status`](#per-status-code-swap-control) attribute for
+  fine-grained control
+- Revert globally: `htmx.config.noSwap = [204, 304, '4xx', '5xx']`
+
+## Per-Status-Code Swap Control
+
+The new `hx-status` attribute lets you control swap behavior per HTTP
+status code:
+
+```html
+<form hx-post="/save"
+      hx-status:422="swap:innerHTML target:#errors select:#validation-errors"
+      hx-status:5xx="swap:none push:false">
+    <!-- form fields -->
+</form>
+```
+
+Available config keys: `swap:`, `target:`, `select:`, `push:`, `replace:`,
+`transition:`.
+
+Supports exact codes (`404`), single-digit wildcards (`50x`), and range
+wildcards (`5xx`). Evaluated in order of specificity.
+
+## Attribute Inheritance Requires `:inherited`
+
+In v2, many htmx attributes were inherited by child elements automatically. In v4,
+inheritance must be explicitly opted into using the `:inherited` modifier.
+
+**Before (v2):**
+
+```html
+<div hx-target="#results">
+    <!-- All children inherit hx-target="#results" -->
+    <button hx-get="/search">Search</button>
+    <button hx-get="/filter">Filter</button>
+</div>
+```
+
+**After (v4):**
+
+```html
+<div hx-target:inherited="#results">
+    <!-- Children inherit hx-target via :inherited modifier -->
+    <button hx-get="/search">Search</button>
+    <button hx-get="/filter">Filter</button>
+</div>
+```
+
+Without `:inherited`, each child element must set its own attributes explicitly.
+
+Use `:append` to add to an inherited value instead of replacing it:
+
+```html
+<div hx-include:inherited="#global-fields">
+    <form hx-include:inherited:append=".extra">...</form>
+</div>
+```
+
+## Multi-Target Updates with `<hx-partial>`
+
+`<hx-partial>` is a new alternative to `hx-swap-oob` for targeting multiple
+elements from one response:
+
+```html
+<hx-partial hx-target="#messages" hx-swap="beforeend">
+    <div>New message</div>
+</hx-partial>
+<hx-partial hx-target="#count">
+    <span>5</span>
+</hx-partial>
+```
+
+Each `<hx-partial>` specifies its own `hx-target` and `hx-swap` strategy.
+
+!!! note
+    OOB swap order changed in v4: the main content swaps first, then
+    OOB and `<hx-partial>` elements swap after (in document order). In v2,
+    OOB elements swapped before the main content.
 
 ## SSE: Native Support Replaces Extension
 
@@ -24,13 +139,20 @@ and `hx-ext="sse"` attribute are no longer needed.
 </div>
 ```
 
-The `sse-connect` and `sse-swap` attributes work exactly the same — just remove
+The `sse-connect` and `sse-swap` attributes work exactly the same, just remove
 `hx-ext="sse"` from the element.
+
+!!! warning
+    The SSE and WebSocket extensions were significantly rewritten for v4.
+    If you use advanced SSE/WS features (custom config, event handling),
+    see the upstream upgrade guides:
+    [SSE](https://four.htmx.org/docs/extensions/sse#upgrading-from-htmx-2x),
+    [WS](https://four.htmx.org/docs/extensions/ws#upgrading-from-htmx-2x).
 
 ## Extension Auto-Registration
 
 In v2, extensions had to be explicitly activated via `hx-ext="..."` on each element
-or a parent. In v4, extensions auto-register when imported — no `hx-ext` attribute
+or a parent. In v4, extensions auto-register when imported, no `hx-ext` attribute
 needed.
 
 **Before (v2):**
@@ -50,6 +172,12 @@ needed.
 ```
 
 Extensions activate automatically once their script is loaded.
+
+To restrict which extensions can register, use an allow list:
+
+```html
+<meta name="htmx-config" content='{"extensions": "preload, sse"}'>
+```
 
 ## `hx-vars` Replaced by `hx-vals` with `js:` Prefix
 
@@ -81,49 +209,13 @@ Use `hx-vals` with the `js:` prefix instead.
 ## `hx-disable` Renamed to `hx-ignore`
 
 The attribute that prevents htmx from processing an element has been renamed.
+Do this rename **before** upgrading, because `hx-disable` means something
+different in v4 (it now does what `hx-disabled-elt` used to do).
 
-**Before (v2):**
+Rename in this order to avoid conflicts:
 
-```html
-<div hx-disable>
-    <a href="/page">Regular link, not processed by htmx</a>
-</div>
-```
-
-**After (v4):**
-
-```html
-<div hx-ignore>
-    <a href="/page">Regular link, not processed by htmx</a>
-</div>
-```
-
-## Attribute Inheritance Requires `:inherited`
-
-In v2, many htmx attributes were inherited by child elements automatically. In v4,
-inheritance must be explicitly opted into using the `:inherited` modifier.
-
-**Before (v2):**
-
-```html
-<div hx-target="#results">
-    <!-- All children inherit hx-target="#results" -->
-    <button hx-get="/search">Search</button>
-    <button hx-get="/filter">Filter</button>
-</div>
-```
-
-**After (v4):**
-
-```html
-<div hx-target:inherited="#results">
-    <!-- Children inherit hx-target via :inherited modifier -->
-    <button hx-get="/search">Search</button>
-    <button hx-get="/filter">Filter</button>
-</div>
-```
-
-Without `:inherited`, each child element must set its own attributes explicitly.
+1. Rename `hx-disable` to `hx-ignore`
+2. Rename `hx-disabled-elt` to `hx-disable`
 
 ## JavaScript Import Changes
 
@@ -164,7 +256,8 @@ import "htmx.org/dist/ext/hx-preload.js";
 
 ## Event Names Changed from camelCase to Colon-Separated
 
-All htmx event names switched from camelCase to colon-separated format.
+All htmx event names switched from camelCase to a colon-separated
+`htmx:phase:action` format.
 
 **Before (v2):**
 
@@ -179,8 +272,23 @@ document.addEventListener("htmx:afterSettle", handler);
 ```javascript
 element.addEventListener("htmx:after:request", handler);
 element.addEventListener("htmx:before:swap", handler);
-element.addEventListener("htmx:after:settle", handler);
+element.addEventListener("htmx:after:swap", handler);
 ```
+
+Key renames:
+
+| htmx 2.x | htmx 4.x |
+|---|---|
+| `htmx:afterOnLoad` | `htmx:after:init` |
+| `htmx:afterProcessNode` | `htmx:after:init` |
+| `htmx:afterRequest` | `htmx:after:request` |
+| `htmx:afterSettle` | `htmx:after:swap` |
+| `htmx:afterSwap` | `htmx:after:swap` |
+| `htmx:beforeRequest` | `htmx:before:request` |
+| `htmx:beforeSwap` | `htmx:before:swap` |
+| `htmx:configRequest` | `htmx:config:request` |
+
+All error events are consolidated to `htmx:error`.
 
 !!! warning
     Events no longer bubble to `document.body` in v4. You must attach listeners
@@ -189,25 +297,24 @@ element.addEventListener("htmx:after:settle", handler);
 
 ## Event Handler Attributes (`hx-on`)
 
-The `hx-on::` shorthand (e.g., `hx-on::after-request`) is broken in htmx 4.0.0-alpha8.
-It registers a listener for `:after-request`, but the dispatched event is
-`htmx:after:request`. Use the explicit long form instead.
-
-**Before (v2):**
+The `hx-on::` shorthand uses kebab-case event names (DOM attributes are
+case-insensitive):
 
 ```html
-<form hx-on::after-request="if(event.detail.successful) this.reset()">
-```
-
-**After (v4):**
-
-```html
-<form hx-on:htmx:after:request="this.reset()">
+<!-- These are equivalent -->
+<button hx-get="/info" hx-on:htmx:before-request="alert('Request!')">
+<button hx-get="/info" hx-on::before-request="alert('Request!')">
 ```
 
 !!! note
-    The `hx-on::` shorthand may be fixed in a future htmx release, but the long
-    form `hx-on:htmx:after:request` works reliably and is the recommended approach.
+    The `hx-on::` shorthand was broken in alpha8 but is fixed in beta1.
+    If you are upgrading from alpha8, you can now use the shorter form.
+
+For JSX compatibility, dashes can replace colons:
+
+```html
+<button hx-get="/info" hx-on--before-request="alert('Request!')">
+```
 
 ## Event Detail Structure Changed
 
@@ -236,22 +343,158 @@ event.detail.ctx.status         // request status string
     checking `if(event.detail.successful)` silently skips the handler body
     without errors.
 
-## View Transitions Disabled
+## `fetch()` Replaces `XMLHttpRequest`
 
-htmx v4 initially shipped with CSS view transitions enabled by default, which
-caused ~500ms UI blocking after each request
-([htmx#3566](https://github.com/bigskysoftware/htmx/issues/3566)). The htmx
-team disabled transitions as the default in a later release.
+All requests use the native `fetch()` API. This cannot be reverted. If you
+have code that interacts with `XMLHttpRequest` objects (e.g., via
+`event.detail.xhr`), it must be updated to use the `Response` object
+available at `event.detail.ctx.response`.
 
-Vibetuner's skeleton template includes a `<meta>` tag that explicitly disables
-them for compatibility with alpha8:
+## `hx-delete` Excludes Form Data
+
+Like `hx-get`, `hx-delete` no longer includes the enclosing form's inputs.
+Add `hx-include="closest form"` where needed.
+
+## `hx-swap` Scroll Modifier Syntax Changed
+
+The `show` and `scroll` modifiers no longer support the combined
+`selector:position` syntax. Use separate keys:
 
 ```html
-<meta name="htmx-config" content='{"globalViewTransitions": false}' />
+<!-- v2 (broken in v4) -->
+<div hx-swap="innerHTML show:#other:top"></div>
+
+<!-- v4 -->
+<div hx-swap="innerHTML show:top showTarget:#other"></div>
+<div hx-swap="innerHTML scroll:bottom scrollTarget:#other"></div>
 ```
 
-If you want view transitions, remove this tag and add CSS transition rules
-per the [htmx view transitions docs](https://four.htmx.org).
+## Config Key Renames
+
+Several config keys were renamed:
+
+| htmx 2.x | htmx 4.x |
+|---|---|
+| `globalViewTransitions` | `transitions` |
+| `defaultSwapStyle` | `defaultSwap` |
+| `historyEnabled` | `history` |
+| `includeIndicatorStyles` | `includeIndicatorCSS` |
+| `timeout` | `defaultTimeout` |
+
+Changed defaults:
+
+| Config | htmx 2 | htmx 4 |
+|---|---|---|
+| `defaultTimeout` | `0` (no timeout) | `60000` (60 seconds) |
+| `defaultSettleDelay` | `20` | `1` |
+
+!!! warning
+    The 60-second default timeout may break long-running requests. If you
+    have endpoints that take longer, set `htmx.config.defaultTimeout = 0`
+    or increase the value.
+
+## View Transitions
+
+View transitions are disabled by default in htmx 4 beta1 (`transitions: false`).
+
+Earlier alpha releases (alpha2 through alpha8) had view transitions enabled
+by default, which caused ~500ms UI blocking after each request
+([htmx#3566](https://github.com/bigskysoftware/htmx/issues/3566)).
+Vibetuner previously included a `<meta>` tag to disable them as a
+workaround. That tag has been removed since beta1 defaults to disabled.
+
+If you had added `{"globalViewTransitions": false}` to your own templates
+as a workaround, you can safely remove it. The old config key name is
+ignored in beta1.
+
+To enable view transitions, set `htmx.config.transitions = true` and add
+CSS transition rules per the
+[htmx view transitions docs](https://four.htmx.org/reference/config/htmx-config-transitions).
+
+## Removed Attributes
+
+| Removed | Use instead |
+|---|---|
+| `hx-vars` | `hx-vals` with `js:` prefix |
+| `hx-params` | `htmx:config:request` event |
+| `hx-prompt` | `hx-confirm` with `js:` prefix |
+| `hx-ext` | Include extension script directly |
+| `hx-disinherit` | Not needed (inheritance is explicit) |
+| `hx-inherit` | Not needed (inheritance is explicit) |
+| `hx-request` | `hx-config` |
+| `hx-history` | Removed (no localStorage in v4) |
+| `hx-history-elt` | Removed |
+
+## New Attributes
+
+| Attribute | Purpose |
+|---|---|
+| `hx-status` | Per-status-code swap behavior |
+| `hx-action` | Specify URL (use with `hx-method`) |
+| `hx-method` | Specify HTTP method |
+| `hx-config` | Per-element request config (replaces `hx-request`) |
+| `hx-ignore` | Disable htmx processing (replaces `hx-disable`) |
+| `hx-validate` | Control form validation behavior |
+
+## New Extensions
+
+htmx 4 ships with these core extensions. All auto-register when imported.
+
+| Extension | Description |
+|---|---|
+| `browser-indicator` | Shows the browser's native loading indicator during requests |
+| `optimistic` | Shows expected content from a template before the server responds |
+| `upsert` | Update-or-insert swap strategy for dynamic lists |
+| `download` | Save responses as file downloads with streaming progress |
+| `targets` | Swap the same response into multiple elements |
+| `history-cache` | Client-side history cache in `sessionStorage` |
+| `ptag` | Per-element polling tags to skip unchanged content |
+| `alpine-compat` | Alpine.js compatibility |
+| `htmx-2-compat` | Backward compatibility layer for htmx 2.x code |
+
+htmx also provides an `htmax` bundle (`htmax.min.js`) that includes htmx
+plus the most popular extensions (SSE, WebSockets, preload,
+browser-indicator, download, optimistic, targets) in a single file.
+
+## JavaScript API Changes
+
+**Removed methods** (use native JS):
+
+| htmx 2.x | Use instead |
+|---|---|
+| `htmx.addClass()` | `element.classList.add()` |
+| `htmx.removeClass()` | `element.classList.remove()` |
+| `htmx.toggleClass()` | `element.classList.toggle()` |
+| `htmx.closest()` | `element.closest()` |
+| `htmx.remove()` | `element.remove()` |
+| `htmx.off()` | `removeEventListener()` |
+| `htmx.location()` | `htmx.ajax()` |
+| `htmx.logAll()` | `htmx.config.logAll = true` |
+
+**Renamed:** `htmx.defineExtension()` is now `htmx.registerExtension()`.
+
+## Alpha to Beta1 Changes
+
+If you are upgrading from an htmx 4 alpha release (not from v2), here is
+what changed specifically between the alpha series and beta1:
+
+- **`hx-on::` shorthand fixed**: The double-colon shorthand
+  (e.g., `hx-on::before-request`) was broken in alpha8. It works correctly
+  in beta1.
+- **`globalViewTransitions` config removed**: Renamed to `transitions`.
+  The old key is silently ignored. Remove any `<meta>` tags using the old
+  name.
+- **View transitions disabled by default**: No longer need the
+  `{"globalViewTransitions": false}` workaround that was required in
+  alpha2-alpha8.
+- **SSE/WS extensions rewritten**: New APIs with per-element config,
+  exponential backoff, `HX-Request-ID` correlation. See the upstream
+  [SSE](https://four.htmx.org/docs/extensions/sse#upgrading-from-htmx-2x)
+  and [WS](https://four.htmx.org/docs/extensions/ws#upgrading-from-htmx-2x)
+  upgrade guides.
+- **New extensions added**: `history-cache`, `ptag`, `targets`, `download`.
+- **`htmax` bundle available**: Single-file bundle with htmx + popular
+  extensions.
 
 ## Common Migration Issues
 
@@ -323,17 +566,52 @@ import "htmx.org/dist/ext/hx-preload.js";
 hx-vals='js:{"token": getToken()}'
 ```
 
+### Error responses replacing page content unexpectedly
+
+**Symptom:** A `422` or `500` response swaps error HTML into the page where it
+previously was ignored.
+
+**Cause:** htmx 4 swaps all HTTP responses by default.
+
+**Fix:** Use `hx-status` for per-element control, or revert globally:
+
+```javascript
+htmx.config.noSwap = [204, 304, '4xx', '5xx'];
+```
+
+### Long-running requests timing out
+
+**Symptom:** Requests that worked in v2 now fail after 60 seconds.
+
+**Cause:** htmx 4 defaults to a 60-second timeout (v2 had no timeout).
+
+**Fix:** Increase or disable the timeout:
+
+```javascript
+htmx.config.defaultTimeout = 0; // no timeout, like v2
+```
+
 ## Migration Checklist
 
-- [ ] Replace `hx-on::` shorthand with `hx-on:htmx:` long form
+- [ ] Replace `hx-on::` shorthand with `hx-on:htmx:` long form, or upgrade
+  to beta1+ where the shorthand works
 - [ ] Replace `event.detail.successful` with `event.detail.ctx.response`
-- [ ] Replace camelCase event names with colon-separated (e.g., `afterRequest` → `after:request`)
-- [ ] Move `document.body` event listeners to the element or use `hx-on` attributes
+- [ ] Replace camelCase event names with colon-separated
+  (e.g., `afterRequest` → `after:request`)
+- [ ] Move `document.body` event listeners to the element or use `hx-on`
+  attributes
 - [ ] Remove all `hx-ext="sse"` attributes from SSE elements
 - [ ] Remove all other `hx-ext="..."` attributes (extensions auto-register)
 - [ ] Replace `hx-vars` with `hx-vals` using `js:` prefix
-- [ ] Replace `hx-disable` with `hx-ignore`
+- [ ] Rename `hx-disable` to `hx-ignore`, then `hx-disabled-elt` to
+  `hx-disable`
 - [ ] Add `:inherited` modifier to attributes that rely on inheritance
 - [ ] Update JS imports to use default import and `window.htmx = htmx`
 - [ ] Update preload extension import path
-- [ ] Remove `htmx-ext-sse` and `htmx-ext-preload` from `package.json` if present
+- [ ] Remove `htmx-ext-sse` and `htmx-ext-preload` from `package.json`
+  if present
+- [ ] Rename config keys (`globalViewTransitions` → `transitions`, etc.)
+- [ ] Remove any `{"globalViewTransitions": false}` meta tags
+- [ ] Test error handling (4xx/5xx now swap by default)
+- [ ] Test long-running requests against the 60-second timeout
+- [ ] Update `hx-swap` scroll modifiers to new syntax if used

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -6,7 +6,6 @@
         <meta name="description" content="{{ meta_description | default('') }}" />
         <meta name="keywords" content="{{ meta_keywords | default('') }}" />
         <meta name="color-scheme" content="light" />
-        <meta name="htmx-config" content='{"globalViewTransitions": false}' />
         <title>
             {% block title %}
             {% endblock title %}


### PR DESCRIPTION
## Summary

- Remove the stale `globalViewTransitions: false` meta tag from the skeleton template
  (config key renamed to `transitions` in htmx 4, defaults to `false` in beta1)
- Expand htmx migration guide with comprehensive coverage of new htmx 4 features:
  error response swapping, `hx-status`, `<hx-partial>`, config key renames, 60s
  default timeout, new extensions, SSE/WS rewrite, `htmax` bundle
- Add dedicated "Alpha to Beta1 Changes" section for users on any alpha version
- Add new troubleshooting entries for error response swapping and request timeouts

## Test plan

- [ ] Verify markdown linting passes
- [ ] Review migration guide for accuracy against https://four.htmx.org/docs/get-started/migration
- [ ] Verify skeleton template renders correctly without the meta tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)