### PR TITLE
feat: enforce CSP in debug by default with opt-out flag

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -545,8 +545,11 @@ generates a Content Security Policy with a unique nonce per request.
 </style>
 ```
 
-In debug mode, CSP uses `Content-Security-Policy-Report-Only` (violations
-are reported but not enforced). In production, CSP is fully enforced.
+CSP is fully enforced in both production and debug mode by default, so
+violations break the page locally and are caught before they ship. To
+fall back to the legacy soft mode (where debug emits
+`Content-Security-Policy-Report-Only`), set
+`CSP_ENFORCE_CSP_IN_DEBUG=false`.
 
 Configure extra allowed sources via environment variables:
 
@@ -558,6 +561,7 @@ Configure extra allowed sources via environment variables:
 | `CSP_EXTRA_CONNECT_SRC` | Additional connect sources |
 | `CSP_EXTRA_FONT_SRC` | Additional font sources |
 | `CSP_EXTRA_MEDIA_SRC` | Additional media sources |
+| `CSP_ENFORCE_CSP_IN_DEBUG` | Enforce CSP in debug mode (default: `true`) |
 
 ## Working with HTMX
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1459,8 +1459,11 @@ Security Policy with a unique nonce per request.
 </style>
 ```
 
-In debug mode, CSP uses `Content-Security-Policy-Report-Only`. In production,
-CSP is fully enforced. Configure extra sources via `CSP_EXTRA_SCRIPT_SRC`,
+CSP is fully enforced in both production and debug mode by default, so
+"works locally, breaks in prod" violations are caught at write time rather
+than at deploy time. Set `CSP_ENFORCE_CSP_IN_DEBUG=false` to opt into the
+legacy soft mode where debug emits `Content-Security-Policy-Report-Only`
+instead. Configure extra sources via `CSP_EXTRA_SCRIPT_SRC`,
 `CSP_EXTRA_STYLE_SRC`, `CSP_EXTRA_IMG_SRC`, `CSP_EXTRA_CONNECT_SRC`,
 `CSP_EXTRA_FONT_SRC`, `CSP_EXTRA_MEDIA_SRC` environment variables.
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -74,9 +74,10 @@ Important notes:
   manually add `nonce=` attributes to `<script>` tags in templates, the middleware handles
   this automatically. For `<style>` tags or other elements that need the nonce, use the
   `{{ csp_nonce }}` template variable (available in all templates via context provider).
-  In debug mode, CSP uses `Content-Security-Policy-Report-Only` (violations reported but
-  not enforced); in production, CSP is fully enforced. Configure extra sources via
-  `CSP_*` environment variables (e.g., `CSP_EXTRA_SCRIPT_SRC`)
+  CSP is enforced in both production and debug mode by default so violations break the
+  page locally; set `CSP_ENFORCE_CSP_IN_DEBUG=false` to fall back to
+  `Content-Security-Policy-Report-Only` in debug. Configure extra sources via `CSP_*`
+  environment variables (e.g., `CSP_EXTRA_SCRIPT_SRC`)
 - **Health Checks**: `/health`, `/health/ping`, `/health/ready`, `/health/id` endpoints
   with service connectivity checks
 - **Robust Tasks**: `@robust_task()` decorator with exponential backoff retries and

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -83,6 +83,7 @@ class SecurityHeadersSettings(BaseSettings):
     extra_img_src: str = ""
     extra_media_src: str = ""
     frame_ancestors: str = "'self'"
+    enforce_csp_in_debug: bool = True
 
     model_config = SettingsConfigDict(
         case_sensitive=False,

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -150,9 +150,10 @@ class SecurityHeadersMiddleware:
             directives.append(f"connect-src 'self' {config.extra_connect_src}")
 
         csp_value = "; ".join(directives)
+        report_only = settings.debug and not config.enforce_csp_in_debug
         csp_header = (
             "Content-Security-Policy-Report-Only"
-            if settings.debug
+            if report_only
             else "Content-Security-Policy"
         )
         headers[csp_header] = csp_value

--- a/vibetuner-py/tests/unit/test_security_headers_middleware.py
+++ b/vibetuner-py/tests/unit/test_security_headers_middleware.py
@@ -22,6 +22,7 @@ class _SecurityHeadersConfig:
     extra_img_src: str = ""
     extra_media_src: str = ""
     frame_ancestors: str = "'self'"
+    enforce_csp_in_debug: bool = True
 
 
 @dataclass
@@ -85,9 +86,10 @@ class SecurityHeadersMiddleware:
             directives.append(f"connect-src 'self' {config.extra_connect_src}")
 
         csp_value = "; ".join(directives)
+        report_only = self._settings.debug and not config.enforce_csp_in_debug
         csp_header = (
             "Content-Security-Policy-Report-Only"
-            if self._settings.debug
+            if report_only
             else "Content-Security-Policy"
         )
         headers[csp_header] = csp_value
@@ -220,9 +222,18 @@ class TestSecurityHeadersMiddleware:
         csp = resp.headers.get("Content-Security-Policy", "")
         assert f"'nonce-{nonce}'" in csp
 
-    def test_report_only_header_in_debug_mode(self):
-        """Debug mode uses Content-Security-Policy-Report-Only."""
+    def test_enforced_header_in_debug_mode_by_default(self):
+        """Debug mode enforces CSP by default so violations break the page locally."""
         app = _make_app(settings=_Settings(debug=True))
+        client = TestClient(app)
+        resp = client.get("/")
+        assert "Content-Security-Policy" in resp.headers
+        assert "Content-Security-Policy-Report-Only" not in resp.headers
+
+    def test_report_only_header_when_debug_opts_out(self):
+        """Debug mode falls back to report-only when enforce_csp_in_debug is False."""
+        config = _SecurityHeadersConfig(enforce_csp_in_debug=False)
+        app = _make_app(settings=_Settings(debug=True, security_headers=config))
         client = TestClient(app)
         resp = client.get("/")
         assert "Content-Security-Policy-Report-Only" in resp.headers
@@ -233,6 +244,15 @@ class TestSecurityHeadersMiddleware:
     def test_enforced_header_in_production(self):
         """Production mode uses enforced Content-Security-Policy."""
         app = _make_app(settings=_Settings(debug=False))
+        client = TestClient(app)
+        resp = client.get("/")
+        assert "Content-Security-Policy" in resp.headers
+        assert "Content-Security-Policy-Report-Only" not in resp.headers
+
+    def test_production_ignores_enforce_csp_in_debug_flag(self):
+        """The flag has no effect outside debug mode — CSP is always enforced."""
+        config = _SecurityHeadersConfig(enforce_csp_in_debug=False)
+        app = _make_app(settings=_Settings(debug=False, security_headers=config))
         client = TestClient(app)
         resp = client.get("/")
         assert "Content-Security-Policy" in resp.headers
@@ -339,10 +359,7 @@ class TestCspNonceAutoInjection:
         """All script tags without nonces get the nonce injected."""
         app = _make_app(
             html_body=(
-                "<html>"
-                '<script src="a.js"></script>'
-                '<script src="b.js"></script>'
-                "</html>"
+                '<html><script src="a.js"></script><script src="b.js"></script></html>'
             )
         )
         client = TestClient(app)
@@ -375,19 +392,15 @@ class TestCspNonceAutoInjection:
 
     def test_handles_inline_script_tags(self):
         """Inline script tags (no src) also get nonce injected."""
-        app = _make_app(
-            html_body="<html><script>alert('hi')</script></html>"
-        )
+        app = _make_app(html_body="<html><script>alert('hi')</script></html>")
         client = TestClient(app)
         resp = client.get("/")
         nonce = app._captured_nonces[0]
-        assert f'<script nonce="{nonce}">alert(\'hi\')</script>' in resp.text
+        assert f"<script nonce=\"{nonce}\">alert('hi')</script>" in resp.text
 
     def test_case_insensitive_script_tag(self):
         """Script tags with mixed case are handled."""
-        app = _make_app(
-            html_body='<html><Script src="app.js"></Script></html>'
-        )
+        app = _make_app(html_body='<html><Script src="app.js"></Script></html>')
         client = TestClient(app)
         resp = client.get("/")
         nonce = app._captured_nonces[0]

--- a/vibetuner-template/.claude/rules/configuration.md
+++ b/vibetuner-template/.claude/rules/configuration.md
@@ -23,9 +23,11 @@ description: Environment variables, settings, security headers, and request ID
 CSP with nonce-based scripts enabled by default. The CSP nonce is
 auto-injected into all `<script>` tags in HTML responses, so you
 don't need to add it manually. For `<style>` tags, use
-`{{ csp_nonce }}` template variable. Debug mode = report-only.
-Configure via `CSP_*` env vars. Avoid inline event handlers
-(`onclick` etc.) — use HTMX attributes or `addEventListener`.
+`{{ csp_nonce }}` template variable. CSP is enforced in both debug
+and production by default; set `CSP_ENFORCE_CSP_IN_DEBUG=false` to
+revert debug to report-only. Configure via `CSP_*` env vars. Avoid
+inline event handlers (`onclick` etc.) — use HTMX attributes or
+`addEventListener`.
 
 ## Request ID
 


### PR DESCRIPTION
## Summary

- Adds `enforce_csp_in_debug: bool = True` to `SecurityHeadersSettings` (env: `CSP_ENFORCE_CSP_IN_DEBUG`).
- `SecurityHeadersMiddleware` now emits `Content-Security-Policy-Report-Only` only when `settings.debug` is true **and** the new flag is false. Default flips so CSP violations break the page locally.
- Updates docs (`development-guide.md`, `llms.txt`, `llms-full.txt`) and the scaffolded-project rule (`vibetuner-template/.claude/rules/configuration.md`).

Closes #1701

## Test plan

- [x] `uv run python -m pytest tests/unit/test_security_headers_middleware.py` — 25/25 pass, including new `test_enforced_header_in_debug_mode_by_default`, `test_report_only_header_when_debug_opts_out`, and `test_production_ignores_enforce_csp_in_debug_flag`.
- [x] Full unit suite (`uv run python -m pytest tests/`) — 695 pass.
- [x] `uv run ruff check` and `ruff format --check` clean on touched files.
- [x] `just lint-md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)