### PR TITLE
feat: add CLI commands for managing runtime config values

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/__init__.py
+++ b/vibetuner-py/src/vibetuner/cli/__init__.py
@@ -7,6 +7,7 @@ from functools import partial, wraps
 import asyncer
 import typer
 
+from vibetuner.cli.config import config_app
 from vibetuner.cli.crypto import crypto_app
 from vibetuner.cli.db import db_app
 from vibetuner.cli.debug import debug_app
@@ -131,6 +132,7 @@ def version(
     console.print(table)
 
 
+app.add_typer(config_app, name="config")
 app.add_typer(crypto_app, name="crypto")
 app.add_typer(db_app, name="db")
 app.add_typer(debug_app, name="debug")

--- a/vibetuner-py/src/vibetuner/cli/config.py
+++ b/vibetuner-py/src/vibetuner/cli/config.py
@@ -1,0 +1,155 @@
+# ABOUTME: CLI commands for managing runtime config values.
+# ABOUTME: Provides list, set, and delete for config entries including secrets.
+from typing import Annotated
+
+import typer
+
+from vibetuner.mongo import init_mongodb
+from vibetuner.runtime_config import RuntimeConfig
+
+
+config_app = typer.Typer(
+    help="Manage runtime configuration values", no_args_is_help=True
+)
+
+
+async def _list_impl() -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    from vibetuner.loader import load_app_config
+
+    load_app_config()
+    await init_mongodb()
+    await RuntimeConfig.refresh_cache()
+
+    entries = await RuntimeConfig.get_all_config()
+
+    if not entries:
+        typer.echo("No config values registered.")
+        return
+
+    console = Console()
+    table = Table(title="Runtime Configuration")
+    table.add_column("Key", style="cyan", no_wrap=True)
+    table.add_column("Value", style="green")
+    table.add_column("Type", style="yellow")
+    table.add_column("Source", style="magenta")
+    table.add_column("Category", style="blue")
+
+    for entry in entries:
+        if entry["is_secret"]:
+            display_value = "********" if entry["source"] != "default" else "(not set)"
+        else:
+            display_value = str(entry["value"])
+
+        table.add_row(
+            entry["key"],
+            display_value,
+            entry["value_type"],
+            entry["source"],
+            entry["category"],
+        )
+
+    console.print(table)
+
+
+async def _set_impl(key: str, value: str | None) -> None:
+    from vibetuner.loader import load_app_config
+
+    load_app_config()
+    await init_mongodb()
+
+    if key not in RuntimeConfig._config_registry:
+        typer.echo(f"Error: Key '{key}' is not registered.", err=True)
+        raise typer.Exit(1)
+
+    entry = RuntimeConfig._config_registry[key]
+    is_secret = entry["is_secret"]
+
+    if value is not None and is_secret:
+        typer.echo(
+            "Warning: Secret value passed as argument. It may appear in shell history.",
+            err=True,
+        )
+    elif value is None:
+        if is_secret:
+            value = typer.prompt("Value", hide_input=True)
+        else:
+            value = typer.prompt("Value")
+
+    await RuntimeConfig.set_value(
+        key=key,
+        value=value,
+        value_type=entry["value_type"],
+        description=entry["description"],
+        category=entry["category"],
+        is_secret=is_secret,
+    )
+
+    typer.echo(f"Set '{key}' successfully.")
+
+
+async def _delete_impl(key: str, yes: bool) -> None:
+    from vibetuner.loader import load_app_config
+
+    load_app_config()
+    await init_mongodb()
+
+    if key not in RuntimeConfig._config_registry:
+        typer.echo(f"Error: Key '{key}' is not registered.", err=True)
+        raise typer.Exit(1)
+
+    if not yes:
+        confirmed = typer.confirm(f"Delete config value '{key}' from MongoDB?")
+        if not confirmed:
+            typer.echo("Aborted.")
+            return
+
+    deleted = await RuntimeConfig.delete_value(key)
+    if deleted:
+        typer.echo(f"Deleted '{key}' from MongoDB.")
+    else:
+        typer.echo(f"Value for '{key}' not found in MongoDB (only default exists).")
+
+
+@config_app.command("list")
+def config_list() -> None:
+    """List all registered config keys, their values, and sources."""
+    import asyncer
+
+    asyncer.runnify(_list_impl)()
+
+
+@config_app.command("set")
+def config_set(
+    key: Annotated[
+        str, typer.Argument(help="Config key to set (e.g. secrets.api_key)")
+    ],
+    value: Annotated[
+        str | None,
+        typer.Option(
+            "--value",
+            "-v",
+            help="Value to set. Omit for secrets to use hidden prompt.",
+        ),
+    ] = None,
+) -> None:
+    """Set a config value. Secrets use a hidden prompt by default."""
+    import asyncer
+
+    asyncer.runnify(_set_impl)(key, value)
+
+
+@config_app.command("delete")
+def config_delete(
+    key: Annotated[str, typer.Argument(help="Config key to delete from MongoDB")],
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Skip confirmation prompt"),
+    ] = False,
+) -> None:
+    """Delete a config value from MongoDB (reverts to default)."""
+    import asyncer
+
+    asyncer.runnify(_delete_impl)(key, yes)

--- a/vibetuner-py/tests/unit/test_config_cli.py
+++ b/vibetuner-py/tests/unit/test_config_cli.py
@@ -1,0 +1,290 @@
+# ABOUTME: Tests for vibetuner.cli.config CLI commands.
+# ABOUTME: Verifies list, set, and delete config commands without requiring MongoDB.
+# ruff: noqa: S101
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+from vibetuner.cli import app
+from vibetuner.runtime_config import RuntimeConfig, register_config_value
+
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Reset RuntimeConfig state between tests."""
+    orig_registry = RuntimeConfig._config_registry.copy()
+    orig_cache = RuntimeConfig._config_cache.copy()
+    orig_overrides = RuntimeConfig._runtime_overrides.copy()
+    yield
+    RuntimeConfig._config_registry.clear()
+    RuntimeConfig._config_registry.update(orig_registry)
+    RuntimeConfig._config_cache.clear()
+    RuntimeConfig._config_cache.update(orig_cache)
+    RuntimeConfig._runtime_overrides.clear()
+    RuntimeConfig._runtime_overrides.update(orig_overrides)
+
+
+def _register_test_configs():
+    """Register a set of test config values."""
+    register_config_value(
+        key="features.dark_mode",
+        default=False,
+        value_type="bool",
+        description="Enable dark mode",
+        category="features",
+    )
+    register_config_value(
+        key="secrets.api_key",
+        default="",
+        value_type="str",
+        description="External API key",
+        category="secrets",
+        is_secret=True,
+    )
+    register_config_value(
+        key="general.max_items",
+        default=50,
+        value_type="int",
+        description="Max items per page",
+        category="general",
+    )
+
+
+class TestConfigList:
+    """Tests for `vibetuner config list`."""
+
+    def test_list_shows_registered_configs(self):
+        """list displays all registered config keys with their metadata."""
+        _register_test_configs()
+
+        with patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock):
+            result = runner.invoke(app, ["config", "list"])
+
+        assert result.exit_code == 0
+        assert "features.dark_mode" in result.output
+        assert "secrets.api_key" in result.output
+        assert "general.max_items" in result.output
+
+    def test_list_shows_source(self):
+        """list displays the value source (default, mongodb, runtime)."""
+        _register_test_configs()
+
+        with patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock):
+            result = runner.invoke(app, ["config", "list"])
+
+        assert result.exit_code == 0
+        assert "default" in result.output
+
+    def test_list_masks_secret_values(self):
+        """list masks secret values instead of showing them."""
+        _register_test_configs()
+        RuntimeConfig._config_cache["secrets.api_key"] = "sk-super-secret-key"
+
+        with patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock):
+            result = runner.invoke(app, ["config", "list"])
+
+        assert result.exit_code == 0
+        assert "sk-super-secret-key" not in result.output
+
+    def test_list_shows_non_secret_values(self):
+        """list shows actual values for non-secret configs."""
+        _register_test_configs()
+
+        with patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock):
+            result = runner.invoke(app, ["config", "list"])
+
+        assert result.exit_code == 0
+        assert "50" in result.output
+
+    def test_list_empty_registry(self):
+        """list handles empty registry gracefully."""
+        RuntimeConfig._config_registry.clear()
+
+        with patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock):
+            result = runner.invoke(app, ["config", "list"])
+
+        assert result.exit_code == 0
+        assert "No config" in result.output
+
+
+class TestConfigSet:
+    """Tests for `vibetuner config set`."""
+
+    def test_set_nonexistent_key_fails(self):
+        """set rejects keys that aren't registered."""
+        with patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock):
+            result = runner.invoke(app, ["config", "set", "nonexistent.key"])
+
+        assert result.exit_code == 1
+        assert "not registered" in result.output.lower()
+
+    def test_set_non_secret_with_value_arg(self):
+        """set accepts a value argument for non-secret configs."""
+        _register_test_configs()
+
+        with (
+            patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.runtime_config.RuntimeConfig.set_value",
+                new_callable=AsyncMock,
+            ) as mock_set,
+        ):
+            result = runner.invoke(
+                app, ["config", "set", "general.max_items", "--value", "100"]
+            )
+
+        assert result.exit_code == 0
+        mock_set.assert_called_once()
+        call_kwargs = mock_set.call_args
+        assert call_kwargs.kwargs["key"] == "general.max_items"
+        assert call_kwargs.kwargs["value"] == "100"
+
+    def test_set_secret_prompts_for_value(self):
+        """set prompts for hidden input when setting a secret without --value."""
+        _register_test_configs()
+
+        with (
+            patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.runtime_config.RuntimeConfig.set_value",
+                new_callable=AsyncMock,
+            ) as mock_set,
+        ):
+            result = runner.invoke(
+                app, ["config", "set", "secrets.api_key"], input="my-secret-value\n"
+            )
+
+        assert result.exit_code == 0
+        mock_set.assert_called_once()
+        call_kwargs = mock_set.call_args
+        assert call_kwargs.kwargs["value"] == "my-secret-value"
+
+    def test_set_secret_with_value_arg_warns(self):
+        """set warns about shell history when --value is used with a secret."""
+        _register_test_configs()
+
+        with (
+            patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.runtime_config.RuntimeConfig.set_value",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["config", "set", "secrets.api_key", "--value", "sk-test"],
+            )
+
+        assert result.exit_code == 0
+        assert "shell history" in result.output.lower()
+
+    def test_set_preserves_registry_metadata(self):
+        """set passes correct metadata from registry to set_value."""
+        _register_test_configs()
+
+        with (
+            patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.runtime_config.RuntimeConfig.set_value",
+                new_callable=AsyncMock,
+            ) as mock_set,
+        ):
+            result = runner.invoke(
+                app, ["config", "set", "secrets.api_key"], input="my-key\n"
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_set.call_args.kwargs
+        assert call_kwargs["is_secret"] is True
+        assert call_kwargs["category"] == "secrets"
+        assert call_kwargs["value_type"] == "str"
+
+
+class TestConfigDelete:
+    """Tests for `vibetuner config delete`."""
+
+    def test_delete_nonexistent_key_fails(self):
+        """delete rejects keys that aren't registered."""
+        with patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock):
+            result = runner.invoke(app, ["config", "delete", "nonexistent.key"])
+
+        assert result.exit_code == 1
+        assert "not registered" in result.output.lower()
+
+    def test_delete_calls_delete_value(self):
+        """delete removes the value from MongoDB."""
+        _register_test_configs()
+
+        with (
+            patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.runtime_config.RuntimeConfig.delete_value",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_delete,
+        ):
+            result = runner.invoke(
+                app, ["config", "delete", "features.dark_mode", "--yes"]
+            )
+
+        assert result.exit_code == 0
+        mock_delete.assert_called_once_with("features.dark_mode")
+
+    def test_delete_prompts_for_confirmation(self):
+        """delete asks for confirmation by default."""
+        _register_test_configs()
+
+        with (
+            patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.runtime_config.RuntimeConfig.delete_value",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_delete,
+        ):
+            result = runner.invoke(
+                app, ["config", "delete", "features.dark_mode"], input="y\n"
+            )
+
+        assert result.exit_code == 0
+        mock_delete.assert_called_once()
+
+    def test_delete_aborted_on_no(self):
+        """delete aborts when user declines confirmation."""
+        _register_test_configs()
+
+        with (
+            patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.runtime_config.RuntimeConfig.delete_value",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            result = runner.invoke(
+                app, ["config", "delete", "features.dark_mode"], input="n\n"
+            )
+
+        assert result.exit_code == 0
+        mock_delete.assert_not_called()
+
+    def test_delete_not_found_in_db(self):
+        """delete reports when value wasn't found in MongoDB."""
+        _register_test_configs()
+
+        with (
+            patch("vibetuner.cli.config.init_mongodb", new_callable=AsyncMock),
+            patch(
+                "vibetuner.runtime_config.RuntimeConfig.delete_value",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = runner.invoke(
+                app, ["config", "delete", "features.dark_mode", "--yes"]
+            )
+
+        assert result.exit_code == 0
+        assert "not found" in result.output.lower()


### PR DESCRIPTION
## Summary

- Adds `vibetuner config list` to display all registered config keys, values, types, sources, and categories (secret values are masked)
- Adds `vibetuner config set <key>` to persist config values to MongoDB, with hidden prompt for secrets to avoid shell history leaks
- Adds `vibetuner config delete <key>` to remove persisted values from MongoDB (with confirmation prompt)

Closes #1586

## Test plan

- [x] 15 unit tests covering all three commands (list, set, delete)
- [x] Tests verify secret masking, prompt behavior, confirmation flow, error cases
- [x] All 662 existing unit tests still pass
- [ ] Manual test with a real project and MongoDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)