### PR TITLE
fix: improve MongoDB connection error handling during startup

### DIFF
--- a/vibetuner-py/src/vibetuner/mongo.py
+++ b/vibetuner-py/src/vibetuner/mongo.py
@@ -5,6 +5,7 @@ from typing import Optional
 from beanie import init_beanie
 from deprecated import deprecated
 from pymongo import AsyncMongoClient
+from pymongo.errors import ConnectionFailure
 
 from vibetuner.config import settings
 from vibetuner.loader import load_app_config
@@ -69,10 +70,19 @@ async def init_mongodb() -> None:
     all_models = get_all_models()
     logger.debug(f"Initializing Beanie with {len(all_models)} models")
 
-    await init_beanie(
-        database=mongo_client[settings.mongo_dbname],
-        document_models=all_models,
-    )
+    try:
+        await init_beanie(
+            database=mongo_client[settings.mongo_dbname],
+            document_models=all_models,
+        )
+    except ConnectionFailure as exc:
+        url = settings.mongodb_url
+        logger.error(
+            "Failed to connect to MongoDB at {}: {}",
+            f"{url.host}:{url.port}" if url else "unknown",
+            exc,
+        )
+        raise
 
     logger.info("MongoDB + Beanie initialized successfully.")
 

--- a/vibetuner-py/tests/unit/test_mongo_init_warning.py
+++ b/vibetuner-py/tests/unit/test_mongo_init_warning.py
@@ -1,10 +1,11 @@
-# ABOUTME: Tests that init_mongodb warns when models are registered but MONGODB_URL is missing.
-# ABOUTME: Ensures users get actionable diagnostics instead of cryptic Beanie errors.
+# ABOUTME: Tests for init_mongodb diagnostic logging.
+# ABOUTME: Covers missing MONGODB_URL warnings and connection failure error messages.
 # ruff: noqa: S101
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pymongo.errors import ConnectionFailure
 
 
 @pytest.mark.asyncio
@@ -44,3 +45,38 @@ async def test_silent_skip_when_no_models_and_no_mongodb_url():
 
         mock_logger.warning.assert_not_called()
         mock_logger.debug.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_logs_error_on_connection_failure():
+    """init_mongodb should log a clear error when MongoDB is unreachable."""
+    mock_url = MagicMock()
+    mock_url.host = "mongo.example.com"
+    mock_url.port = 27017
+
+    mock_settings = MagicMock(mongodb_url=mock_url, mongo_dbname="testdb")
+    mock_client = MagicMock()
+    mock_client.__getitem__ = MagicMock(return_value=MagicMock())
+
+    with (
+        patch("vibetuner.mongo.settings", mock_settings),
+        patch("vibetuner.mongo.load_app_config", return_value=MagicMock(models=[])),
+        patch("vibetuner.mongo.mongo_client", mock_client),
+        patch("vibetuner.mongo._ensure_client"),
+        patch(
+            "vibetuner.mongo.init_beanie",
+            new_callable=AsyncMock,
+            side_effect=ConnectionFailure("connection refused"),
+        ),
+        patch("vibetuner.mongo.logger") as mock_logger,
+    ):
+        from vibetuner.mongo import init_mongodb
+
+        with pytest.raises(ConnectionFailure):
+            await init_mongodb()
+
+        mock_logger.error.assert_called_once()
+        error_msg = mock_logger.error.call_args[0][0]
+        assert "Failed to connect to MongoDB" in error_msg
+        fmt_args = mock_logger.error.call_args[0]
+        assert "mongo.example.com:27017" in fmt_args[1]


### PR DESCRIPTION
## Summary
- Wraps `init_beanie()` in `init_mongodb()` with a `ConnectionFailure` try/except that logs a clear vibetuner-level error with host:port before re-raising
- Adds test for the connection failure logging path

Closes #1426

## Test plan
- [x] Existing mongo init warning tests still pass
- [x] New `test_logs_error_on_connection_failure` verifies error is logged with host:port and `ConnectionFailure` is re-raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)