### PR TITLE
fix: use PyPI package for lint-po instead of git+https

### DIFF
--- a/vibetuner-template/.justfiles/linting.justfile
+++ b/vibetuner-template/.justfiles/linting.justfile
@@ -26,7 +26,7 @@ lint-yaml:
 # Lint PO translation files with lint-po
 [group('Code quality: linting')]
 lint-po:
-    @bash -c 'shopt -s nullglob; files=(locales/*/LC_MESSAGES/*.po); if (( ${#files[@]} )); then uvx --from "git+https://github.com/himdel/lint-po" lint-po "${files[@]}"; else echo "No .po files to lint"; fi'
+    @bash -c 'shopt -s nullglob; files=(locales/*/LC_MESSAGES/*.po); if (( ${#files[@]} )); then uvx lint-po "${files[@]}"; else echo "No .po files to lint"; fi'
 
 # Type check Python files with ty
 [group('Code quality: linting')]

--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -58,6 +58,6 @@ repos:
     hooks:
       - id: lint-po
         name: lint-po
-        entry: uvx --from "git+https://github.com/himdel/lint-po" lint-po
+        entry: uvx lint-po
         language: system
         files: \.po$


### PR DESCRIPTION
## Summary
- Replace `git+https://github.com/himdel/lint-po` with `uvx lint-po` (PyPI) in both the
  pre-commit hook and the justfile lint task
- Eliminates transient git resolution failures when GitHub is slow

Closes #1608

🤖 Generated with [Claude Code](https://claude.com/claude-code)