### PR TITLE
feat: add Cloudflare Email Service provider

### DIFF
--- a/vibetuner-docs/docs/authentication.md
+++ b/vibetuner-docs/docs/authentication.md
@@ -413,8 +413,16 @@ MAIL_RESEND_API_KEY=re_xxxxxxxxxxxx
 # MAIL_MAILJET_API_KEY=your-api-key
 # MAIL_MAILJET_API_SECRET=your-api-secret
 
+# Option C: Cloudflare Email Service (public beta)
+# MAIL_CLOUDFLARE_API_TOKEN=cf-token
+# MAIL_CLOUDFLARE_ACCOUNT_ID=your-account-id
+
 FROM_EMAIL=noreply@example.com
 ```
+
+When multiple providers are configured, auto-detection prefers Resend, then
+Mailjet, then Cloudflare. Set `MAIL_PROVIDER=cloudflare` (or `resend` /
+`mailjet`) to pick explicitly.
 
 ### How It Works
 
@@ -631,7 +639,7 @@ Ensure callback URLs exactly match in:
 
 Check:
 
-1. Email provider credentials are correct (MAIL_RESEND_API_KEY or MAIL_MAILJET_API_KEY)
+1. Email provider credentials are correct (MAIL_RESEND_API_KEY, MAIL_MAILJET_API_KEY, or MAIL_CLOUDFLARE_API_TOKEN + MAIL_CLOUDFLARE_ACCOUNT_ID)
 2. Email is being sent (check logs)
 3. Token hasn't expired (15 minutes default)
 4. Email isn't in spam folder

--- a/vibetuner-docs/docs/deployment.md
+++ b/vibetuner-docs/docs/deployment.md
@@ -40,7 +40,7 @@ MONGODB_URL=mongodb://user:password@mongodb-host:27017/myapp?authSource=admin
 DATABASE_URL=postgresql+asyncpg://user:password@postgres-host:5432/myapp
 # Redis (if background jobs enabled)
 REDIS_URL=redis://redis-host:6379/0
-# Email (Resend recommended, Mailjet also supported)
+# Email (Resend recommended; Mailjet and Cloudflare Email Service also supported)
 MAIL_RESEND_API_KEY=re_xxxxxxxxxxxx
 FROM_EMAIL=noreply@example.com
 # OAuth

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -846,12 +846,23 @@ Magic links are enabled by default. Configure email settings:
 
 ```bash
 # .env
-SMTP_HOST=smtp.gmail.com
-SMTP_PORT=587
-SMTP_USER=your-email@gmail.com
-SMTP_PASSWORD=your-app-password
+# Option A: Resend (recommended)
+MAIL_RESEND_API_KEY=re_xxxxxxxxxxxx
+
+# Option B: Mailjet
+# MAIL_MAILJET_API_KEY=your-api-key
+# MAIL_MAILJET_API_SECRET=your-api-secret
+
+# Option C: Cloudflare Email Service (public beta)
+# MAIL_CLOUDFLARE_API_TOKEN=cf-token
+# MAIL_CLOUDFLARE_ACCOUNT_ID=your-account-id
+
 FROM_EMAIL=noreply@example.com
 ```
+
+When multiple providers are configured, auto-detection prefers Resend, then
+Mailjet, then Cloudflare. Set `MAIL_PROVIDER=cloudflare` (or `resend` /
+`mailjet`) to pick explicitly.
 
 **How It Works**
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -77,6 +77,12 @@ Important notes:
   block after `bundle.css`. `bundle.css` stays tenant-agnostic and cached
 - **Service DI**: `get_email_service()`, `get_blob_service()`, `get_runtime_config()`
   FastAPI dependency wrappers
+- **Email Providers**: Pluggable transactional email via Resend
+  (`MAIL_RESEND_API_KEY`), Mailjet (`MAIL_MAILJET_API_KEY` +
+  `MAIL_MAILJET_API_SECRET`), or Cloudflare Email Service
+  (`MAIL_CLOUDFLARE_API_TOKEN` + `MAIL_CLOUDFLARE_ACCOUNT_ID`). Auto-detected
+  from available credentials; `MAIL_PROVIDER=resend|mailjet|cloudflare` to
+  pick explicitly. Auto-detection priority: resend > mailjet > cloudflare
 - **CSP Nonce Auto-Injection**: `SecurityHeadersMiddleware` generates a unique CSP nonce
   per request and auto-injects it into all `<script>` tags in HTML responses. Do NOT
   manually add `nonce=` attributes to `<script>` tags in templates, the middleware handles

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -143,7 +143,7 @@ class LocaleDetectionSettings(BaseSettings):
 class MailSettings(BaseSettings):
     """Mail provider configuration. Read from MAIL_* env vars."""
 
-    provider: Literal["resend", "mailjet"] | None = None
+    provider: Literal["resend", "mailjet", "cloudflare"] | None = None
 
     # Resend
     resend_api_key: SecretStr | None = None
@@ -151,6 +151,10 @@ class MailSettings(BaseSettings):
     # Mailjet
     mailjet_api_key: SecretStr | None = None
     mailjet_api_secret: SecretStr | None = None
+
+    # Cloudflare Email Service
+    cloudflare_api_token: SecretStr | None = None
+    cloudflare_account_id: str | None = None
 
     model_config = SettingsConfigDict(
         case_sensitive=False,

--- a/vibetuner-py/src/vibetuner/services/email/cloudflare.py
+++ b/vibetuner-py/src/vibetuner/services/email/cloudflare.py
@@ -1,0 +1,96 @@
+# ABOUTME: Cloudflare Email Service provider implementation.
+# ABOUTME: Sends transactional email via Cloudflare's REST API (account-scoped).
+"""Cloudflare Email Service for Agents — Python provider.
+
+The official ``cloudflare`` SDK only added the ``email_sending.send`` resource
+in ``5.0.0b2`` (a pre-release at the time of writing) and the service itself
+is in public beta. Pinning a beta SDK in the blessed stack is undesirable, so
+this provider talks to the documented REST endpoint directly through
+``httpx.AsyncClient``. When ``cloudflare>=5.0.0`` ships stable, swapping the
+implementation to the SDK is a one-file change — the inputs and JSON payload
+are identical.
+
+Endpoint:  ``POST /accounts/{account_id}/email/sending/send``
+Auth:      ``Authorization: Bearer <api_token>``
+Body:      ``{from, to, subject, text, html}``
+"""
+
+from typing import Any
+
+import httpx
+
+from vibetuner.services.email.base import EmailAddress, format_email_str
+
+
+_API_BASE_URL = "https://api.cloudflare.com/client/v4"
+_DEFAULT_TIMEOUT = 30.0
+
+
+class CloudflareEmailProvider:
+    """Email provider using Cloudflare Email Service.
+
+    A single :class:`httpx.AsyncClient` is created lazily on first use and
+    reused across requests so that connection pooling kicks in. ``aclose``
+    is exposed for callers that want to release sockets explicitly (the
+    framework relies on process exit otherwise, matching how the other
+    providers behave).
+    """
+
+    def __init__(
+        self,
+        api_token: str,
+        account_id: str,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ) -> None:
+        self._api_token = api_token
+        self._account_id = account_id
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=_API_BASE_URL,
+                timeout=self._timeout,
+                headers={
+                    "Authorization": f"Bearer {self._api_token}",
+                    "Content-Type": "application/json",
+                },
+            )
+        return self._client
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def send(
+        self,
+        from_addr: EmailAddress,
+        to_addr: EmailAddress,
+        subject: str,
+        html_body: str,
+        text_body: str,
+        tags: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        # Cloudflare's documented payload does not include a tags / metadata
+        # field today (public beta). The argument is accepted for protocol
+        # parity — extend this once the API exposes it.
+        del tags
+
+        payload: dict[str, Any] = {
+            "from": format_email_str(from_addr),
+            "to": format_email_str(to_addr),
+            "subject": subject,
+            "text": text_body,
+            "html": html_body,
+        }
+
+        client = self._get_client()
+        response = await client.post(
+            f"/accounts/{self._account_id}/email/sending/send",
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/vibetuner-py/src/vibetuner/services/email/service.py
+++ b/vibetuner-py/src/vibetuner/services/email/service.py
@@ -1,9 +1,10 @@
 # ABOUTME: EmailService facade and provider resolution.
 # ABOUTME: Resolves the configured provider and delegates email sending.
 
-from typing import Any
+from collections.abc import Callable
+from typing import Any, NoReturn
 
-from vibetuner.config import settings
+from vibetuner.config import MailSettings, settings
 from vibetuner.services.email.base import (
     EmailAddress,
     EmailProvider,
@@ -11,44 +12,82 @@ from vibetuner.services.email.base import (
 )
 
 
-def _resolve_provider() -> EmailProvider:
-    """Resolve the email provider from settings."""
-    mail = settings.mail
-
-    # Explicit provider selection
-    provider = mail.provider
-
-    # Auto-detect from available credentials
-    if provider is None:
-        if mail.resend_api_key:
-            provider = "resend"
-        elif mail.mailjet_api_key and mail.mailjet_api_secret:
-            provider = "mailjet"
-
-    if provider == "resend":
-        if not mail.resend_api_key:
-            from vibetuner.services.errors import email_not_configured
-
-            raise EmailServiceNotConfiguredError(email_not_configured(log=False))
-        from vibetuner.services.email.resend import ResendEmailProvider
-
-        return ResendEmailProvider(api_key=mail.resend_api_key.get_secret_value())
-
-    if provider == "mailjet":
-        if not mail.mailjet_api_key or not mail.mailjet_api_secret:
-            from vibetuner.services.errors import email_not_configured
-
-            raise EmailServiceNotConfiguredError(email_not_configured(log=False))
-        from vibetuner.services.email.mailjet import MailjetEmailProvider
-
-        return MailjetEmailProvider(
-            api_key=mail.mailjet_api_key.get_secret_value(),
-            api_secret=mail.mailjet_api_secret.get_secret_value(),
-        )
-
+def _raise_not_configured() -> NoReturn:
     from vibetuner.services.errors import email_not_configured
 
     raise EmailServiceNotConfiguredError(email_not_configured(log=False))
+
+
+def _build_resend(mail: MailSettings) -> EmailProvider:
+    if not mail.resend_api_key:
+        _raise_not_configured()
+    from vibetuner.services.email.resend import ResendEmailProvider
+
+    return ResendEmailProvider(api_key=mail.resend_api_key.get_secret_value())
+
+
+def _build_mailjet(mail: MailSettings) -> EmailProvider:
+    if not mail.mailjet_api_key or not mail.mailjet_api_secret:
+        _raise_not_configured()
+    from vibetuner.services.email.mailjet import MailjetEmailProvider
+
+    return MailjetEmailProvider(
+        api_key=mail.mailjet_api_key.get_secret_value(),
+        api_secret=mail.mailjet_api_secret.get_secret_value(),
+    )
+
+
+def _build_cloudflare(mail: MailSettings) -> EmailProvider:
+    if not mail.cloudflare_api_token or not mail.cloudflare_account_id:
+        _raise_not_configured()
+    from vibetuner.services.email.cloudflare import CloudflareEmailProvider
+
+    return CloudflareEmailProvider(
+        api_token=mail.cloudflare_api_token.get_secret_value(),
+        account_id=mail.cloudflare_account_id,
+    )
+
+
+# Order defines auto-detection priority when MAIL_PROVIDER is unset.
+# Each entry is (name, predicate, builder). Adding a new provider is a single
+# entry plus its build_* helper.
+_PROVIDERS: list[
+    tuple[
+        str,
+        Callable[[MailSettings], bool],
+        Callable[[MailSettings], EmailProvider],
+    ]
+] = [
+    ("resend", lambda m: bool(m.resend_api_key), _build_resend),
+    (
+        "mailjet",
+        lambda m: bool(m.mailjet_api_key and m.mailjet_api_secret),
+        _build_mailjet,
+    ),
+    (
+        "cloudflare",
+        lambda m: bool(m.cloudflare_api_token and m.cloudflare_account_id),
+        _build_cloudflare,
+    ),
+]
+
+
+def _resolve_provider() -> EmailProvider:
+    """Resolve the email provider from settings."""
+    mail = settings.mail
+    name = mail.provider
+
+    if name is None:
+        for candidate, predicate, _ in _PROVIDERS:
+            if predicate(mail):
+                name = candidate
+                break
+
+    for candidate, _, builder in _PROVIDERS:
+        if candidate == name:
+            return builder(mail)
+
+    _raise_not_configured()
 
 
 class EmailService:

--- a/vibetuner-py/src/vibetuner/services/errors.py
+++ b/vibetuner-py/src/vibetuner/services/errors.py
@@ -123,13 +123,22 @@ def s3_not_configured(*, log: bool = True) -> str:
 
 EMAIL_ERROR = _build_message(
     service="Email sending",
-    env_vars=["MAIL_RESEND_API_KEY", "MAIL_MAILJET_API_KEY", "MAIL_MAILJET_API_SECRET"],
+    env_vars=[
+        "MAIL_RESEND_API_KEY",
+        "MAIL_MAILJET_API_KEY",
+        "MAIL_MAILJET_API_SECRET",
+        "MAIL_CLOUDFLARE_API_TOKEN",
+        "MAIL_CLOUDFLARE_ACCOUNT_ID",
+    ],
     example_env=(
         "# Option A: Resend (recommended)\n"
         "MAIL_RESEND_API_KEY=re_xxxxxxxxxxxx\n\n"
         "# Option B: Mailjet\n"
         "MAIL_MAILJET_API_KEY=your-api-key\n"
-        "MAIL_MAILJET_API_SECRET=your-api-secret"
+        "MAIL_MAILJET_API_SECRET=your-api-secret\n\n"
+        "# Option C: Cloudflare Email Service (public beta)\n"
+        "MAIL_CLOUDFLARE_API_TOKEN=cf-token\n"
+        "MAIL_CLOUDFLARE_ACCOUNT_ID=your-account-id"
     ),
     disable_hint="Don't import EmailService or get_email_service if email isn't needed.",
     docs_path="configuration#email",

--- a/vibetuner-py/tests/unit/test_email_service.py
+++ b/vibetuner-py/tests/unit/test_email_service.py
@@ -1,9 +1,11 @@
 # ABOUTME: Unit tests for EmailService with multi-provider support
-# ABOUTME: Tests Resend and Mailjet providers, auto-detection, and backward compat
-# ruff: noqa: S101
+# ABOUTME: Tests Resend, Mailjet, and Cloudflare providers, auto-detection, and backward compat
+# ruff: noqa: S101, S106
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 
@@ -258,3 +260,228 @@ async def test_email_service_legacy_event_payload(email_service_resend):
 
         call_params = mock_send.call_args[0][0]
         assert {"name": "event_payload", "value": "user_id=123"} in call_params["tags"]
+
+
+# ── CloudflareEmailProvider tests ────────────────────────────────────
+
+
+def _cloudflare_provider_with_transport(handler):
+    """Build a provider whose internal AsyncClient uses an httpx MockTransport."""
+    from vibetuner.services.email.cloudflare import (
+        _API_BASE_URL,
+        CloudflareEmailProvider,
+    )
+
+    provider = CloudflareEmailProvider(api_token="cf-token", account_id="acct-xyz")
+    provider._client = httpx.AsyncClient(
+        base_url=_API_BASE_URL,
+        transport=httpx.MockTransport(handler),
+        headers={
+            "Authorization": "Bearer cf-token",
+            "Content-Type": "application/json",
+        },
+    )
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_send_basic_payload_and_endpoint():
+    """Posts to /accounts/{id}/email/sending/send with the documented body."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["payload"] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "errors": [],
+                "messages": [],
+                "result": {"queued": ["recipient@example.com"]},
+            },
+        )
+
+    provider = _cloudflare_provider_with_transport(handler)
+    try:
+        result = await provider.send(
+            from_addr="sender@example.com",
+            to_addr="recipient@example.com",
+            subject="Test Subject",
+            html_body="<p>Hello</p>",
+            text_body="Hello",
+        )
+    finally:
+        await provider.aclose()
+
+    assert captured["url"].endswith("/accounts/acct-xyz/email/sending/send")
+    assert captured["headers"]["authorization"] == "Bearer cf-token"
+    assert captured["payload"] == {
+        "from": "sender@example.com",
+        "to": "recipient@example.com",
+        "subject": "Test Subject",
+        "text": "Hello",
+        "html": "<p>Hello</p>",
+    }
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_send_named_addresses():
+    """Named addresses serialise as 'Display <email>' on both sides."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"success": True})
+
+    provider = _cloudflare_provider_with_transport(handler)
+    try:
+        await provider.send(
+            from_addr=("Acme Support", "support@acme.com"),
+            to_addr=("John Doe", "john@example.com"),
+            subject="Test",
+            html_body="<p>Hi</p>",
+            text_body="Hi",
+        )
+    finally:
+        await provider.aclose()
+
+    assert captured["payload"]["from"] == "Acme Support <support@acme.com>"
+    assert captured["payload"]["to"] == "John Doe <john@example.com>"
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_send_ignores_tags():
+    """Tags are accepted for protocol parity but not yet sent (API has no field)."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"success": True})
+
+    provider = _cloudflare_provider_with_transport(handler)
+    try:
+        await provider.send(
+            from_addr="sender@example.com",
+            to_addr="recipient@example.com",
+            subject="Test",
+            html_body="<p>Hi</p>",
+            text_body="Hi",
+            tags={"category": "welcome"},
+        )
+    finally:
+        await provider.aclose()
+
+    # Body matches the documented schema exactly — no extra fields leaked.
+    assert set(captured["payload"]) == {"from", "to", "subject", "text", "html"}
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_send_raises_on_4xx():
+    """Non-2xx responses surface as httpx.HTTPStatusError."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"errors": [{"message": "Auth failed"}]})
+
+    provider = _cloudflare_provider_with_transport(handler)
+    try:
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            await provider.send(
+                from_addr="sender@example.com",
+                to_addr="recipient@example.com",
+                subject="Test",
+                html_body="<p>Hi</p>",
+                text_body="Hi",
+            )
+    finally:
+        await provider.aclose()
+
+    assert exc.value.response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_aclose_idempotent():
+    """Calling aclose twice doesn't raise; client is reset to None."""
+    from vibetuner.services.email.cloudflare import CloudflareEmailProvider
+
+    provider = CloudflareEmailProvider(api_token="cf-token", account_id="acct-xyz")
+    # Force lazy client creation.
+    provider._get_client()
+    assert provider._client is not None
+    await provider.aclose()
+    assert provider._client is None
+    await provider.aclose()  # second call is a no-op
+
+
+# ── _resolve_provider auto-detection tests ───────────────────────────
+
+
+def _patch_mail_settings(**kwargs):
+    """Return a context manager that swaps ``settings.mail`` with the given values."""
+    fake = MagicMock()
+    fake.provider = kwargs.get("provider")
+    for attr in (
+        "resend_api_key",
+        "mailjet_api_key",
+        "mailjet_api_secret",
+        "cloudflare_api_token",
+        "cloudflare_account_id",
+    ):
+        fake.__setattr__(attr, kwargs.get(attr))
+    return patch("vibetuner.services.email.service.settings.mail", fake)
+
+
+def _secret(value: str):
+    sec = MagicMock()
+    sec.get_secret_value.return_value = value
+    sec.__bool__ = lambda self: True
+    return sec
+
+
+def test_resolve_auto_detect_cloudflare_when_token_and_account_set():
+    from vibetuner.services.email.cloudflare import CloudflareEmailProvider
+    from vibetuner.services.email.service import _resolve_provider
+
+    with _patch_mail_settings(
+        cloudflare_api_token=_secret("cf-token"),
+        cloudflare_account_id="acct-xyz",
+    ):
+        provider = _resolve_provider()
+    assert isinstance(provider, CloudflareEmailProvider)
+
+
+def test_resolve_explicit_cloudflare_provider_requires_both_credentials():
+    from vibetuner.services.email.base import EmailServiceNotConfiguredError
+    from vibetuner.services.email.service import _resolve_provider
+
+    # Missing account id
+    with (
+        _patch_mail_settings(
+            provider="cloudflare", cloudflare_api_token=_secret("cf-token")
+        ),
+        pytest.raises(EmailServiceNotConfiguredError),
+    ):
+        _resolve_provider()
+
+    # Missing token
+    with (
+        _patch_mail_settings(provider="cloudflare", cloudflare_account_id="acct-xyz"),
+        pytest.raises(EmailServiceNotConfiguredError),
+    ):
+        _resolve_provider()
+
+
+def test_resolve_resend_wins_over_cloudflare_when_both_configured():
+    """Auto-detection priority: resend > mailjet > cloudflare."""
+    from vibetuner.services.email.resend import ResendEmailProvider
+    from vibetuner.services.email.service import _resolve_provider
+
+    with _patch_mail_settings(
+        resend_api_key=_secret("re_xxx"),
+        cloudflare_api_token=_secret("cf-token"),
+        cloudflare_account_id="acct-xyz",
+    ):
+        provider = _resolve_provider()
+    assert isinstance(provider, ResendEmailProvider)

--- a/vibetuner-template/.claude/rules/development.md
+++ b/vibetuner-template/.claude/rules/development.md
@@ -62,8 +62,9 @@ configure, `vibetuner crypto rotate-key` to rotate.
 
 No registration needed — just import where used. Email via
 `vibetuner.services.email.EmailService`. Configure with
-`MAIL_RESEND_API_KEY` or `MAIL_MAILJET_API_KEY` /
-`MAIL_MAILJET_API_SECRET` in `.env`.
+`MAIL_RESEND_API_KEY`, `MAIL_MAILJET_API_KEY` /
+`MAIL_MAILJET_API_SECRET`, or `MAIL_CLOUDFLARE_API_TOKEN` /
+`MAIL_CLOUDFLARE_ACCOUNT_ID` (public beta) in `.env`.
 
 ## Template Filters
 


### PR DESCRIPTION
Closes #1672.

## Summary

Adds a third pluggable transactional-email backend alongside Resend and Mailjet, talking to Cloudflare Email Service for Agents (public beta).

- New `CloudflareEmailProvider` (`services/email/cloudflare.py`) using `httpx.AsyncClient` directly against the documented REST endpoint (`POST /accounts/{account_id}/email/sending/send`). No new dependency — `httpx[http2]` was already in the blessed stack.
- `MailSettings`: `provider` Literal now includes `cloudflare`; new `cloudflare_api_token` (SecretStr) and `cloudflare_account_id` slots driven by `MAIL_CLOUDFLARE_*` env vars.
- `_resolve_provider` refactored from a 3-branch if-cascade into a `(name, predicate, builder)` registry. Adding a future provider is one registry entry plus a `_build_*` helper. Auto-detection priority remains `resend > mailjet > cloudflare`; explicit `MAIL_PROVIDER` selection wins.
- `EMAIL_ERROR` updated to advertise the new env vars in the not-configured rich error.
- Docs: `llms.txt` feature entry, `llms-full.txt` magic-link config refreshed (dropped a stale `SMTP_*` example), `authentication.md` + `deployment.md` updated, scaffold-side rules file refreshed.

## Why httpx and not the SDK

The official `cloudflare` Python SDK only added `email_sending.send` in `5.0.0b2` (pre-release) — pinning a beta in the blessed stack isn't worth it. The httpx payload matches the SDK's documented input shape exactly, so swapping to `cloudflare>=5.0.0` once stable is a one-file change.

## Tags

Cloudflare's documented payload has no tags / metadata field today. The `tags` argument is accepted for `EmailProvider` protocol parity but ignored on this provider; a test pins that contract so the body schema can't drift accidentally.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_email_service.py` (17 tests, +7 new for Cloudflare)
- [x] `uv run python -m pytest tests/` (full suite, 729 passed)
- [x] `just format && just lint && just type-check` clean
- [ ] Smoke-test end-to-end against a real Cloudflare account once a verified sender domain is provisioned (out of scope for this PR; covered by integration in a downstream app)

## Incidental notes (filed separately if you want)

While reviewing the email surface I noticed `vibetuner-py/src/vibetuner/frontend/routes/health.py:105` references `settings.mailjet_api_key` (top-level) — that attribute doesn't exist; the Mailjet creds live under `settings.mail.*`. The `_check_all_services` path on `/health/ready` currently `AttributeError`s if exercised. Not bundling here to keep the diff scoped — happy to file as its own bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)