### PR TITLE
ci: skip claude-review for dependabot and renovate PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip automated dependency bots — they can't access the OAuth token secret,
+    # so the job fails with nothing actionable to review.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/vibetuner-template/.github/workflows/claude-code-review.yml
+++ b/vibetuner-template/.github/workflows/claude-code-review.yml
@@ -12,11 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip automated dependency bots — they can't access the OAuth token secret,
+    # so the job fails with nothing actionable to review.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Skip the `claude-review` job when the PR actor is `dependabot[bot]` or `renovate[bot]`. Bot-authored PRs can't access the `CLAUDE_CODE_OAUTH_TOKEN` secret, so the job always fails with nothing actionable.
- Apply the same guard to the scaffolded `vibetuner-template` workflow so new projects inherit the behavior.
- Removed the placeholder `Filter by PR author` comment in favor of the real `if:` expression.

## Test plan

- [ ] Next dependabot/renovate PR shows `claude-review` as skipped rather than failing
- [ ] A human-authored PR still runs `claude-review` as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)