### PR TITLE
fix: refresh stale cache in RuntimeConfig.get() and get_all_config()

### DIFF
--- a/vibetuner-py/src/vibetuner/runtime_config.py
+++ b/vibetuner-py/src/vibetuner/runtime_config.py
@@ -113,6 +113,10 @@ class RuntimeConfig:
         if key in cls._runtime_overrides:
             return cls._runtime_overrides[key]
 
+        # Ensure MongoDB cache is populated
+        if cls.is_cache_stale():
+            await cls.refresh_cache()
+
         # 2. Check MongoDB cache
         if key in cls._config_cache:
             return cls._config_cache[key]
@@ -220,6 +224,9 @@ class RuntimeConfig:
     @classmethod
     async def get_all_config(cls) -> list[ConfigEntry]:
         """Get all config entries with their sources for debug display."""
+        if cls.is_cache_stale():
+            await cls.refresh_cache()
+
         entries: list[ConfigEntry] = []
 
         # Start with all registered configs

--- a/vibetuner-py/tests/unit/test_runtime_config.py
+++ b/vibetuner-py/tests/unit/test_runtime_config.py
@@ -251,6 +251,77 @@ class TestCacheManagement:
         assert RuntimeConfig.is_cache_stale() is True
 
 
+class TestGetRefreshesStaleCache:
+    """Tests that get() and get_all_config() refresh a stale cache."""
+
+    @pytest.mark.asyncio
+    async def test_get_refreshes_stale_cache(self):
+        """get() calls refresh_cache when cache is stale."""
+        from vibetuner.runtime_config import RuntimeConfig, register_config_value
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+        RuntimeConfig._cache_last_refresh = None  # stale
+
+        register_config_value(
+            key="test.refresh",
+            default="default",
+            value_type="str",
+        )
+
+        with patch.object(
+            RuntimeConfig, "refresh_cache", new_callable=AsyncMock
+        ) as mock_refresh:
+            await RuntimeConfig.get("test.refresh")
+            mock_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_skips_refresh_when_cache_fresh(self):
+        """get() does not call refresh_cache when cache is fresh."""
+        from vibetuner.runtime_config import RuntimeConfig, register_config_value
+        from vibetuner.time import now
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+        RuntimeConfig._cache_last_refresh = now()  # fresh
+
+        register_config_value(
+            key="test.fresh",
+            default="default",
+            value_type="str",
+        )
+
+        with patch.object(
+            RuntimeConfig, "refresh_cache", new_callable=AsyncMock
+        ) as mock_refresh:
+            await RuntimeConfig.get("test.fresh")
+            mock_refresh.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_all_config_refreshes_stale_cache(self):
+        """get_all_config() calls refresh_cache when cache is stale."""
+        from vibetuner.runtime_config import RuntimeConfig, register_config_value
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+        RuntimeConfig._cache_last_refresh = None  # stale
+
+        register_config_value(
+            key="test.all",
+            default="default",
+            value_type="str",
+        )
+
+        with patch.object(
+            RuntimeConfig, "refresh_cache", new_callable=AsyncMock
+        ) as mock_refresh:
+            await RuntimeConfig.get_all_config()
+            mock_refresh.assert_awaited_once()
+
+
 class TestGetAllConfig:
     """Tests for retrieving all config entries."""
 


### PR DESCRIPTION
## Summary
- `RuntimeConfig.get()` never called `refresh_cache()` when the cache was stale, so MongoDB-stored config values were never loaded
- Same issue in `get_all_config()` which also reads from `_config_cache` without refreshing
- Added stale-cache check before cache lookups in both methods

Fixes #1588

## Test plan
- [x] Added test: `get()` calls `refresh_cache()` when cache is stale
- [x] Added test: `get()` skips refresh when cache is fresh
- [x] Added test: `get_all_config()` calls `refresh_cache()` when cache is stale
- [x] All 45 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)