### PR TITLE
fix: checkout release tag before reading project config in docker workflow

### DIFF
--- a/vibetuner-template/.github/workflows/docker.yml
+++ b/vibetuner-template/.github/workflows/docker.yml
@@ -63,6 +63,12 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout release tag
+        if: steps.version.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+
       - name: Install uv
         if: steps.version.outputs.skip != 'true'
         uses: astral-sh/setup-uv@v7
@@ -74,12 +80,6 @@ jobs:
           echo "python_version=$(cat .python-version)" >> "$GITHUB_OUTPUT"
           registry=$(uv run --with pyyaml python -c "import yaml; print(yaml.safe_load(open('.copier-answers.yml')).get('docker_registry', 'localhost:5050'))")
           echo "docker_registry=$registry" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout release tag
-        if: steps.version.outputs.skip != 'true'
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ steps.version.outputs.tag }}
 
       - name: Set up QEMU
         if: steps.version.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

- Moves the "Checkout release tag" step before "Install uv" and "Read project config" in the scaffolded Docker workflow
- Without checkout, `.copier-answers.yml` and `.python-version` don't exist yet, causing incorrect config reads on self-hosted runners or outright failures on GitHub-hosted runners

Closes #1650

## Test plan

- [ ] Verify step order in the rendered workflow: checkout → uv → read config → QEMU → buildx → build
- [ ] Trigger a Docker build on a scaffolded project to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)