### PR TITLE
docs: document recent features across docs site, llms.txt, and AGENTS.md

### DIFF
--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -245,9 +245,67 @@ async def critical_sync(data: dict):
     ...
 ```
 
+## The `@robust_cron()` Decorator
+
+For scheduled tasks that need the same retry and dead letter support as
+`@robust_task()`, use `@robust_cron()`:
+
+```python
+from vibetuner.tasks.robust import robust_cron
+
+@robust_cron("*/15 * * * *", max_retries=5, backoff_max=120)
+async def refresh_caches():
+    """Refresh external caches every 15 minutes with retry on failure."""
+    import httpx
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get("https://api.example.com/cache/refresh")
+        resp.raise_for_status()
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tab` | `str` | *(required)* | Crontab schedule expression (e.g., `"0 9 * * *"`) |
+| `max_retries` | `int` | `3` | Maximum attempts before giving up |
+| `backoff_base` | `float` | `2.0` | Base for exponential backoff (`delay = base ** tries`) |
+| `backoff_max` | `float` | `300.0` | Maximum backoff delay in seconds |
+| `timeout` | `timedelta \| int \| None` | `None` | Task timeout (forwarded to `worker.cron()`) |
+| `on_failure` | `Callable \| None` | `None` | Called on permanent failure (sync or async) |
+| `**cron_kwargs` | | | Extra keyword arguments forwarded to `worker.cron()` |
+
+The retry behavior, dead letter collection, and failure callback work
+identically to [`@robust_task()`](#the-robust_task-decorator). The only
+difference is that `@robust_cron()` runs on a schedule instead of being
+enqueued manually.
+
+```python
+async def alert_on_failure(task_name: str, task_id: str, exc: Exception):
+    await notify_ops_team(f"Cron {task_name} failed: {exc}")
+
+@robust_cron("0 0 * * *", max_retries=3, on_failure=alert_on_failure)
+async def nightly_sync():
+    """Nightly data sync with failure alerting."""
+    ...
+```
+
+Register cron tasks in `tune.py` the same way as regular tasks:
+
+```python
+# src/app/tune.py
+from vibetuner import VibetunerApp
+from app.tasks.maintenance import refresh_caches, nightly_sync
+
+app = VibetunerApp(
+    tasks=[refresh_caches, nightly_sync],
+)
+```
+
 ## Scheduled Tasks (Cron)
 
-Use `@worker.cron()` to run tasks on a schedule:
+For simple scheduled tasks that don't need retries or dead letter tracking,
+use `@worker.cron()` directly:
 
 ```python
 from vibetuner.tasks.worker import get_worker

--- a/vibetuner-docs/docs/cli-reference.md
+++ b/vibetuner-docs/docs/cli-reference.md
@@ -226,6 +226,80 @@ Summary
 - **✗** (red) — error, must be fixed
 - **-** (dim) — skipped (not applicable)
 
+## `vibetuner config`
+
+Manage runtime configuration values from the command line. All subcommands
+require a project directory with MongoDB configured.
+
+### `list`
+
+```bash
+vibetuner config list
+```
+
+Displays a table of all registered config keys with their current values,
+types, sources, and categories. Secret values are masked with `********`.
+
+### `set`
+
+```bash
+vibetuner config set KEY [--value VALUE]
+```
+
+Sets a config value and persists it to MongoDB.
+
+#### Arguments
+
+- `KEY` — Config key to set (e.g., `features.dark_mode`). Must be a
+  registered key.
+
+#### Options
+
+- `--value`, `-v` — Value to set. When omitted for secret keys, a hidden
+  input prompt is used (recommended to avoid shell history exposure). When
+  omitted for non-secret keys, a regular input prompt is used.
+
+#### Examples
+
+```bash
+# Set a non-secret value
+vibetuner config set features.dark_mode --value true
+
+# Set a secret value (hidden prompt, no shell history)
+vibetuner config set integrations.api_key
+```
+
+!!! warning
+    Passing secrets via `--value` exposes them in shell history. Omit
+    `--value` for secret keys to use the secure hidden prompt.
+
+### `delete`
+
+```bash
+vibetuner config delete KEY [--yes]
+```
+
+Deletes a config value from MongoDB, reverting the key to its registered
+default.
+
+#### Arguments
+
+- `KEY` — Config key to delete from MongoDB.
+
+#### Options
+
+- `--yes`, `-y` — Skip the confirmation prompt.
+
+#### Examples
+
+```bash
+# Delete with confirmation prompt
+vibetuner config delete features.dark_mode
+
+# Skip confirmation
+vibetuner config delete features.dark_mode --yes
+```
+
 ## `vibetuner debug`
 
 Access the debug dashboard on deployed applications using short-lived HMAC-signed links.

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -286,6 +286,41 @@ await post.save()
 **CRUD factory:** The `DELETE` endpoint automatically performs a soft delete for models
 that use `DocumentWithSoftDelete`. No configuration needed.
 
+#### Encrypted Fields
+
+Encrypt sensitive fields at rest using `EncryptedFieldsMixin` and the
+`EncryptedStr` type. Fields are transparently encrypted before database
+writes and decrypted on load:
+
+```python
+from beanie import Document
+from pydantic import Field
+from vibetuner.models.mixins import EncryptedFieldsMixin, EncryptedStr
+
+class ApiCredential(Document, EncryptedFieldsMixin):
+    provider: str
+    api_key: EncryptedStr = Field(..., description="Encrypted API key")
+    token: EncryptedStr | None = Field(default=None)
+
+    class Settings:
+        name = "api_credentials"
+```
+
+```python
+# Usage — encryption/decryption is automatic
+cred = ApiCredential(provider="stripe", api_key="sk_live_xxx")
+await cred.insert()         # api_key is encrypted before write
+
+loaded = await ApiCredential.get(cred.id)
+print(loaded.api_key)       # "sk_live_xxx" — decrypted on load
+```
+
+Encryption requires the `FIELD_ENCRYPTION_KEY` environment variable
+(a Fernet key). When the key is not set, fields are stored as plaintext.
+Use `vibetuner crypto set-key` to generate and configure a key, and
+`vibetuner crypto rotate-key` to rotate it. See the
+[CLI Reference](cli-reference.md#vibetuner-crypto) for details.
+
 ### Creating Templates
 
 Add templates in `templates/frontend/`:
@@ -328,6 +363,25 @@ The same convention applies to `{% extends %}` and `{% include %}` inside templa
 {% extends "base/skeleton.html.jinja" %}          {# correct #}
 {% extends "frontend/base/skeleton.html.jinja" %} {# wrong #}
 ```
+
+### Built-in Template Globals
+
+Vibetuner provides these variables in every template automatically:
+
+| Variable | Type | Value |
+|----------|------|-------|
+| `now` | `datetime` | `datetime.now(timezone.utc)` — timezone-aware UTC datetime |
+| `today` | `str` | `date.today().isoformat()` — ISO date string (e.g., `"2026-04-07"`) |
+
+```html
+<p>Page rendered at {{ now | format_datetime }}</p>
+<p>Today is {{ today }}</p>
+<footer>&copy; {{ now.year }} My Company</footer>
+```
+
+These are re-evaluated on every render, so `now` reflects the current
+request time. For custom globals, see
+[Template Context Providers](#template-context-providers).
 
 ### Built-in Template Filters
 
@@ -464,6 +518,46 @@ Vibetuner uses Tailwind CSS + DaisyUI. Edit `assets/config.css` for custom style
 
 The build process automatically compiles to `assets/statics/css/bundle.css`.
 
+### Security Headers and CSP Nonce
+
+Vibetuner includes `SecurityHeadersMiddleware` that sets security headers
+(X-Content-Type-Options, X-Frame-Options, Referrer-Policy, etc.) and
+generates a Content Security Policy with a unique nonce per request.
+
+**Script tags** get the nonce auto-injected by the middleware. Do not add
+`nonce=` attributes to `<script>` tags manually:
+
+```html
+<!-- Correct — nonce is added automatically by middleware -->
+<script src="/static/app.js"></script>
+
+<!-- Wrong — manual nonce causes double-injection issues -->
+<script nonce="{{ csp_nonce }}" src="/static/app.js"></script>
+```
+
+**Style tags and other elements** that need the nonce must use the
+`{{ csp_nonce }}` template variable (available in all templates):
+
+```html
+<style nonce="{{ csp_nonce }}">
+    .highlight { color: red; }
+</style>
+```
+
+In debug mode, CSP uses `Content-Security-Policy-Report-Only` (violations
+are reported but not enforced). In production, CSP is fully enforced.
+
+Configure extra allowed sources via environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `CSP_EXTRA_SCRIPT_SRC` | Additional script sources |
+| `CSP_EXTRA_STYLE_SRC` | Additional style sources |
+| `CSP_EXTRA_IMG_SRC` | Additional image sources |
+| `CSP_EXTRA_CONNECT_SRC` | Additional connect sources |
+| `CSP_EXTRA_FONT_SRC` | Additional font sources |
+| `CSP_EXTRA_MEDIA_SRC` | Additional media sources |
+
 ## Working with HTMX
 
 Vibetuner uses HTMX for interactive features without JavaScript:
@@ -576,6 +670,36 @@ if you already have `REDIS_URL` configured.
 - Works with JSON, HTML, and dict responses
 - **Disabled by default in debug mode** — pass `force_caching=True` to override
 - If Redis is not configured or unavailable, the decorator is a transparent no-op
+
+**Request-dependent cache keys with `vary_on`:**
+
+Use `vary_on` to cache different responses for different users, tenants, or
+any other request-derived dimension:
+
+```python
+# Per-user cache — each user gets their own cached dashboard
+@router.get("/dashboard")
+@cache(expire=120, vary_on=lambda r: str(r.state.user.id))
+async def dashboard(request: Request):
+    return await render_dashboard(request)
+
+# Per-tenant cache
+@router.get("/reports")
+@cache(expire=300, vary_on=lambda r: r.state.tenant_id)
+async def reports(request: Request):
+    return await generate_reports(request)
+
+# Vary by header
+@router.get("/api/data")
+@cache(expire=60, vary_on=lambda r: r.headers.get("x-tenant", ""))
+async def data(request: Request):
+    return await fetch_data(request)
+```
+
+`vary_on` accepts a callable with signature `(Request) -> str`. The
+returned string is included in the cache key, so different values produce
+independent cache entries. When `None` (the default), all requests to the
+same path and query share one cache entry.
 
 **Cache invalidation:**
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -304,6 +304,29 @@ Use `find_many_in_all()` to include them. `delete()` sets `deleted_at` instead o
 `hard_delete()` permanently removes it. To restore: `doc.deleted_at = None; await doc.save()`.
 The CRUD factory's DELETE endpoint automatically performs a soft delete for these models.
 
+**Encrypted Fields (MongoDB)**
+
+Encrypt sensitive fields at rest using `EncryptedFieldsMixin` and `EncryptedStr`:
+
+```python
+from beanie import Document
+from pydantic import Field
+from vibetuner.models.mixins import EncryptedFieldsMixin, EncryptedStr
+
+class ApiCredential(Document, EncryptedFieldsMixin):
+    provider: str
+    api_key: EncryptedStr = Field(..., description="Encrypted API key")
+    token: EncryptedStr | None = Field(default=None)
+
+    class Settings:
+        name = "api_credentials"
+```
+
+Fields are transparently encrypted before database writes and decrypted on load.
+Requires `FIELD_ENCRYPTION_KEY` environment variable (Fernet key). Use
+`vibetuner crypto set-key` to generate a key, `vibetuner crypto rotate-key` to
+rotate it.
+
 #### Creating Templates
 
 Add templates in `templates/`:
@@ -324,6 +347,18 @@ Add templates in `templates/`:
         </div>
     </div>
 {% endblock %}
+```
+
+#### Built-in Template Globals
+
+These variables are available in every template automatically:
+
+- `now` — `datetime.now(timezone.utc)`, timezone-aware UTC datetime
+- `today` — `date.today().isoformat()`, ISO date string (e.g., `"2026-04-07"`)
+
+```html
+<p>Page rendered at {{ now | format_datetime }}</p>
+<footer>&copy; {{ now.year }} My Company</footer>
 ```
 
 #### Built-in Template Filters
@@ -1118,6 +1153,49 @@ automatically bridged via Redis pub/sub for multi-worker support.
 </div>
 ```
 
+### Response Caching
+
+Cache route responses in Redis with `@cache`:
+
+```python
+from vibetuner.cache import cache
+
+@router.get("/api/stats")
+@cache(expire=60)  # cache for 60 seconds
+async def get_stats(request: Request):
+    return {"users": await count_users()}
+```
+
+Parameters: `expire` (TTL in seconds, default 60), `force_caching` (override
+debug mode disable, default False), `vary_on` (callable for request-dependent
+keys, default None).
+
+Cache key is derived from path + sorted query params. Disabled in debug mode.
+No-op if Redis is unavailable.
+
+**Request-dependent keys with `vary_on`:**
+
+```python
+# Per-user cache
+@router.get("/dashboard")
+@cache(expire=120, vary_on=lambda r: str(r.state.user.id))
+async def dashboard(request: Request):
+    return await render_dashboard(request)
+```
+
+`vary_on` accepts `Callable[[Request], str]`. The returned string is included
+in the cache key, so different values produce independent cache entries.
+
+**Cache invalidation:**
+
+```python
+from vibetuner.cache import invalidate, invalidate_pattern
+
+await invalidate("/api/stats")
+await invalidate("/api/stats", query_params="page=1")
+await invalidate_pattern("/api/*")
+```
+
 ### Template Context Providers
 
 Register static globals or dynamic context providers available in every template.
@@ -1355,6 +1433,35 @@ actionable error messages with:
 
 These errors are displayed as rich console panels via `vibetuner.services.errors`.
 
+### Security Headers and CSP Nonce
+
+`SecurityHeadersMiddleware` sets security headers and generates a Content
+Security Policy with a unique nonce per request.
+
+**Script tags** get the nonce auto-injected by the middleware. Do NOT add
+`nonce=` attributes to `<script>` tags manually:
+
+```html
+<!-- Correct — nonce added automatically -->
+<script src="/static/app.js"></script>
+
+<!-- Wrong — manual nonce breaks auto-injection -->
+<script nonce="{{ csp_nonce }}" src="/static/app.js"></script>
+```
+
+**Style tags** must use the `{{ csp_nonce }}` template variable:
+
+```html
+<style nonce="{{ csp_nonce }}">
+    .highlight { color: red; }
+</style>
+```
+
+In debug mode, CSP uses `Content-Security-Policy-Report-Only`. In production,
+CSP is fully enforced. Configure extra sources via `CSP_EXTRA_SCRIPT_SRC`,
+`CSP_EXTRA_STYLE_SRC`, `CSP_EXTRA_IMG_SRC`, `CSP_EXTRA_CONNECT_SRC`,
+`CSP_EXTRA_FONT_SRC`, `CSP_EXTRA_MEDIA_SRC` environment variables.
+
 ### Background Tasks
 
 Run long-running or scheduled work outside the request cycle using Vibetuner's
@@ -1457,7 +1564,33 @@ Parameters: `max_retries` (default 3), `backoff_base` (default 2.0),
 
 Failed tasks are stored in the `dead_letters` MongoDB collection.
 
+#### The `@robust_cron()` Decorator
+
+For scheduled tasks that need retries and dead letter tracking, use
+`@robust_cron()` instead of `@worker.cron()`:
+
+```python
+from vibetuner.tasks.robust import robust_cron
+
+@robust_cron("*/15 * * * *", max_retries=5, backoff_max=120)
+async def refresh_caches():
+    """Refresh external caches with retry on failure."""
+    import httpx
+    async with httpx.AsyncClient() as client:
+        resp = await client.get("https://api.example.com/cache/refresh")
+        resp.raise_for_status()
+```
+
+Parameters: `tab` (crontab expression, required), `max_retries` (default 3),
+`backoff_base` (default 2.0), `backoff_max` (default 300.0), `timeout`,
+`on_failure` callback, plus extra `**cron_kwargs` forwarded to `worker.cron()`.
+
+Retry behavior, dead letter collection, and failure callbacks work identically
+to `@robust_task()`.
+
 #### Scheduled Tasks (Cron)
+
+For simple scheduled tasks without retries, use `@worker.cron()`:
 
 ```python
 @worker.cron("0 9 * * *")  # Every day at 9:00 AM UTC
@@ -1632,6 +1765,45 @@ Each field is registered under `"{category}.{field_name}"`.
 | `register_config_value()` | Imperative registration at module level |
 | `@config_value()` | Single standalone config values with defaults |
 | `ConfigGroup` | Groups of related settings (feature flags, limits) |
+
+#### `set_config()` Convenience Function
+
+Persist a config value, inferring metadata from the registry:
+
+```python
+from vibetuner.runtime_config import set_config
+
+await set_config("features.dark_mode", True)
+```
+
+The key must be registered. Raises `KeyError` if not. For unregistered keys,
+use `RuntimeConfig.set_value()` with explicit metadata.
+
+#### Registration via `VibetunerApp`
+
+Register config values declaratively in `tune.py`:
+
+```python
+app = VibetunerApp(
+    runtime_config={
+        "features.dark_mode": {
+            "default": False,
+            "value_type": "bool",
+            "description": "Enable dark mode",
+            "category": "features",
+        },
+    },
+)
+```
+
+#### CLI Management
+
+```bash
+vibetuner config list                              # View all values
+vibetuner config set features.dark_mode -v true    # Set a value
+vibetuner config set integrations.api_token        # Set secret (hidden prompt)
+vibetuner config delete features.dark_mode --yes   # Delete, revert to default
+```
 
 #### MongoDB Persistence and Caching
 
@@ -1858,6 +2030,86 @@ vibetuner doctor
 Validates project structure, configuration, service connectivity, models,
 templates, dependencies, and port availability. Exits with code 1 if errors
 are found.
+
+#### `vibetuner config`
+
+Manage runtime configuration values. Requires a project directory with MongoDB.
+
+**`list`**
+
+```bash
+vibetuner config list
+```
+
+Displays all registered config keys with values, types, sources, and categories.
+Secret values are masked.
+
+**`set`**
+
+```bash
+vibetuner config set KEY [--value VALUE]
+```
+
+Sets a config value and persists to MongoDB. When `--value` is omitted for
+secret keys, a hidden input prompt is used (avoids shell history exposure).
+When omitted for non-secret keys, a regular prompt is used.
+
+**`delete`**
+
+```bash
+vibetuner config delete KEY [--yes]
+```
+
+Deletes a config value from MongoDB, reverting to the registered default.
+`--yes` skips the confirmation prompt.
+
+#### `vibetuner debug`
+
+Access debug dashboards on deployed applications.
+
+**`open`**
+
+```bash
+vibetuner debug open URL [--secret SECRET]
+```
+
+Generates an HMAC-signed link (expires after 5 minutes) and opens it in the
+default browser. Grants an 8-hour debug session cookie on the server.
+
+- `URL` — Base URL of the deployed application (e.g., `https://myapp.com`)
+- `--secret`, `-s` — Signing secret. Must match the server's `SESSION_KEY`.
+  Reads from local `.env` when omitted.
+
+```bash
+# From a project directory
+vibetuner debug open https://myapp.com
+
+# From anywhere
+uvx vibetuner debug open https://myapp.com --secret mysecretkey
+```
+
+#### `vibetuner crypto`
+
+Manage encryption keys for fields encrypted with `EncryptedFieldsMixin`.
+
+**`set-key`**
+
+```bash
+vibetuner crypto set-key [--key PASSPHRASE] [--env-file PATH]
+```
+
+Sets the encryption key and encrypts all existing plaintext secrets.
+A secure random key is generated if `--key` is omitted. Errors if a key
+is already configured (use `rotate-key` instead).
+
+**`rotate-key`**
+
+```bash
+vibetuner crypto rotate-key [--new-key PASSPHRASE] [--env-file PATH]
+```
+
+Decrypts all secrets with the current key and re-encrypts with a new one.
+Errors if no current key is configured (use `set-key` first).
 
 #### `vibetuner version`
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -46,6 +46,12 @@ Important notes:
 - **Block Rendering**: `render_template_block(template, block_name, request, ctx)`
   renders a single `{% block %}` for HTMX partials. `render_template_blocks()` renders
   multiple blocks for OOB swaps. No extra dependencies. Import from `vibetuner`
+- **`@cache` Decorator**: `@cache(expire=60)` caches route responses in Redis.
+  Key derived from path + query params. Use `vary_on=lambda r: str(r.state.user.id)`
+  for request-dependent keys (per-user, per-tenant). Disabled in debug mode
+  (override with `force_caching=True`). No-op if Redis unavailable.
+  `invalidate(path)` and `invalidate_pattern(path)` for cache busting.
+  Import from `vibetuner.cache`
 - **`@cache_control` Decorator**: `@cache_control(max_age=300, public=True)` sets
   `Cache-Control` headers declaratively. Supports `public`, `private`, `no_cache`,
   `no_store`, `max_age`, `s_maxage`, `must_revalidate`, `stale_while_revalidate`,
@@ -54,6 +60,11 @@ Important notes:
   `hx_push_url()`, `hx_reswap()`, `hx_retarget()`, `hx_refresh()`,
   `hx_replace_url()`, `hx_trigger_after_settle()`, `hx_trigger_after_swap()`.
   Handles JSON serialization internally. Import from `vibetuner.htmx`
+- **Built-in Template Globals**: `now` (UTC datetime) and `today` (ISO date string)
+  are available in all templates automatically
+- **Encrypted Fields**: `EncryptedFieldsMixin` and `EncryptedStr` type for
+  transparent Fernet encrypt-on-save / decrypt-on-load on any Beanie model field.
+  Import from `vibetuner.models.mixins`. Requires `FIELD_ENCRYPTION_KEY` env var
 - **Template Context Providers**: `register_globals()` and `@register_context_provider`
   inject variables into every template render
 - **Service DI**: `get_email_service()`, `get_blob_service()`, `get_runtime_config()`
@@ -70,10 +81,16 @@ Important notes:
   with service connectivity checks
 - **Robust Tasks**: `@robust_task()` decorator with exponential backoff retries and
   MongoDB dead letter collection
+- **Robust Cron**: `@robust_cron("*/15 * * * *")` decorator combines scheduled
+  execution with the same retry/dead letter support as `@robust_task()`.
+  Import from `vibetuner.tasks.robust`
 - **Streaq UI**: Task queue monitoring dashboard at `/debug/tasks`
 - **Doctor CLI**: `vibetuner doctor` validates project setup, services, and config
 - **Config Decorators**: `@config_value()` and `ConfigGroup` for type-safe runtime
-  configuration
+  configuration. `set_config(key, value)` persists values programmatically.
+  `VibetunerApp(runtime_config={...})` for declarative registration in `tune.py`
+- **Config CLI**: `vibetuner config list|set|delete` manages runtime config
+  values from the command line. Secret values use hidden input prompts
 - **Testing Fixtures**: `vibetuner_client`, `mock_auth`, `mock_tasks`,
   `override_config`, `vibetuner_db` pytest fixtures
 - **Error Messages**: Actionable error messages with env var examples, Docker
@@ -82,7 +99,9 @@ Important notes:
 ## Reference
 
 - [CLI Reference](https://vibetuner.alltuner.com/cli-reference/):
-  Commands for `vibetuner scaffold`, `vibetuner run`, `vibetuner db`, and `vibetuner doctor`
+  Commands for `vibetuner scaffold`, `vibetuner run`, `vibetuner db`,
+  `vibetuner doctor`, `vibetuner config`, `vibetuner debug`, `vibetuner crypto`,
+  and `vibetuner version`
 - [Scaffolding Reference](https://vibetuner.alltuner.com/scaffolding/):
   Template prompts, post-generation tasks, and updating existing projects
 - [Deployment](https://vibetuner.alltuner.com/deployment/):

--- a/vibetuner-docs/docs/runtime-config.md
+++ b/vibetuner-docs/docs/runtime-config.md
@@ -162,6 +162,28 @@ await get_config(
 ) -> Any
 ```
 
+### `set_config`
+
+Persist a configuration value, inferring metadata from the registry:
+
+```python
+from vibetuner.runtime_config import set_config
+
+await set_config("features.dark_mode", True)
+```
+
+```python
+await set_config(
+    key: str,              # Must be a registered config key
+    value: Any,            # Value to persist to MongoDB
+) -> None
+```
+
+The key must have been registered (via `register_config_value()`,
+`@config_value()`, or `ConfigGroup`). Raises `KeyError` if the key is not
+registered. For unregistered keys or explicit metadata, use
+`RuntimeConfig.set_value()` instead.
+
 ### `RuntimeConfig` Class
 
 For advanced usage, access the `RuntimeConfig` class directly:
@@ -304,6 +326,48 @@ ConfigField(
 
 All three APIs share the same underlying `RuntimeConfig` resolution and
 appear together in the debug UI at `/debug/config`.
+
+### Registration via `VibetunerApp`
+
+You can also register config values declaratively in `tune.py`:
+
+```python
+from vibetuner import VibetunerApp
+
+app = VibetunerApp(
+    runtime_config={
+        "features.dark_mode": {
+            "default": False,
+            "value_type": "bool",
+            "description": "Enable dark mode by default",
+            "category": "features",
+        },
+        "integrations.api_token": {
+            "default": "",
+            "value_type": "str",
+            "is_secret": True,
+            "description": "External API token (encrypted at rest)",
+            "category": "integrations",
+        },
+    },
+)
+```
+
+Each entry accepts the same parameters as `register_config_value()`:
+`default`, `value_type`, `description`, `category`, and `is_secret`.
+
+## CLI Management
+
+Use `vibetuner config` to manage runtime config values from the command line:
+
+```bash
+vibetuner config list                              # View all config values
+vibetuner config set features.dark_mode -v true    # Set a value
+vibetuner config set integrations.api_token        # Set a secret (hidden prompt)
+vibetuner config delete features.dark_mode --yes   # Delete, revert to default
+```
+
+See the [CLI Reference](cli-reference.md#vibetuner-config) for details.
 
 ## Debug UI
 

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -62,7 +62,7 @@ app = VibetunerApp(
     routes=[app_router],          # frontend/HTMX (hidden from /docs)
     api_routes=[api_router],      # JSON API (visible in /docs)
     # Also supports: middleware, template_filters, frontend_lifespan,
-    # worker_lifespan, oauth_providers, tasks, cli
+    # worker_lifespan, oauth_providers, tasks, cli, runtime_config
 )
 ```
 
@@ -221,6 +221,15 @@ class Post(Document, TimeStampMixin):
 
 Export from `__init__.py`, list in `tune.py` `models=[]`.
 
+**Soft delete**: Use `DocumentWithSoftDelete` instead of `Document`.
+`delete()` sets `deleted_at`, queries auto-filter deleted docs.
+`hard_delete()` for permanent removal.
+
+**Encrypted fields**: `EncryptedFieldsMixin` + `EncryptedStr` type
+for transparent encrypt-on-save / decrypt-on-load. Requires
+`FIELD_ENCRYPTION_KEY` env var. `vibetuner crypto set-key` to
+configure, `vibetuner crypto rotate-key` to rotate.
+
 ### Services
 
 No registration needed — just import where used. Email via
@@ -268,6 +277,15 @@ async def send_digest_email(user_id: str): ...
 
 List in `tune.py` `tasks=[]`. Queue with
 `await send_digest_email.enqueue(user.id)`.
+
+**Robust tasks** (retries + dead letters):
+`from vibetuner.tasks.robust import robust_task, robust_cron`.
+`@robust_task(max_retries=3)` for enqueued tasks.
+`@robust_cron("*/15 * * * *", max_retries=3)` for scheduled tasks.
+Both support `backoff_base`, `backoff_max`, `timeout`, `on_failure`
+callback. Failed tasks stored in `dead_letters` MongoDB collection.
+
+**Cron** (no retries): `@worker.cron("0 9 * * *")`.
 
 ### CLI Commands
 
@@ -362,6 +380,7 @@ for full details.
 
 `from vibetuner.cache import cache, invalidate, invalidate_pattern`.
 `@cache(expire=60)` — Redis-backed, key from path+query params.
+`vary_on=lambda r: str(r.state.user.id)` for per-user/tenant keys.
 Disabled in debug mode (`force_caching=True` to override).
 No-op without Redis.
 
@@ -399,10 +418,15 @@ def dynamic_context() -> dict:
 
 ### Runtime Configuration
 
-`from vibetuner.runtime_config import register_config_value, get_config`.
+`from vibetuner.runtime_config import register_config_value, get_config, set_config`.
 Register with `register_config_value(key=, default=, value_type=,
-category=, description=)`. Read with `await get_config("key")`.
-Debug UI at `/debug/config`.
+category=, description=, is_secret=)`. Or declaratively in `tune.py`
+via `runtime_config={...}`. Read with `await get_config("key")`.
+Write with `await set_config("key", value)`.
+Debug UI at `/debug/config`. CLI: `vibetuner config list|set|delete`.
+
+**Built-in template globals**: `now` (UTC datetime), `today` (ISO
+date string) — available in all templates automatically.
 
 ### Template Override
 
@@ -413,6 +437,10 @@ defaults.
 
 `uv run vibetuner doctor` — validates project structure, config, env
 vars, services, models, templates, deps.
+
+`vibetuner debug open https://myapp.com` — generates HMAC-signed
+magic link for production debug access (8-hour session, 5-min link
+expiry). Uses `SESSION_KEY` from `.env`.
 
 ---
 
@@ -451,9 +479,10 @@ at `http://localhost:8000`.
 
 CSP with nonce-based scripts enabled by default. The CSP nonce is
 auto-injected into all `<script>` tags in HTML responses, so you
-don't need to add it manually. Debug mode = report-only. Configure
-via `CSP_*` env vars. Avoid inline event handlers (`onclick`
-etc.) — use HTMX attributes or `addEventListener`.
+don't need to add it manually. For `<style>` tags, use
+`{{ csp_nonce }}` template variable. Debug mode = report-only.
+Configure via `CSP_*` env vars. Avoid inline event handlers
+(`onclick` etc.) — use HTMX attributes or `addEventListener`.
 
 ### Request ID
 


### PR DESCRIPTION
## Summary

- Document features from the last 4 weeks that were missing from the docs site,
  `llms.txt`, `llms-full.txt`, and the template `AGENTS.md`
- Features covered: `@robust_cron`, `vibetuner config` CLI, `set_config()`,
  `VibetunerApp(runtime_config=...)`, `now`/`today` template globals,
  `EncryptedFieldsMixin`/`EncryptedStr`, CSP nonce, `@cache` `vary_on`,
  `vibetuner debug`/`crypto` CLI commands, response caching
- All changes are documentation-only across 7 files (630 lines added)

## Test plan

- [x] `just lint-md` passes (no issues in 42 files)
- [x] `just docs-build` succeeds
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)