### PR TITLE
feat: per-tenant theming via runtime CSS-variable injection

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1231,6 +1231,105 @@ def analytics_context() -> dict:
 Values from providers and globals are merged into every `render_template()` call.
 User-provided context in the render call takes precedence.
 
+### Per-Tenant Theming
+
+Multi-tenant apps can swap DaisyUI role colors per tenant without rebuilding
+`bundle.css`. The bundle stays tenant-agnostic and cached; theming happens
+at request time via a small `<style>:root { ... }</style>` block injected
+after the stylesheet link.
+
+**1. Embed `TenantTheme` on your tenant document:**
+
+```python
+from beanie import Document
+from pydantic import Field
+from vibetuner.models import TenantTheme
+from vibetuner.models.mixins import TimeStampMixin
+
+
+class TenantModel(Document, TimeStampMixin):
+    name: str
+    slug: str
+    theme: TenantTheme = Field(default_factory=TenantTheme)
+```
+
+`TenantTheme` exposes eight optional `#rrggbb` fields — `primary`,
+`secondary`, `accent`, `neutral`, and their `*_content` foreground variants —
+mapping to `--color-primary`, `--color-secondary`, etc. The validator
+rejects anything that isn't a 7-character `#rrggbb` string.
+
+Existing tenant documents without the field are unaffected: MongoDB is
+schema-on-read, the default-constructed `TenantTheme` has all `None` fields,
+and `keep_nulls=False` keeps it out of the database until a value is set.
+
+**2. Register the opt-in provider:**
+
+```python
+from starlette.requests import Request
+from vibetuner import register_tenant_theme_provider
+
+
+def _tenant_from_request(request: Request):
+    # Tenant should already be on request.state by upstream middleware/dep.
+    return getattr(request.state, "tenant", None)
+
+
+register_tenant_theme_provider(_tenant_from_request)
+```
+
+The getter must be synchronous and cheap — it runs on every render. Do DB
+work in middleware. Pass `attribute="branding"` if your tenant uses a
+different attribute name.
+
+The provider is fail-soft: a getter exception, missing attribute, or a
+non-`TenantTheme` value is logged and the request renders with no overrides
+rather than 500ing.
+
+**3. Template partial.** Vibetuner's `base/skeleton.html.jinja` already
+includes `base/theme.html.jinja` between the bundled stylesheet link and
+`{% block head %}`. The partial emits:
+
+```html
+<style nonce="{{ csp_nonce }}">:root {
+    --color-primary: #009ddc;
+    --color-accent: #ff8800;
+}</style>
+```
+
+only when `theme_overrides` is non-empty. Apps that haven't registered the
+provider see no extra markup.
+
+If you've replaced the skeleton wholesale in your project, mirror the
+include order:
+
+```jinja
+<link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
+{% include "base/theme.html.jinja" %}
+{% block head %}{% endblock head %}
+```
+
+DaisyUI scopes its theme via `:where(:root)` (zero specificity), so a plain
+`:root { ... }` block always wins the cascade.
+
+**Footguns:**
+
+- **Build-time literals in custom tokens.** A `--shadow-glow-primary: 0 0
+  80px rgba(0, 157, 220, 0.2)` won't follow the theme. Use
+  `color-mix(in oklab, var(--color-primary) 20%, transparent)` so the
+  derived token tracks the role color.
+- **Hardcoded scale shades mixed into role-driven utilities.** `from-accent/70
+  to-tiger-flame-700` only themes one half of the gradient. Either keep it
+  role-only (`from-accent/70 to-accent/30`) or accept the scale shade as a
+  brand constant.
+- **Inline `<style>` without a CSP nonce.** The shipped partial sets it for
+  you; if you write a custom override template, do the same with
+  `{{ csp_nonce }}`.
+
+**Out of scope:** per-tenant fonts. Font swapping requires `@font-face`
+rules to load the binary before any `--font-display` variable can switch to
+it, which is a different mechanism. Tracked in
+[vibetuner#1705](https://github.com/alltuner/vibetuner/issues/1705).
+
 ### Service Dependency Injection
 
 Vibetuner provides FastAPI `Depends()` wrappers for built-in services:

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -26,6 +26,7 @@ Important notes:
 - [Background Tasks](https://vibetuner.alltuner.com/background-tasks/): Background task system powered by Streaq and Redis with retries, cron scheduling, and SSE integration
 - [Runtime Configuration](https://vibetuner.alltuner.com/runtime-config/): Layered configuration system with MongoDB persistence, debug UI, and feature flags
 - [HTMX v2 to v4 Migration](https://vibetuner.alltuner.com/htmx-migration/): Breaking changes and migration guide for upgrading from HTMX v2 to v4
+- [Per-Tenant Theming](https://vibetuner.alltuner.com/theming/): Embedded `TenantTheme` model + opt-in `register_tenant_theme_provider()` helper + shipped `base/theme.html.jinja` partial that injects DaisyUI role-color overrides at request time
 
 ## Features
 
@@ -67,6 +68,13 @@ Important notes:
   Import from `vibetuner.models.mixins`. Requires `FIELD_ENCRYPTION_KEY` env var
 - **Template Context Providers**: `register_globals()` and `@register_context_provider`
   inject variables into every template render
+- **Per-Tenant Theming**: `TenantTheme` embedded model (`vibetuner.models.TenantTheme`)
+  with eight optional `#rrggbb` fields for DaisyUI role / role-content colors plus
+  `.overrides()` for the `{css_var: hex}` map. Wire it up with
+  `register_tenant_theme_provider(getter)` from `vibetuner` — opt-in, runs on every
+  render, fail-soft. Vibetuner's `base/skeleton.html.jinja` already includes
+  `base/theme.html.jinja`, which emits a CSP-noncified `<style>:root { ... }</style>`
+  block after `bundle.css`. `bundle.css` stays tenant-agnostic and cached
 - **Service DI**: `get_email_service()`, `get_blob_service()`, `get_runtime_config()`
   FastAPI dependency wrappers
 - **CSP Nonce Auto-Injection**: `SecurityHeadersMiddleware` generates a unique CSP nonce

--- a/vibetuner-docs/docs/theming.md
+++ b/vibetuner-docs/docs/theming.md
@@ -1,0 +1,145 @@
+# Per-Tenant Theming
+
+Multi-tenant Vibetuner apps often need per-tenant visual identity — at minimum
+the four DaisyUI role colors and their content variants. Vibetuner ships a
+small primitive for this: an embedded `TenantTheme` model, an opt-in context
+provider, and a Jinja partial that injects the overrides at request time.
+
+The model is simple: `bundle.css` stays tenant-agnostic and cached, and
+theming is per-request HTML — no per-tenant CSS rebuilds.
+
+## How it composes
+
+1. **Bundled CSS defines the role variables.** Tailwind 4 + DaisyUI emit
+   `--color-primary`, `--color-secondary`, `--color-accent`, `--color-neutral`
+   (and their `*-content` foreground variants) into `bundle.css`.
+2. **Each request renders a tiny `<style>:root { ... }</style>` block** after
+   the `<link rel="stylesheet" href="bundle.css">`, overriding *only* the
+   variables the tenant has set.
+3. **Cascade does the rest.** DaisyUI scopes its own theme via
+   `:where(:root)` (zero specificity), so a plain `:root { ... }` block always
+   wins.
+
+## Add a TenantTheme to your tenant model
+
+```python
+from beanie import Document
+from pydantic import Field
+from vibetuner.models import TenantTheme
+from vibetuner.models.mixins import TimeStampMixin
+
+
+class TenantModel(Document, TimeStampMixin):
+    name: str
+    slug: str
+    theme: TenantTheme = Field(default_factory=TenantTheme)
+```
+
+`TenantTheme` exposes eight optional `#rrggbb` fields:
+
+| Field | CSS variable |
+| --- | --- |
+| `primary` | `--color-primary` |
+| `secondary` | `--color-secondary` |
+| `accent` | `--color-accent` |
+| `neutral` | `--color-neutral` |
+| `primary_content` | `--color-primary-content` |
+| `secondary_content` | `--color-secondary-content` |
+| `accent_content` | `--color-accent-content` |
+| `neutral_content` | `--color-neutral-content` |
+
+Hex strings are validated to match `^#[0-9a-fA-F]{6}$` — any other format
+raises a Pydantic `ValidationError` at the model layer.
+
+### Backwards compatibility
+
+Adding `theme: TenantTheme = Field(default_factory=TenantTheme)` to an existing
+tenant document is a no-op for already-persisted records. MongoDB is
+schema-on-read, so old documents load with a default-constructed `TenantTheme`
+(all `None`s) and `keep_nulls=False` keeps the field out of the database
+until a value is set.
+
+## Wire up the context provider
+
+The provider is **opt-in** — Vibetuner does not auto-register one, so apps
+that don't multi-tenant pay nothing. Register it once at startup, with a
+synchronous tenant getter that already has the tenant in hand:
+
+```python
+from starlette.requests import Request
+from vibetuner import register_tenant_theme_provider
+
+
+def _tenant_from_request(request: Request):
+    # Whatever upstream middleware / dependency attached.
+    return getattr(request.state, "tenant", None)
+
+
+register_tenant_theme_provider(_tenant_from_request)
+```
+
+The getter must be synchronous and cheap — it runs on every render. Do any
+DB lookups in middleware (or a dependency) that fires before the route
+executes, and stash the resulting object on `request.state`.
+
+If your tenant model uses a different attribute name (e.g. `branding`
+instead of `theme`), pass `attribute="branding"` to
+`register_tenant_theme_provider`.
+
+The provider is fail-soft: a getter exception, missing attribute, or wrong
+type is logged and the request renders with no overrides rather than 500ing.
+
+## Template integration
+
+Vibetuner's `base/skeleton.html.jinja` already includes
+`base/theme.html.jinja` between the bundled stylesheet link and
+`{% block head %}`. The partial emits a CSP-noncified
+`<style>:root { ... }</style>` only when `theme_overrides` is non-empty, so
+apps that haven't registered the provider see no extra markup.
+
+If you've replaced the skeleton wholesale in your project, mirror the same
+include order:
+
+```jinja
+<link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
+{% include "base/theme.html.jinja" %}
+{% block head %}{% endblock head %}
+```
+
+## Footguns
+
+**1. Build-time literals in custom tokens.** A custom `--shadow-glow-primary`
+that bakes an rgba literal will never follow theming, because the rgba is a
+constant — not a `var(...)` reference:
+
+```css
+/* Won't follow the theme */
+--shadow-glow-primary: 0 0 80px rgba(0, 157, 220, 0.2);
+
+/* Follows the theme */
+--shadow-glow-primary: 0 0 80px color-mix(
+  in oklab, var(--color-primary) 20%, transparent
+);
+```
+
+When you derive a custom token from a role color, always express it in terms
+of the role variable.
+
+**2. Hardcoded scale colors mixed into role-driven utilities.** A class like
+`bg-linear-to-br from-accent/70 to-tiger-flame-700` mixes one role color with
+a fixed-palette shade — only half of it follows the theme. Either keep the
+gradient role-only (`from-accent/70 to-accent/30`) or accept that the scale
+shade is a brand constant.
+
+**3. Inline `<style>` without a CSP nonce.** The shipped partial sets
+`nonce="{{ csp_nonce }}"` automatically; if you write a custom override
+template, do the same.
+
+## What this primitive does *not* cover
+
+- **Fonts.** Per-tenant font swapping is genuinely different from color
+  injection — `@font-face` rules have to load the binary first, before any
+  `--font-display` variable can switch to it. That's tracked separately in
+  [vibetuner#1705](https://github.com/alltuner/vibetuner/issues/1705).
+- **Logos / favicons / assets.** These are app-specific and don't belong in a
+  cross-cutting framework primitive. Wire them through your existing context.

--- a/vibetuner-docs/mkdocs.yml
+++ b/vibetuner-docs/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Runtime Configuration: runtime-config.md
       - Deployment: deployment.md
       - URL Routing: url-routing.md
+      - Per-Tenant Theming: theming.md
       - HTMX v2 → v4 Migration: htmx-migration.md
   - Contributing:
       - Development Workflow: development.md

--- a/vibetuner-py/src/vibetuner/__init__.py
+++ b/vibetuner-py/src/vibetuner/__init__.py
@@ -13,6 +13,7 @@ from vibetuner.rendering import (
     render_template_stream,
     render_template_string,
 )
+from vibetuner.theming import register_tenant_theme_provider
 
 
 __version__ = version("vibetuner")
@@ -32,6 +33,7 @@ __all__ = [
     "VibetunerApp",
     "register_context_provider",
     "register_globals",
+    "register_tenant_theme_provider",
     "render",
     "render_template",
     "render_template_block",

--- a/vibetuner-py/src/vibetuner/models/__init__.py
+++ b/vibetuner-py/src/vibetuner/models/__init__.py
@@ -7,9 +7,14 @@ from .config_entry import ConfigEntryModel
 from .email_verification import EmailVerificationTokenModel
 from .oauth import OAuthAccountModel
 from .oauth_app import OAuthProviderAppModel
+from .tenant_theme import TenantTheme as TenantTheme
 from .user import UserModel
 
 
+# NOTE: ``__all__`` is consumed at runtime by ``vibetuner.mongo.get_all_models``
+# as the registry of Beanie Documents/Views to initialise. Keep it limited to
+# Document/View subclasses; embedded models (TenantTheme) are exported via the
+# normal module-level import above.
 __all__: list[type[Document] | type[View]] = [
     DocumentWithSoftDelete,
     BlobModel,

--- a/vibetuner-py/src/vibetuner/models/tenant_theme.py
+++ b/vibetuner-py/src/vibetuner/models/tenant_theme.py
@@ -1,0 +1,128 @@
+# ABOUTME: TenantTheme embedded model for per-tenant runtime CSS-variable theming.
+# ABOUTME: Apps embed it on their tenant document and call .overrides() to get the {css_var: hex} map.
+"""Tenant-scoped color theme overrides for DaisyUI role colors.
+
+Apps that need per-tenant visual identity embed :class:`TenantTheme` on their
+tenant document::
+
+    from vibetuner.models import TenantTheme
+
+    class TenantModel(Document, TimeStampMixin):
+        name: str
+        theme: TenantTheme = Field(default_factory=TenantTheme)
+
+The model holds the eight DaisyUI role / role-content colors as optional
+``#rrggbb`` strings. :meth:`TenantTheme.overrides` returns a mapping suitable
+for runtime ``:root { ... }`` injection by the shipped ``base/theme.html.jinja``
+partial. ``bundle.css`` stays tenant-agnostic and cached; theming happens at
+request time in HTML, not via per-tenant CSS rebuilds.
+"""
+
+import re
+from typing import ClassVar
+
+from pydantic import BaseModel, Field, field_validator
+
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+class TenantTheme(BaseModel):
+    """Per-tenant overrides for DaisyUI role colors.
+
+    All fields are optional. Unset fields are omitted from
+    :meth:`overrides`, so the shipped CSS values from ``bundle.css`` continue
+    to apply.
+
+    Field-to-CSS-variable mapping:
+
+    ============== =========================
+    Field          CSS variable
+    ============== =========================
+    primary        ``--color-primary``
+    secondary      ``--color-secondary``
+    accent         ``--color-accent``
+    neutral        ``--color-neutral``
+    primary_content   ``--color-primary-content``
+    secondary_content ``--color-secondary-content``
+    accent_content    ``--color-accent-content``
+    neutral_content   ``--color-neutral-content``
+    ============== =========================
+    """
+
+    primary: str | None = Field(
+        default=None,
+        description="DaisyUI primary role color (#rrggbb).",
+    )
+    secondary: str | None = Field(
+        default=None,
+        description="DaisyUI secondary role color (#rrggbb).",
+    )
+    accent: str | None = Field(
+        default=None,
+        description="DaisyUI accent role color (#rrggbb).",
+    )
+    neutral: str | None = Field(
+        default=None,
+        description="DaisyUI neutral role color (#rrggbb).",
+    )
+    primary_content: str | None = Field(
+        default=None,
+        description="Foreground color used on top of `primary` (#rrggbb).",
+    )
+    secondary_content: str | None = Field(
+        default=None,
+        description="Foreground color used on top of `secondary` (#rrggbb).",
+    )
+    accent_content: str | None = Field(
+        default=None,
+        description="Foreground color used on top of `accent` (#rrggbb).",
+    )
+    neutral_content: str | None = Field(
+        default=None,
+        description="Foreground color used on top of `neutral` (#rrggbb).",
+    )
+
+    _CSS_VAR_BY_FIELD: ClassVar[dict[str, str]] = {
+        "primary": "--color-primary",
+        "secondary": "--color-secondary",
+        "accent": "--color-accent",
+        "neutral": "--color-neutral",
+        "primary_content": "--color-primary-content",
+        "secondary_content": "--color-secondary-content",
+        "accent_content": "--color-accent-content",
+        "neutral_content": "--color-neutral-content",
+    }
+
+    @field_validator(
+        "primary",
+        "secondary",
+        "accent",
+        "neutral",
+        "primary_content",
+        "secondary_content",
+        "accent_content",
+        "neutral_content",
+        mode="before",
+    )
+    @classmethod
+    def _validate_hex(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not _HEX_COLOR_RE.match(value):
+            raise ValueError(
+                f"Theme color must be a 7-character #rrggbb hex string, got {value!r}"
+            )
+        return value.lower()
+
+    def overrides(self) -> dict[str, str]:
+        """Return the ``{css_var: hex}`` map for set fields.
+
+        Unset fields are omitted, so callers can render an empty ``:root { }``
+        block (or skip rendering entirely) when no overrides are configured.
+        """
+        return {
+            self._CSS_VAR_BY_FIELD[field]: value
+            for field, value in self.model_dump(exclude_none=True).items()
+            if field in self._CSS_VAR_BY_FIELD and value
+        }

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -11,6 +11,8 @@
             {% endblock title %}
         </title>
         <link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
+        {% include "base/theme.html.jinja" %}
+
         {% block scripts %}
             <script src="{{ url_for('js', path='bundle.js').path }}"></script>
         {% endblock scripts %}

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/theme.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/theme.html.jinja
@@ -1,0 +1,20 @@
+{# Per-tenant theme override partial.
+   Emits a CSP-noncified <style>:root { ... }</style> block when
+   `theme_overrides` is a non-empty mapping of {css_var: hex_value}.
+
+   Render order matters: include this *after* the bundle.css <link> in
+   skeleton.html.jinja so the :root rule wins the cascade. DaisyUI scopes
+   its theme variables under :where(:root), which has zero specificity, so
+   a plain :root { ... } block always overrides them.
+
+   Hex values are validated by vibetuner.models.TenantTheme to match
+   #rrggbb. We escape them again here defensively in case a caller
+   bypasses the helper. -#}
+{% if theme_overrides %}
+    <style nonce="{{ csp_nonce }}">:root {
+        {%- for css_var, hex_value in theme_overrides.items() %}
+            {{- css_var | e }}: {{ hex_value | e }};
+        {%- endfor %}
+        }
+    </style>
+{% endif %}

--- a/vibetuner-py/src/vibetuner/theming.py
+++ b/vibetuner-py/src/vibetuner/theming.py
@@ -1,0 +1,104 @@
+# ABOUTME: Opt-in helper that wires a tenant getter into the template context
+# ABOUTME: as ``theme_overrides`` for the shipped base/theme.html.jinja partial.
+"""Per-tenant theming via runtime CSS-variable injection.
+
+This module ships the opt-in glue that connects an app's tenant lookup to the
+:class:`vibetuner.models.TenantTheme` model and the shipped
+``base/theme.html.jinja`` partial. Apps register a synchronous tenant *getter*
+once at startup; on every render, the getter pulls the tenant off the request,
+and ``.theme.overrides()`` is exposed as ``theme_overrides`` in the template
+context.
+
+The getter is intentionally synchronous — context providers run on every render
+and must not perform DB I/O. The tenant is expected to already be attached to
+``request.state`` (or accessible from another sync source) by middleware /
+dependency code that ran upstream.
+
+Example::
+
+    from vibetuner.theming import register_tenant_theme_provider
+
+    def _tenant_from_request(request):
+        return getattr(request.state, "tenant", None)
+
+    register_tenant_theme_provider(_tenant_from_request)
+
+The helper is opt-in: until ``register_tenant_theme_provider`` is called, no
+provider is registered and ``base/theme.html.jinja`` renders nothing.
+"""
+
+from collections.abc import Callable
+from typing import Any, Protocol, runtime_checkable
+
+from starlette.requests import Request
+
+from vibetuner.logging import logger
+from vibetuner.models import TenantTheme
+from vibetuner.rendering import register_context_provider
+
+
+__all__ = ["register_tenant_theme_provider"]
+
+
+@runtime_checkable
+class _ThemeBearer(Protocol):
+    """Anything exposing a ``.theme`` attribute that yields a TenantTheme."""
+
+    theme: TenantTheme
+
+
+TenantGetter = Callable[[Request], object | None]
+
+
+def register_tenant_theme_provider(
+    getter: TenantGetter,
+    *,
+    attribute: str = "theme",
+) -> None:
+    """Register a context provider that exposes ``theme_overrides``.
+
+    The ``getter`` is called once per render with the current
+    :class:`~starlette.requests.Request`. It should return the tenant object
+    (or ``None`` if the current request has no tenant, e.g. unauthenticated
+    pages or a default landing page). The tenant's
+    ``getattr(tenant, attribute)`` is expected to be a :class:`TenantTheme`
+    instance whose ``.overrides()`` produces the ``{css_var: hex}`` map.
+
+    The provider is fail-soft: any exception raised by ``getter`` or
+    ``.overrides()`` is logged and the request renders with no theme overrides
+    rather than 500ing.
+
+    Args:
+        getter: Callable that returns the tenant for a given request.
+            Must be synchronous; do any DB lookups in upstream middleware.
+        attribute: Name of the :class:`TenantTheme` attribute on the tenant
+            object. Defaults to ``"theme"``.
+    """
+
+    def tenant_theme_context(request: Request) -> dict[str, Any]:
+        try:
+            tenant = getter(request)
+        except Exception as exc:
+            logger.error(f"tenant_theme_context: getter raised {exc!r}")
+            return {}
+        if tenant is None:
+            return {}
+        theme = getattr(tenant, attribute, None)
+        if theme is None:
+            return {}
+        if not isinstance(theme, TenantTheme):
+            logger.error(
+                f"tenant_theme_context: expected TenantTheme on '{attribute}', "
+                f"got {type(theme).__name__}"
+            )
+            return {}
+        try:
+            overrides = theme.overrides()
+        except Exception as exc:
+            logger.error(f"tenant_theme_context: .overrides() raised {exc!r}")
+            return {}
+        if not overrides:
+            return {}
+        return {"theme_overrides": overrides}
+
+    register_context_provider(tenant_theme_context)

--- a/vibetuner-py/tests/unit/test_tenant_theme.py
+++ b/vibetuner-py/tests/unit/test_tenant_theme.py
@@ -1,0 +1,250 @@
+# ABOUTME: Unit tests for TenantTheme model, register_tenant_theme_provider helper,
+# ABOUTME: and the base/theme.html.jinja partial render.
+# ruff: noqa: S101
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from jinja2 import DictLoader, Environment, select_autoescape
+from pydantic import BaseModel, Field, ValidationError
+from vibetuner.models import TenantTheme
+from vibetuner.paths import frontend_templates
+from vibetuner.rendering import (
+    _collect_provider_context,
+    _context_providers,
+    _template_globals,
+)
+from vibetuner.theming import register_tenant_theme_provider
+
+
+def _reset_globals() -> None:
+    _template_globals.clear()
+    _context_providers.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_providers():
+    _reset_globals()
+    yield
+    _reset_globals()
+
+
+@pytest.fixture()
+def request_with_tenant():
+    """Build a starlette-ish request mock with arbitrary state attached."""
+
+    def _build(**state_attrs: Any) -> MagicMock:
+        request = MagicMock()
+        state = MagicMock(spec=[])  # spec=[] -> no auto-attrs, raises AttributeError
+        for key, value in state_attrs.items():
+            setattr(state, key, value)
+        request.state = state
+        return request
+
+    return _build
+
+
+class TestTenantThemeModel:
+    def test_default_is_empty(self):
+        theme = TenantTheme()
+        assert theme.overrides() == {}
+
+    def test_overrides_includes_only_set_fields(self):
+        theme = TenantTheme(primary="#009ddc", accent="#ff8800")
+        assert theme.overrides() == {
+            "--color-primary": "#009ddc",
+            "--color-accent": "#ff8800",
+        }
+
+    def test_overrides_lowercases_hex(self):
+        theme = TenantTheme(primary="#009DDC")
+        assert theme.overrides() == {"--color-primary": "#009ddc"}
+
+    def test_all_eight_role_colors(self):
+        theme = TenantTheme(
+            primary="#111111",
+            secondary="#222222",
+            accent="#333333",
+            neutral="#444444",
+            primary_content="#555555",
+            secondary_content="#666666",
+            accent_content="#777777",
+            neutral_content="#888888",
+        )
+        assert theme.overrides() == {
+            "--color-primary": "#111111",
+            "--color-secondary": "#222222",
+            "--color-accent": "#333333",
+            "--color-neutral": "#444444",
+            "--color-primary-content": "#555555",
+            "--color-secondary-content": "#666666",
+            "--color-accent-content": "#777777",
+            "--color-neutral-content": "#888888",
+        }
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "009ddc",  # missing #
+            "#fff",  # 3-digit shorthand not allowed
+            "#009ddcg",  # bad char
+            "#009ddc ",  # trailing whitespace
+            "rgb(0,0,0)",
+            "primary",
+            "",
+        ],
+    )
+    def test_rejects_bad_hex(self, bad_value: str):
+        with pytest.raises(ValidationError):
+            TenantTheme(primary=bad_value)
+
+
+class TestRegisterTenantThemeProvider:
+    def test_no_tenant_returns_empty_context(self, request_with_tenant):
+        register_tenant_theme_provider(lambda r: None)
+        result = _collect_provider_context(request=request_with_tenant())
+        assert "theme_overrides" not in result
+
+    def test_tenant_without_theme_attr_returns_empty(self, request_with_tenant):
+        class _Tenant:
+            pass
+
+        register_tenant_theme_provider(lambda r: _Tenant())
+        result = _collect_provider_context(request=request_with_tenant())
+        assert "theme_overrides" not in result
+
+    def test_tenant_with_empty_theme_returns_empty(self, request_with_tenant):
+        class _Tenant(BaseModel):
+            theme: TenantTheme = Field(default_factory=TenantTheme)
+
+        register_tenant_theme_provider(lambda r: _Tenant())
+        result = _collect_provider_context(request=request_with_tenant())
+        assert "theme_overrides" not in result
+
+    def test_tenant_with_overrides_exposes_them(self, request_with_tenant):
+        class _Tenant(BaseModel):
+            theme: TenantTheme
+
+        tenant = _Tenant(theme=TenantTheme(primary="#009ddc", neutral="#222222"))
+        register_tenant_theme_provider(lambda r: tenant)
+        result = _collect_provider_context(request=request_with_tenant())
+        assert result["theme_overrides"] == {
+            "--color-primary": "#009ddc",
+            "--color-neutral": "#222222",
+        }
+
+    def test_custom_attribute_name(self, request_with_tenant):
+        class _Tenant(BaseModel):
+            branding: TenantTheme
+
+        tenant = _Tenant(branding=TenantTheme(accent="#ff8800"))
+        register_tenant_theme_provider(lambda r: tenant, attribute="branding")
+        result = _collect_provider_context(request=request_with_tenant())
+        assert result["theme_overrides"] == {"--color-accent": "#ff8800"}
+
+    def test_getter_exception_is_swallowed(self, request_with_tenant, log_sink):
+        def _explode(_request: Any) -> Any:
+            raise RuntimeError("boom")
+
+        register_tenant_theme_provider(_explode)
+        result = _collect_provider_context(request=request_with_tenant())
+        assert "theme_overrides" not in result
+        assert any("getter raised" in msg for msg in log_sink)
+
+    def test_wrong_type_on_attribute_logs_and_returns_empty(
+        self, request_with_tenant, log_sink
+    ):
+        class _Tenant:
+            theme = "not-a-theme"
+
+        register_tenant_theme_provider(lambda r: _Tenant())
+        result = _collect_provider_context(request=request_with_tenant())
+        assert "theme_overrides" not in result
+        assert any("expected TenantTheme" in msg for msg in log_sink)
+
+
+class TestThemePartialRender:
+    """Render base/theme.html.jinja directly against the framework template dir."""
+
+    def _env(self) -> Environment:
+        # Mirror the production loader so includes resolve.
+        from jinja2 import FileSystemLoader
+
+        return Environment(
+            loader=FileSystemLoader([str(p) for p in frontend_templates]),
+            autoescape=select_autoescape(["html", "jinja"]),
+        )
+
+    def test_no_overrides_renders_blank(self):
+        env = self._env()
+        template = env.get_template("base/theme.html.jinja")
+        rendered = template.render(theme_overrides={}, csp_nonce="abc123")
+        assert "<style" not in rendered
+
+    def test_renders_style_block_with_nonce(self):
+        env = self._env()
+        template = env.get_template("base/theme.html.jinja")
+        rendered = template.render(
+            theme_overrides={
+                "--color-primary": "#009ddc",
+                "--color-accent": "#ff8800",
+            },
+            csp_nonce="nonce-xyz",
+        )
+        assert '<style nonce="nonce-xyz">' in rendered
+        assert ":root {" in rendered
+        assert "--color-primary: #009ddc;" in rendered
+        assert "--color-accent: #ff8800;" in rendered
+        assert "</style>" in rendered
+
+    def test_html_escapes_defensively(self):
+        """A caller that bypasses TenantTheme cannot inject HTML/CSS through the partial."""
+        env = self._env()
+        template = env.get_template("base/theme.html.jinja")
+        rendered = template.render(
+            theme_overrides={
+                '--color-primary"</style><script>alert(1)</script>': "#000000",
+            },
+            csp_nonce="n",
+        )
+        assert "<script>alert(1)</script>" not in rendered
+        assert "&lt;/style&gt;" in rendered or "&lt;script&gt;" in rendered
+
+    def test_isolated_skeleton_includes_theme_block(self):
+        """Skeleton renders the partial when ``theme_overrides`` is provided.
+
+        Builds a tiny child template that extends a stub of the skeleton head
+        section so we can inspect the include without hitting url_for or the
+        i18n machinery.
+        """
+        env = Environment(
+            loader=DictLoader(
+                {
+                    "skeleton_stub.html.jinja": (
+                        "<head>"
+                        '<link rel="stylesheet" href="bundle.css" />'
+                        '{% include "base/theme.html.jinja" %}'
+                        "</head>"
+                    ),
+                }
+            ),
+            autoescape=select_autoescape(["html", "jinja"]),
+        )
+        # Splice the framework partial into the env loader.
+        from jinja2 import ChoiceLoader, FileSystemLoader
+
+        env.loader = ChoiceLoader(
+            [
+                env.loader,
+                FileSystemLoader([str(p) for p in frontend_templates]),
+            ]
+        )
+        rendered = env.get_template("skeleton_stub.html.jinja").render(
+            theme_overrides={"--color-primary": "#009ddc"},
+            csp_nonce="N",
+        )
+        # Cascade order: theme block must appear *after* the bundle.css link.
+        link_index = rendered.index('href="bundle.css"')
+        style_index = rendered.index("<style")
+        assert link_index < style_index


### PR DESCRIPTION
Closes #1704.

## Summary

- New embedded model `vibetuner.models.TenantTheme` with eight optional `#rrggbb` fields for DaisyUI role / role-content colors plus `.overrides()` → `{css_var: hex}`.
- New opt-in helper `vibetuner.register_tenant_theme_provider(getter, *, attribute="theme")` that registers a context provider exposing `theme_overrides` per request. Fail-soft: getter/type errors log and render with no overrides.
- New shipped partial `base/theme.html.jinja` that emits a CSP-noncified `<style>:root { ... }</style>` only when `theme_overrides` is non-empty. Wired into `base/skeleton.html.jinja` between the `bundle.css` link and `{% block head %}`.
- Docs: new `theming.md` page (added to User Guide nav), feature entry in `llms.txt`, detailed section in `llms-full.txt` covering cascade ordering, the two color footguns (build-time literals in custom tokens, hardcoded scale shades), and the per-tenant fonts carve-out (#1705).

`bundle.css` stays tenant-agnostic and cached; theming happens at request time in HTML — no per-tenant CSS rebuilds.

## Backwards compatibility

- The helper is **opt-in**: nothing fires until an app calls `register_tenant_theme_provider(...)`. Apps that don't multi-tenant pay zero overhead.
- Adding `theme: TenantTheme = Field(default_factory=TenantTheme)` to an existing tenant document is a no-op for already-persisted records (MongoDB is schema-on-read; `keep_nulls=False` keeps unset fields out of the database).
- `base/skeleton.html.jinja` now includes `base/theme.html.jinja`, which renders nothing when `theme_overrides` is empty — apps that haven't registered a provider see no extra markup.
- Apps that have already shipped a bespoke per-tenant theming block (e.g. radio's #377) keep working until they swap to the primitive in their own follow-up PR.

## Test plan

- [x] `uv run python -m pytest tests/` (full suite, 717 passed)
- [x] `uv run python -m pytest tests/unit/test_tenant_theme.py` (22 new tests covering the model validator, the provider helper, the rendered partial output, and HTML-escape defenses)
- [x] `just format && just lint && just type-check` clean
- [ ] Smoke-test in a scaffolded project against a real tenant document
- [ ] Once merged, file a follow-up to migrate radio's bespoke implementation to this primitive

🤖 Generated with [Claude Code](https://claude.com/claude-code)