### PR TITLE
ci: simplify template release workflow and clean actionlint warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,8 +148,8 @@ jobs:
             echo "Using release-please version: $VERSION"
           fi
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_ENV"
 
           # Determine version type
           if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.0$ ]] && [[ "$VERSION" != ^1\.0\.0$ ]]; then
@@ -173,20 +173,22 @@ jobs:
             echo "🔍 Checking for meaningful changes in patch version..."
 
             # Check for changes in all packages (excluding version files)
-            PYTHON_CHANGED=$(git diff --name-only $PREV_TAG..HEAD | grep -E "^vibetuner-py/" | grep -v -E "pyproject\.toml" | wc -l)
-            JS_CHANGED=$(git diff --name-only $PREV_TAG..HEAD | grep -E "^vibetuner-js/" | grep -v -E "package\.json" | wc -l)
-            TEMPLATE_CHANGED=$(git diff --name-only $PREV_TAG..HEAD | grep -E "^vibetuner-template/" | grep -v -E "pyproject\.toml|package\.json" | wc -l)
-            DOCS_CHANGED=$(git diff --name-only $PREV_TAG..HEAD | grep -E "^vibetuner-docs/" | wc -l)
+            PYTHON_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -E "^vibetuner-py/" | grep -vcE "pyproject\.toml")
+            JS_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -E "^vibetuner-js/" | grep -vcE "package\.json")
+            TEMPLATE_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -E "^vibetuner-template/" | grep -vcE "pyproject\.toml|package\.json")
+            DOCS_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -cE "^vibetuner-docs/")
 
             TOTAL_CHANGED=$((PYTHON_CHANGED + JS_CHANGED + TEMPLATE_CHANGED + DOCS_CHANGED))
 
             if [ "$TOTAL_CHANGED" -eq 0 ]; then
               echo "❌ No meaningful changes found in patch version"
               echo "Only version file changes detected - skipping release"
-              echo "version=" >> $GITHUB_OUTPUT
-              echo "python-needed=false" >> $GITHUB_OUTPUT
-              echo "js-needed=false" >> $GITHUB_OUTPUT
-              echo "docs-needed=false" >> $GITHUB_OUTPUT
+              {
+                echo "version="
+                echo "python-needed=false"
+                echo "js-needed=false"
+                echo "docs-needed=false"
+              } >> "$GITHUB_OUTPUT"
               exit 0
             else
               echo "✅ Found meaningful changes in patch version"
@@ -230,7 +232,7 @@ jobs:
             PYTHON_NEEDED="true"
             echo "✅ Building Python (major/minor version)"
           elif [ -n "$PREV_TAG" ]; then
-            PYTHON_CHANGED=$(git diff --name-only $PREV_TAG..HEAD | grep -E "^vibetuner-py/" | grep -v -E "pyproject\.toml" | wc -l)
+            PYTHON_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -E "^vibetuner-py/" | grep -vcE "pyproject\.toml")
             if [ "$PYTHON_CHANGED" -gt 0 ]; then
               PYTHON_NEEDED="true"
               echo "✅ Python has changes"
@@ -250,7 +252,7 @@ jobs:
             JS_NEEDED="true"
             echo "✅ Building JavaScript (major/minor version)"
           elif [ -n "$PREV_TAG" ]; then
-            JS_CHANGED=$(git diff --name-only $PREV_TAG..HEAD | grep -E "^vibetuner-js/" | grep -v -E "package\.json" | wc -l)
+            JS_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -E "^vibetuner-js/" | grep -vcE "package\.json")
             if [ "$JS_CHANGED" -gt 0 ]; then
               JS_NEEDED="true"
               echo "✅ JavaScript has changes"
@@ -280,9 +282,11 @@ jobs:
             echo "❌ Not building documentation"
           fi
 
-          echo "python-needed=$PYTHON_NEEDED" >> $GITHUB_OUTPUT
-          echo "js-needed=$JS_NEEDED" >> $GITHUB_OUTPUT
-          echo "docs-needed=$DOCS_NEEDED" >> $GITHUB_OUTPUT
+          {
+            echo "python-needed=$PYTHON_NEEDED"
+            echo "js-needed=$JS_NEEDED"
+            echo "docs-needed=$DOCS_NEEDED"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/vibetuner-template/.github/workflows/release.yml
+++ b/vibetuner-template/.github/workflows/release.yml
@@ -30,21 +30,16 @@ jobs:
         if: steps.release.outputs.prs_created == 'true'
         uses: astral-sh/setup-uv@v8.1.0
 
-      - name: Install bun
-        if: steps.release.outputs.prs_created == 'true'
-        uses: oven-sh/setup-bun@v2
-
-      - name: Regenerate lockfiles on release PR
+      - name: Regenerate uv.lock on release PR
         if: steps.release.outputs.prs_created == 'true'
         run: |
           uv lock
-          bun install
-          if git diff --quiet uv.lock bun.lock; then
-            echo "Lock files already up to date"
+          if git diff --quiet uv.lock; then
+            echo "Lock file already up to date"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add uv.lock bun.lock
-          git commit -m "chore: regenerate lockfiles"
+          git add uv.lock
+          git commit -m "chore: regenerate uv.lock"
           git push


### PR DESCRIPTION
## Summary
- Drop `bun install` / `bun.lock` regeneration from `vibetuner-template/.github/workflows/release.yml`: the only reason it ever produced a diff was the `bun.lock` workspace-mirror drift fixed upstream in #1686, so keeping it just masks future regressions. `uv lock` stays — release-please bumps `version` in `pyproject.toml` every release and that string is embedded in `uv.lock`.
- Clean up pre-existing actionlint shellcheck warnings in `.github/workflows/release.yml` — quote `$GITHUB_OUTPUT` / `$GITHUB_ENV` / `$PREV_TAG` (SC2086), fold `grep ... | wc -l` into `grep -c` / `grep -vc` (SC2126), consolidate adjacent `>> $GITHUB_OUTPUT` writes into grouped redirects (SC2129). No behavior change.

## Test plan
- [x] `just lint-gh` passes clean (was failing with 19 shellcheck warnings before).
- [x] `just lint-yaml` passes.
- [ ] Verify next release-please PR on `main` still gets a `chore: regenerate uv.lock files` commit attached by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)