### PR TITLE
chore: include commit authors in release-please changelog

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "simple",
+      "include-commit-authors": true,
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Summary
- Add `include-commit-authors: true` to `.release-please-config.json` so generated changelog entries credit PR authors (e.g. `(@username)`)

Closes #1661

## Test plan
- [ ] Verify Release Please PR after next merge includes `(@handle)` in changelog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)