### PR TITLE
chore: add `vibetuner core-templates-path` CLI for setup-tw-sources

### DIFF
--- a/vibetuner-docs/docs/cli-reference.md
+++ b/vibetuner-docs/docs/cli-reference.md
@@ -376,6 +376,26 @@ vibetuner version [--app]
 
 - `--app`, `-a` – Show app settings version even if not in a project directory.
 
+## `vibetuner core-templates-path`
+
+Print the absolute path to the framework's frontend templates directory on a
+single line. Used by frontend builds (notably `vibetuner-template`'s
+`setup-tw-sources` script) to point Tailwind's `@source` directive at the
+package-shipped templates.
+
+```bash
+vibetuner core-templates-path
+# /…/site-packages/vibetuner/templates/frontend
+```
+
+Output is plain stdout (logs go to stderr), so the command is safe to use in
+shell command substitution:
+
+```bash
+TARGET=$(uv run --frozen vibetuner core-templates-path)
+ln -sfn "$TARGET" .core-templates
+```
+
 ## Custom CLI Commands
 
 You can extend the vibetuner CLI with your own commands using `AsyncTyper`. Commands are

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2227,6 +2227,22 @@ vibetuner version [--app]
 
 - `--app`, `-a` – Show app settings version even if not in a project directory.
 
+#### `vibetuner core-templates-path`
+
+Print the absolute path to the framework's frontend templates directory on a
+single line. Used by frontend builds (notably `vibetuner-template`'s
+`setup-tw-sources` script) to point Tailwind's `@source` directive at the
+package-shipped templates without inline `python -c "import vibetuner; ..."`
+invocations.
+
+```bash
+vibetuner core-templates-path
+# /…/site-packages/vibetuner/templates/frontend
+```
+
+Output is plain stdout (logs go to stderr), suitable for shell command
+substitution: `TARGET=$(uv run --frozen vibetuner core-templates-path)`.
+
 ### Scaffolding Reference
 
 #### Template Prompts

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -113,7 +113,7 @@ Important notes:
 - [CLI Reference](https://vibetuner.alltuner.com/cli-reference/):
   Commands for `vibetuner scaffold`, `vibetuner run`, `vibetuner db`,
   `vibetuner doctor`, `vibetuner config`, `vibetuner debug`, `vibetuner crypto`,
-  and `vibetuner version`
+  `vibetuner version`, and `vibetuner core-templates-path`
 - [Scaffolding Reference](https://vibetuner.alltuner.com/scaffolding/):
   Template prompts, post-generation tasks, and updating existing projects
 - [Deployment](https://vibetuner.alltuner.com/deployment/):

--- a/vibetuner-py/src/vibetuner/cli/__init__.py
+++ b/vibetuner-py/src/vibetuner/cli/__init__.py
@@ -132,6 +132,25 @@ def version(
     console.print(table)
 
 
+@app.command("core-templates-path")
+def core_templates_path() -> None:
+    """Print the absolute path to the framework's frontend templates directory.
+
+    Used by frontend builds (e.g. ``vibetuner-template/package.json``'s
+    ``setup-tw-sources``) to point Tailwind's ``@source`` directive at the
+    package-shipped templates without resorting to inline
+    ``python -c "import vibetuner; ..."`` invocations.
+
+    Output is plain stdout (no log noise) and is suitable for use in shell
+    command substitution (``$(vibetuner core-templates-path)``).
+    """
+    import sys
+
+    from vibetuner.paths import package_templates
+
+    sys.stdout.write(f"{(package_templates / 'frontend').resolve()}\n")
+
+
 app.add_typer(config_app, name="config")
 app.add_typer(crypto_app, name="crypto")
 app.add_typer(db_app, name="db")

--- a/vibetuner-py/tests/unit/test_core_templates_path_cli.py
+++ b/vibetuner-py/tests/unit/test_core_templates_path_cli.py
@@ -1,0 +1,46 @@
+# ABOUTME: Tests for the `vibetuner core-templates-path` CLI command.
+# ABOUTME: Verifies stdout payload, no log noise, and that the path resolves to a real dir.
+# ruff: noqa: S101
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+from vibetuner.cli import app
+
+
+runner = CliRunner()
+
+
+class TestCoreTemplatesPathCli:
+    def test_prints_existing_directory(self):
+        result = runner.invoke(app, ["core-templates-path"])
+        assert result.exit_code == 0
+        path = Path(result.stdout.strip())
+        assert path.is_dir()
+
+    def test_path_contains_skeleton_template(self):
+        """Sanity check: it points at the framework's frontend templates."""
+        result = runner.invoke(app, ["core-templates-path"])
+        assert result.exit_code == 0
+        path = Path(result.stdout.strip())
+        assert (path / "base" / "skeleton.html.jinja").is_file()
+
+    def test_stdout_is_just_the_path_no_log_noise(self):
+        """Output is suitable for shell command substitution.
+
+        ``CliRunner`` by default merges stderr into ``output``; ``stdout``
+        contains only what's written to ``sys.stdout``. Loguru routes log
+        records to stderr, so a clean ``stdout`` is what setup-tw-sources
+        depends on.
+        """
+        result = runner.invoke(app, ["core-templates-path"])
+        assert result.exit_code == 0
+        # Single trailing newline, no extra whitespace, single line.
+        assert result.stdout.endswith("\n")
+        assert len(result.stdout.strip().splitlines()) == 1
+
+    def test_path_is_absolute(self):
+        result = runner.invoke(app, ["core-templates-path"])
+        assert result.exit_code == 0
+        path = Path(result.stdout.strip())
+        assert path.is_absolute()

--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "setup-tw-sources": "[ -L .core-templates ] || (rm -rf .core-templates && ln -s \"$(uv run --frozen python -c \"import vibetuner; print(vibetuner.__path__[0])\")/templates/frontend\" .core-templates)",
+    "setup-tw-sources": "TARGET=$(uv run --frozen vibetuner core-templates-path) && { [ -L .core-templates ] && [ \"$(readlink .core-templates)\" = \"$TARGET\" ] || (rm -rf .core-templates && ln -s \"$TARGET\" .core-templates); }",
     "build:css": "bun tailwindcss -i config.css -o assets/statics/css/bundle.css",
     "build:js": "bun build config.js --outdir=assets/statics/js --entry-naming=\"bundle.[ext]\" --sourcemap",
     "dev:css": "bun tailwindcss -w=always -i config.css -o assets/statics/css/bundle.css",


### PR DESCRIPTION
Closes #1706.

## Summary

- New `vibetuner core-templates-path` CLI command that prints the absolute path to the framework's frontend templates directory on a single line. Logs go to stderr; stdout is just the path, so it's safe in shell command substitution.
- Updated `vibetuner-template/package.json`'s `setup-tw-sources` to call the new command **and** verify the existing `.core-templates` symlink target before rebuilding. Previously a venv rebuild that shifted the framework path could leave the symlink pointing at a defunct location, silently dropping framework templates from Tailwind's `@source` scan.
- Tests: stdout payload is exactly the path, single line, absolute, points at a real directory containing `base/skeleton.html.jinja`.
- Docs: new section in `cli-reference.md` and `llms-full.txt`; `llms.txt` reference list updated.

## Smoke test

Verified locally that `setup-tw-sources` is idempotent across three scenarios:

- Fresh checkout with no `.core-templates` → creates symlink.
- Run again → no-op (target matches).
- Manually point `.core-templates` at a wrong path → rebuilds correctly.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_core_templates_path_cli.py` (4 new tests)
- [x] `uv run python -m pytest tests/` (full suite, 721 passed)
- [x] `just format && just lint && just type-check` clean
- [ ] First scaffolded project against the new template confirms the build still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)