### PR TITLE
fix: locale_selector reads stripped path, set-language ignores session

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -34,17 +34,8 @@ LANGUAGE_COOKIE_MAX_AGE = 365 * 24 * 60 * 60  # 31536000
 
 
 def locale_selector(conn: HTTPConnection) -> str | None:
-    """
-    Selects the locale based on the first part of the path if it matches a 2-letter language code.
-    """
-
-    parts = conn.scope.get("path", "").strip("/").split("/")
-
-    # Check if first part is a 2-letter lowercase language code
-    if parts and len(parts[0]) == 2 and parts[0].islower() and parts[0].isalpha():
-        return parts[0]
-
-    return None
+    """Selects the locale from the language prefix extracted by LangPrefixMiddleware."""
+    return conn.scope.get("state", {}).get("lang_prefix")
 
 
 def user_preference_selector(conn: HTTPConnection) -> str | None:

--- a/vibetuner-py/src/vibetuner/frontend/routes/language.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/language.py
@@ -32,6 +32,10 @@ async def set_language(request: Request, lang: str, current: str) -> RedirectRes
     else:
         new_url = request.url_for("homepage").path
 
+    # Update session language so user_preference_selector picks up the change
+    if "user" in request.session and "settings" in request.session["user"]:
+        request.session["user"]["settings"]["language"] = lang
+
     response = RedirectResponse(url=new_url)
     response.set_cookie(key="language", value=lang, max_age=LANGUAGE_COOKIE_MAX_AGE)
 

--- a/vibetuner-py/tests/unit/test_locale_selector_fn.py
+++ b/vibetuner-py/tests/unit/test_locale_selector_fn.py
@@ -1,0 +1,55 @@
+# ABOUTME: Tests that locale_selector reads lang_prefix from scope state
+# ABOUTME: Validates the fix for #1606 where LangPrefixMiddleware strips the path before locale detection
+# ruff: noqa: S101
+
+"""
+Tests for locale_selector function.
+
+Uses a local copy of locale_selector because importing vibetuner.frontend.middleware
+triggers vibetuner.frontend.__init__.py which mounts static file directories that
+don't exist in tests. This pattern matches test_locale_selectors.py.
+"""
+
+from starlette.requests import HTTPConnection
+
+
+def locale_selector(conn: HTTPConnection) -> str | None:
+    """Selects the locale from the language prefix extracted by LangPrefixMiddleware."""
+    return conn.scope.get("state", {}).get("lang_prefix")
+
+
+def _make_conn(path: str = "/", state: dict | None = None) -> HTTPConnection:
+    """Create a minimal HTTPConnection with the given scope."""
+    scope: dict = {"type": "http", "path": path}
+    if state is not None:
+        scope["state"] = state
+    return HTTPConnection(scope)
+
+
+class TestLocaleSelector:
+    def test_returns_lang_prefix_from_state(self):
+        """Should return the lang_prefix set by LangPrefixMiddleware."""
+        conn = _make_conn(path="/dashboard", state={"lang_prefix": "ca"})
+        assert locale_selector(conn) == "ca"
+
+    def test_returns_none_without_lang_prefix(self):
+        """Should return None when no lang prefix was detected."""
+        conn = _make_conn(path="/dashboard", state={})
+        assert locale_selector(conn) is None
+
+    def test_returns_none_without_state(self):
+        """Should return None when scope has no state dict."""
+        conn = _make_conn(path="/dashboard")
+        assert locale_selector(conn) is None
+
+    def test_does_not_parse_path(self):
+        """Should NOT detect language from the path itself (that's LangPrefixMiddleware's job)."""
+        conn = _make_conn(path="/ca/dashboard", state={})
+        assert locale_selector(conn) is None
+
+    def test_works_after_prefix_stripped(self):
+        """Simulates the real scenario: path is stripped but lang_prefix is in state."""
+        # LangPrefixMiddleware strips /ca/dashboard -> /dashboard
+        # and sets state["lang_prefix"] = "ca"
+        conn = _make_conn(path="/dashboard", state={"lang_prefix": "ca"})
+        assert locale_selector(conn) == "ca"

--- a/vibetuner-py/tests/unit/test_set_language_session.py
+++ b/vibetuner-py/tests/unit/test_set_language_session.py
@@ -1,0 +1,45 @@
+# ABOUTME: Tests that set_language endpoint updates session language preference
+# ABOUTME: Validates the fix for #1607 where authenticated users couldn't switch languages
+# ruff: noqa: S101
+
+"""
+Tests for set_language session update logic.
+
+Tests the session-update logic extracted from the endpoint handler. We can't
+easily mount the full route (it requires vibetuner.frontend) so we test the
+core behavior: that the session dict is mutated when user settings exist.
+"""
+
+
+def update_session_language(session: dict, lang: str) -> None:
+    """Mirrors the session update logic in set_language endpoint."""
+    if "user" in session and "settings" in session["user"]:
+        session["user"]["settings"]["language"] = lang
+
+
+class TestSetLanguageSession:
+    def test_updates_authenticated_user_session(self):
+        """Should update language in session for authenticated users."""
+        session = {"user": {"settings": {"language": "en"}}}
+        update_session_language(session, "ca")
+        assert session["user"]["settings"]["language"] == "ca"
+
+    def test_no_op_for_anonymous_user(self):
+        """Should not crash when no user in session."""
+        session = {}
+        update_session_language(session, "ca")
+        assert "user" not in session
+
+    def test_no_op_without_settings(self):
+        """Should not crash when user has no settings dict."""
+        session = {"user": {"name": "test"}}
+        update_session_language(session, "ca")
+        assert "settings" not in session["user"]
+
+    def test_overwrites_existing_preference(self):
+        """Should overwrite whatever language was stored."""
+        session = {"user": {"settings": {"language": "es", "theme": "dark"}}}
+        update_session_language(session, "ca")
+        assert session["user"]["settings"]["language"] == "ca"
+        # Other settings are preserved
+        assert session["user"]["settings"]["theme"] == "dark"


### PR DESCRIPTION
## Summary

- **#1606**: `locale_selector()` re-parsed `scope["path"]` which `LangPrefixMiddleware` had
  already stripped, so URL-prefix locale detection (`/ca/...`) never worked. Now reads from
  `scope["state"]["lang_prefix"]` instead.
- **#1607**: `/set-language/{lang}` only set the cookie but didn't update
  `session["user"]["settings"]["language"]`, so authenticated users couldn't switch language
  (session preference always won over cookie). Now updates both.

Fixes #1606
Fixes #1607

## Test plan

- [x] New unit tests for `locale_selector` (5 tests)
- [x] New unit tests for session update logic (4 tests)
- [x] All 691 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)