### PR TITLE
feat(scaffolding): reorder deps-scaffolding-pr and add deps-scaffolding variant

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -115,7 +115,8 @@ just deploy-latest HOST      # Deploy to remote host
 
 ```bash
 just update-scaffolding      # Update project to latest vibetuner template
-just deps-scaffolding-pr     # Update deps + scaffolding and open a PR
+just deps-scaffolding        # Update deps + scaffolding on the current branch (no PR)
+just deps-scaffolding-pr     # Update deps + scaffolding in a worktree and open a PR
 ```
 
 ## Common Tasks

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -161,6 +161,8 @@ just deploy-latest HOST      # Deploy to remote host
 
 ```bash
 just update-scaffolding      # Update project to latest vibetuner template
+just deps-scaffolding        # Update deps + scaffolding on the current branch (no PR)
+just deps-scaffolding-pr     # Update deps + scaffolding in a worktree and open a PR
 ```
 
 ## Core Documentation

--- a/vibetuner-docs/docs/scaffolding.md
+++ b/vibetuner-docs/docs/scaffolding.md
@@ -131,8 +131,11 @@ just deps-scaffolding-pr
 This command:
 
 1. Creates an isolated git worktree so your working tree is untouched.
-2. Updates dependencies (`just update-and-commit-repo-deps`).
-3. Applies the latest scaffolding (`just update-scaffolding`).
+2. Applies the latest scaffolding (`just update-scaffolding`), so Copier's
+   manifest bumps (e.g. `package.json`, `pyproject.toml`) land first.
+3. Updates dependencies (`just update-and-commit-repo-deps`) so `bun update`
+   and `uv lock` resolve against the just-bumped manifests, keeping
+   lockfiles fully in sync.
 4. Detects merge conflicts and flags them if present.
 5. Creates a PR with a summary of changes.
 

--- a/vibetuner-docs/docs/scaffolding.md
+++ b/vibetuner-docs/docs/scaffolding.md
@@ -121,14 +121,17 @@ running them, review the results, and resolve any merge prompts Copier surfaces.
 
 ## Automated Update
 
-Scaffolded projects include a justfile command that updates dependencies
-and scaffolding in one step, creates a worktree, and opens a PR:
+Scaffolded projects ship two justfile commands that bundle the scaffolding
+update with the dependency bump. Pick the one that matches your workflow:
 
 ```bash
-just deps-scaffolding-pr
+just deps-scaffolding-pr   # Worktree + PR (full automation)
+just deps-scaffolding      # Current branch (no worktree, no PR)
 ```
 
-This command:
+### `deps-scaffolding-pr` (worktree + PR)
+
+Use this when you want a turnkey update PR off `main`.
 
 1. Creates an isolated git worktree so your working tree is untouched.
 2. Applies the latest scaffolding (`just update-scaffolding`), so Copier's
@@ -136,11 +139,30 @@ This command:
 3. Updates dependencies (`just update-and-commit-repo-deps`) so `bun update`
    and `uv lock` resolve against the just-bumped manifests, keeping
    lockfiles fully in sync.
-4. Detects merge conflicts and flags them if present.
-5. Creates a PR with a summary of changes.
+4. Detects merge conflicts and flags them if present (the worktree is left
+   in place for manual resolution; no half-baked PR is pushed).
+5. Pushes the branch and opens a PR with a summary of changes.
 
-If the scaffolding update produces conflicts, the command will print
-instructions for resolving them in the worktree before merging the PR.
+### `deps-scaffolding` (current branch, no PR)
+
+Use this when you want to drive the update yourself: you stay on a feature
+branch you already created and finish with the new commits ready to push.
+
+Pre-flight requirements:
+
+- The working tree must be clean (commit or stash first).
+- You must be on a non-default branch (the recipe refuses to run on
+  `main`).
+
+The command then runs the same two phases as the worktree variant:
+
+1. Applies the latest scaffolding and commits as `chore: update scaffolding`.
+2. Runs `just update-and-commit-repo-deps`, committing as
+   `chore: update dependencies` against the bumped manifests.
+
+If Copier produces conflict markers, the command bails (exit code `2`) and
+leaves the conflicted files in your working tree along with a manual
+resolution checklist.
 
 ## Recommended Workflow
 
@@ -151,12 +173,18 @@ instructions for resolving them in the worktree before merging the PR.
 3. Re-run tests (`just test-build-prod`, `just dev`) to confirm nothing broke.
 4. Commit the changes produced by the update.
 
-### One Command
+### One Command (PR)
 
 1. Run `just deps-scaffolding-pr`.
 2. Review the PR it creates.
 3. Resolve any flagged conflicts if needed.
 4. Merge the PR.
+
+### One Command (current branch)
+
+1. Check out a fresh feature branch with a clean working tree.
+2. Run `just deps-scaffolding`.
+3. Review the two new commits, then push and open a PR however you like.
 
 Refer back to this document whenever you need to adjust template answers,
 automate non-interactive scaffolding, or keep existing projects in sync with the

--- a/vibetuner-template/.justfiles/deps.justfile
+++ b/vibetuner-template/.justfiles/deps.justfile
@@ -14,7 +14,54 @@ update-and-commit-repo-deps: update-repo-deps
         pyproject.toml uv.lock bun.lock package.json .pre-commit-config.yaml \
         || echo "No changes to commit"
 
-# Create PR with updated dependencies and scaffolding
+# Update scaffolding and commit dependency bumps on the current branch (no PR).
+# Requires a clean working tree and refuses to run on the default branch.
+# Exits 2 (and leaves the conflicted worktree intact) if Copier produces conflict markers.
+[group('Dependencies')]
+deps-scaffolding:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+        | sed 's@^refs/remotes/origin/@@' || echo main)
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ]; then
+        echo "Refusing to run on '$DEFAULT_BRANCH'. Switch to a feature branch first."
+        exit 1
+    fi
+
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Working tree is not clean. Commit or stash changes first."
+        git status --short
+        exit 1
+    fi
+
+    # Phase 1: Update scaffolding (copier bumps manifests like package.json and pyproject.toml)
+    just update-scaffolding
+
+    # Check for conflict markers in any file (tracked or new)
+    # Pattern is split to avoid matching itself when scanning for unresolved conflicts
+    CONFLICT_MARKER="<""<""<""<""<""<""<"
+    if grep -rl "$CONFLICT_MARKER" --exclude-dir=.git . >/dev/null 2>&1; then
+        echo ""
+        echo "Scaffolding update produced conflicts. Resolve them, then run:"
+        echo "  git add -A && git commit -m 'chore: update scaffolding'"
+        echo "  just update-and-commit-repo-deps"
+        exit 2
+    fi
+
+    # Commit scaffolding changes
+    git add -A
+    git diff --cached --quiet || git commit -m "chore: update scaffolding"
+
+    # Phase 2: Update dependencies (runs bun update / uv lock against the bumped manifests,
+    # so bun.lock's workspaces mirror resyncs to the committed package.json)
+    just update-and-commit-repo-deps
+
+    echo ""
+    echo "Done. Review the new commits before pushing."
+
+# Create PR with updated dependencies and scaffolding (uses an isolated worktree).
 [group('Dependencies')]
 deps-scaffolding-pr:
     #!/usr/bin/env bash
@@ -51,38 +98,26 @@ deps-scaffolding-pr:
 
     cd "$WORKTREE_DIR"
 
-    # Phase 1: Update scaffolding (copier bumps manifests like package.json and pyproject.toml)
-    just update-scaffolding
+    # Apply scaffolding + deps update inside the worktree. Exit 2 means Copier conflicts;
+    # leave the worktree intact so the user can resolve and drive the rest manually.
+    set +e
+    just deps-scaffolding
+    RC=$?
+    set -e
 
-    # Check for conflict markers in any file (tracked or new)
-    # Pattern is split to avoid matching itself when scanning for unresolved conflicts
-    CONFLICT_MARKER="<""<""<""<""<""<""<"
-    if grep -rl "$CONFLICT_MARKER" --exclude-dir=.git . >/dev/null 2>&1; then
-        # Leave the worktree and branch in place so the user can resolve conflicts
-        # and drive the remaining steps manually. Running the dependency update now
-        # would fail against manifests containing conflict markers.
+    if [ "$RC" -eq 2 ]; then
         trap - ERR INT TERM
         echo ""
-        echo "Scaffolding update produced conflicts. Next steps:"
-        echo ""
-        echo "1. cd $WORKTREE_DIR"
-        echo "2. Resolve conflicts (look for $CONFLICT_MARKER markers)"
-        echo "3. git add -A && git commit -m 'chore: update scaffolding'"
-        echo "4. just update-and-commit-repo-deps"
-        echo "5. git push -u origin $BRANCH"
-        echo "6. gh pr create --base main --title 'chore: update dependencies and scaffolding'"
-        echo "7. Merge the PR, then clean up:"
-        echo "   cd - && git worktree remove $WORKTREE_DIR"
+        echo "(Worktree left at $WORKTREE_DIR for conflict resolution.)"
+        echo "After committing the resolved scaffolding and running the deps update, finish with:"
+        echo "  git push -u origin $BRANCH"
+        echo "  gh pr create --base main --title 'chore: update dependencies and scaffolding'"
+        echo "Then clean up:"
+        echo "  cd - && git worktree remove $WORKTREE_DIR"
         exit 0
+    elif [ "$RC" -ne 0 ]; then
+        exit "$RC"
     fi
-
-    # Commit scaffolding changes
-    git add -A
-    git diff --cached --quiet || git commit -m "chore: update scaffolding"
-
-    # Phase 2: Update dependencies (runs bun update / uv lock against the bumped manifests,
-    # so bun.lock's workspaces mirror resyncs to the committed package.json)
-    just update-and-commit-repo-deps
 
     # Bail if nothing changed at all
     if [ "$(git rev-list origin/main..HEAD --count)" -eq 0 ]; then

--- a/vibetuner-template/.justfiles/deps.justfile
+++ b/vibetuner-template/.justfiles/deps.justfile
@@ -51,25 +51,38 @@ deps-scaffolding-pr:
 
     cd "$WORKTREE_DIR"
 
-    # Phase 1: Update dependencies
-    just update-and-commit-repo-deps
-
-    # Phase 2: Update scaffolding
+    # Phase 1: Update scaffolding (copier bumps manifests like package.json and pyproject.toml)
     just update-scaffolding
 
     # Check for conflict markers in any file (tracked or new)
     # Pattern is split to avoid matching itself when scanning for unresolved conflicts
     CONFLICT_MARKER="<""<""<""<""<""<""<"
-    HAS_CONFLICTS=false
     if grep -rl "$CONFLICT_MARKER" --exclude-dir=.git . >/dev/null 2>&1; then
-        HAS_CONFLICTS=true
+        # Leave the worktree and branch in place so the user can resolve conflicts
+        # and drive the remaining steps manually. Running the dependency update now
+        # would fail against manifests containing conflict markers.
+        trap - ERR INT TERM
+        echo ""
+        echo "Scaffolding update produced conflicts. Next steps:"
+        echo ""
+        echo "1. cd $WORKTREE_DIR"
+        echo "2. Resolve conflicts (look for $CONFLICT_MARKER markers)"
+        echo "3. git add -A && git commit -m 'chore: update scaffolding'"
+        echo "4. just update-and-commit-repo-deps"
+        echo "5. git push -u origin $BRANCH"
+        echo "6. gh pr create --base main --title 'chore: update dependencies and scaffolding'"
+        echo "7. Merge the PR, then clean up:"
+        echo "   cd - && git worktree remove $WORKTREE_DIR"
+        exit 0
     fi
 
-    # Stage and commit scaffolding changes if clean
-    if [ "$HAS_CONFLICTS" = false ]; then
-        git add -A
-        git diff --cached --quiet || git commit -m "chore: update scaffolding"
-    fi
+    # Commit scaffolding changes
+    git add -A
+    git diff --cached --quiet || git commit -m "chore: update scaffolding"
+
+    # Phase 2: Update dependencies (runs bun update / uv lock against the bumped manifests,
+    # so bun.lock's workspaces mirror resyncs to the committed package.json)
+    just update-and-commit-repo-deps
 
     # Bail if nothing changed at all
     if [ "$(git rev-list origin/main..HEAD --count)" -eq 0 ]; then
@@ -85,22 +98,10 @@ deps-scaffolding-pr:
         --title "chore: update dependencies and scaffolding ($DATE)" \
         --body "Updates dependencies and scaffolding from upstream vibetuner template."
 
-    if [ "$HAS_CONFLICTS" = true ]; then
-        echo ""
-        echo "PR created, but scaffolding has conflicts. Next steps:"
-        echo ""
-        echo "1. cd $WORKTREE_DIR"
-        echo "2. Resolve conflicts (look for $CONFLICT_MARKER markers)"
-        echo "3. git add -A && git commit -m 'chore: resolve scaffolding conflicts'"
-        echo "4. git push"
-        echo "5. Merge the PR, then clean up:"
-        echo "   cd - && git worktree remove $WORKTREE_DIR"
-    else
-        echo ""
-        echo "PR created and ready for review."
-        # Clean up worktree since everything is pushed
-        cleanup
-    fi
+    echo ""
+    echo "PR created and ready for review."
+    # Clean up worktree since everything is pushed
+    cleanup
 
 # Install dependencies from lockfiles
 [group('Dependencies')]

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -123,8 +123,14 @@ via git tags + `uv-dynamic-versioning`.
 Update dependencies and scaffolding in one step:
 
 ```bash
-just deps-scaffolding-pr     # Update deps + scaffolding and open a PR
+just deps-scaffolding-pr     # In a fresh worktree, then open a PR
+just deps-scaffolding        # On the current feature branch, no PR
 ```
+
+Both apply the latest scaffolding first (so Copier bumps `package.json`
+/ `pyproject.toml`), then run `bun update` / `uv lock --upgrade` against
+the bumped manifests. `deps-scaffolding` requires a clean working tree
+and refuses to run on the default branch.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Fix #1683**: swap the two phases of `just deps-scaffolding-pr` so Copier bumps the manifests (`package.json`, `pyproject.toml`) **before** `bun update` / `uv lock --upgrade` run. This keeps `bun.lock`'s workspaces manifest mirror in sync with the just-bumped `package.json`, so Renovate's `lockFileMaintenance` no longer keeps reopening drift-only PRs.
- Tighten the conflict path: with no deps-update commit available to push anymore, an unresolved Copier conflict now bails locally and leaves the worktree intact with manual-resolution steps printed, instead of pushing a half-baked PR.
- Add `just deps-scaffolding`: the same scaffolding + deps update, but on the user's current feature branch with no worktree and no PR. Requires a clean working tree and refuses to run on the default branch; on Copier conflict it exits `2` and leaves the conflicted files in place with resolution steps.
- `deps-scaffolding-pr` now invokes `deps-scaffolding` inside the worktree, removing the duplicated scaffolding + conflict-detect + commit + deps-bump block.
- Docs updated in `scaffolding.md`, `development-guide.md`, `llms-full.txt`, and `AGENTS.md`.

Closes #1683

## Test plan

- [ ] In a freshly scaffolded project with stale lockfile drift, run `just deps-scaffolding-pr` and verify `bun.lock`'s workspaces mirror block matches `package.json` after the run.
- [ ] In a scaffolded project where Copier produces a conflict marker, run `just deps-scaffolding-pr` and verify it bails early, leaves `.tmp/deps-scaffolding/` intact, and prints the resolution checklist.
- [ ] On a clean feature branch in a scaffolded project, run `just deps-scaffolding` and verify two commits land (`chore: update scaffolding`, `chore: update dependencies`) with `bun.lock` fully in sync.
- [ ] Run `just deps-scaffolding` with a dirty tree and on `main`; verify each case bails with a clear message.
- [ ] `just lint-md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)