### PR TITLE
feat: skeleton extension points (blocks + context vars)

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -365,6 +365,79 @@ The same convention applies to `{% extends %}` and `{% include %}` inside templa
 {% extends "frontend/base/skeleton.html.jinja" %} {# wrong #}
 ```
 
+#### Skeleton Extension Points
+
+The shipped `base/skeleton.html.jinja` exposes blocks and context variables so
+projects can slot in customisations without copying the whole skeleton.
+Extending it is preferable to overriding it: upstream changes (CSP nonce,
+theming, etc.) flow through automatically.
+
+**Blocks** (override in any child template):
+
+| Block | Position | Use for |
+| --- | --- | --- |
+| `extra_head_links` | After `<title>`, before `bundle.css` | `<link rel="alternate">` feeds, RSS, custom meta tags |
+| `extra_scripts` | After the bundled `<script>` (and optional umami) | Per-app scripts that don't replace `bundle.js` |
+| `before_main` | Inside `<body>`, before `block body` | Dev banners, sticky overlays |
+| `after_main` | Inside `<body>`, after `block body` | Persistent mini-players, floating toolbars |
+
+Existing blocks already there: `title`, `head`, `scripts`, `start_of_body`,
+`header`, `body`, `content`, `footer`, `end_of_body`.
+
+**Context variables** (set via `register_globals`, a context provider, or
+per-render `ctx`):
+
+| Variable | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `color_scheme` | `str` | `"light"` | Sets `<meta name="color-scheme">` content |
+| `canonical_url` | `str \| None` | `None` | When set, renders `<link rel="canonical" href="…">` |
+| `font_preloads` | `list[dict]` | `[]` | Each entry renders `<link rel="preload" as="font" href="…" type="…" [crossorigin="…"]>` |
+
+```python
+# tune.py
+from vibetuner import register_globals
+
+register_globals({"color_scheme": "dark"})  # whole site is dark
+```
+
+```python
+# Per-page canonical URL
+return render_template(
+    "blog/post.html.jinja",
+    request,
+    {"canonical_url": str(request.url_for("blog_post", slug=post.slug))},
+)
+```
+
+```python
+# Self-hosted brand fonts (preload-scanner picks these up before bundle.css)
+register_globals({
+    "font_preloads": [
+        {"href": "/static/fonts/brand.woff2", "type": "font/woff2", "crossorigin": "anonymous"},
+    ],
+})
+```
+
+```html
+<!-- templates/frontend/base/skeleton.html.jinja override -->
+{% extends "base/skeleton.html.jinja" %}
+
+{% block extra_head_links %}
+    <link rel="alternate" type="application/rss+xml"
+          title="My App" href="{{ url_for('rss').path }}" />
+{% endblock extra_head_links %}
+
+{% block after_main %}
+    {# Persistent player survives HTMX boost swaps #}
+    {% include "components/player.html.jinja" %}
+{% endblock after_main %}
+```
+
+If you do need to override the whole skeleton (e.g. to wrap the body in an
+HTMX-boost container, change the `<html>` attributes, or add markup before
+`<head>`), prefer the smallest possible override and keep the upstream
+blocks intact so future framework changes still apply.
+
 ### Built-in Template Globals
 
 Vibetuner provides these variables in every template automatically:

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -351,6 +351,54 @@ Add templates in `templates/`:
 {% endblock %}
 ```
 
+#### Skeleton Extension Points
+
+`base/skeleton.html.jinja` exposes blocks and context variables so projects
+can slot in customisations without copying the whole skeleton. Extending it
+is preferable to overriding it: upstream changes (CSP nonce, theming, etc.)
+flow through automatically.
+
+**Blocks** (override in any child template):
+
+- `extra_head_links` — after `<title>`, before `bundle.css`. For
+  `<link rel="alternate">` feeds, RSS, custom meta tags.
+- `extra_scripts` — after the bundled `<script>` (and optional umami). For
+  per-app scripts that don't replace `bundle.js`.
+- `before_main` — inside `<body>`, before `block body`. For dev banners,
+  sticky overlays.
+- `after_main` — inside `<body>`, after `block body`. For persistent
+  mini-players, floating toolbars.
+
+Existing blocks already there: `title`, `head`, `scripts`, `start_of_body`,
+`header`, `body`, `content`, `footer`, `end_of_body`.
+
+**Context variables** (set via `register_globals`, a context provider, or
+per-render `ctx`):
+
+- `color_scheme` — `str`, defaults to `"light"`. Sets
+  `<meta name="color-scheme">` content.
+- `canonical_url` — `str | None`, defaults to `None`. When set, renders
+  `<link rel="canonical" href="…">`.
+- `font_preloads` — `list[dict]`, defaults to `[]`. Each entry renders
+  `<link rel="preload" as="font" href="…" type="…" [crossorigin="…"]>`.
+  Listed before `bundle.css` so the preload scanner picks them up early.
+
+Example: a project skeleton override that adds an RSS feed and a persistent
+player without touching upstream markup:
+
+```html
+{% extends "base/skeleton.html.jinja" %}
+
+{% block extra_head_links %}
+    <link rel="alternate" type="application/rss+xml"
+          title="My App" href="{{ url_for('rss').path }}" />
+{% endblock extra_head_links %}
+
+{% block after_main %}
+    {% include "components/player.html.jinja" %}
+{% endblock after_main %}
+```
+
 #### Built-in Template Globals
 
 These variables are available in every template automatically:

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -63,6 +63,11 @@ Important notes:
   Handles JSON serialization internally. Import from `vibetuner.htmx`
 - **Built-in Template Globals**: `now` (UTC datetime) and `today` (ISO date string)
   are available in all templates automatically
+- **Skeleton Extension Points**: `base/skeleton.html.jinja` exposes blocks
+  (`extra_head_links`, `extra_scripts`, `before_main`, `after_main`) and
+  context variables (`color_scheme`, `canonical_url`, `font_preloads`) so
+  projects can extend instead of wholesale-overriding the skeleton —
+  upstream changes (CSP nonce, theming, etc.) flow through automatically
 - **Encrypted Fields**: `EncryptedFieldsMixin` and `EncryptedStr` type for
   transparent Fernet encrypt-on-save / decrypt-on-load on any Beanie model field.
   Import from `vibetuner.models.mixins`. Requires `FIELD_ENCRYPTION_KEY` env var

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -5,11 +5,21 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="{{ meta_description | default('') }}" />
         <meta name="keywords" content="{{ meta_keywords | default('') }}" />
-        <meta name="color-scheme" content="light" />
+        <meta name="color-scheme" content="{{ color_scheme | default('light') }}" />
         <title>
             {% block title %}
             {% endblock title %}
         </title>
+        {% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}" />{% endif %}
+        {% for fp in font_preloads | default([]) %}
+            <link rel="preload"
+                  as="font"
+                  href="{{ fp.href }}"
+                  type="{{ fp.type }}"
+                  {% if fp.crossorigin %}crossorigin="{{ fp.crossorigin }}"{% endif %} />
+        {% endfor %}
+        {% block extra_head_links %}
+        {% endblock extra_head_links %}
         <link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
         {% include "base/theme.html.jinja" %}
 
@@ -19,6 +29,8 @@
         {% if umami_website_id and not DEBUG %}
             <script defer src="/meta.js" data-website-id="{{ umami_website_id }}"></script>
         {% endif %}
+        {% block extra_scripts %}
+        {% endblock extra_scripts %}
         {% include "base/favicons.html.jinja" %}
         {% include "base/opengraph.html.jinja" %}
 
@@ -34,10 +46,14 @@
 
             {% endif %}
         {% endblock header %}
+        {% block before_main %}
+        {% endblock before_main %}
         {% block body %}
             {% block content %}
             {% endblock content %}
         {% endblock body %}
+        {% block after_main %}
+        {% endblock after_main %}
         {% block footer %}
             {% if not SKIP_FOOTER %}
                 {% include "base/footer.html.jinja" %}

--- a/vibetuner-py/tests/unit/test_skeleton_extension_points.py
+++ b/vibetuner-py/tests/unit/test_skeleton_extension_points.py
@@ -1,0 +1,233 @@
+# ABOUTME: Tests for skeleton.html.jinja extension blocks and context vars.
+# ABOUTME: Pins behavior so projects can extend instead of wholesale-overriding.
+# ruff: noqa: S101, N801
+
+from typing import Any
+
+import pytest
+from jinja2 import (
+    ChainableUndefined,
+    ChoiceLoader,
+    DictLoader,
+    Environment,
+    FileSystemLoader,
+    select_autoescape,
+)
+from vibetuner.paths import frontend_templates
+
+
+# A minimal harness: render a tiny child template that extends the framework
+# skeleton, with framework-side includes resolvable via FileSystemLoader.
+# Skeleton-included partials (opengraph, favicons) reference globals like
+# ``project_name`` that aren't relevant to these tests; ChainableUndefined
+# silently renders missing chains as empty so we don't have to stub them all.
+
+
+class _StubRequest:
+    class state:
+        language = "en"
+
+    url = "https://test.example.com/"
+
+
+def _stub_url_for(name: str, **kwargs: Any) -> Any:
+    class _URL:
+        path = f"/static/{kwargs.get('path', name)}"
+
+    return _URL()
+
+
+def _make_env(child_body: str = "") -> Environment:
+    env = Environment(
+        loader=ChoiceLoader(
+            [
+                DictLoader(
+                    {
+                        "_test_child.html.jinja": (
+                            "{% extends 'base/skeleton.html.jinja' %}" + child_body
+                        ),
+                    }
+                ),
+                FileSystemLoader([str(p) for p in frontend_templates]),
+            ]
+        ),
+        autoescape=select_autoescape(["html", "jinja"]),
+        undefined=ChainableUndefined,
+    )
+    env.globals["url_for"] = _stub_url_for
+    env.globals["DEBUG"] = False
+    env.globals["BODY_CLASS"] = ""
+    env.globals["SKIP_HEADER"] = True
+    env.globals["SKIP_FOOTER"] = True
+    env.globals["project_name"] = "test"
+    env.globals["project_description"] = "test"
+    return env
+
+
+def _render(env: Environment, **ctx: Any) -> str:
+    base = {"request": _StubRequest(), "csp_nonce": "n", "umami_website_id": None}
+    base.update(ctx)
+    return env.get_template("_test_child.html.jinja").render(**base)
+
+
+# ── color_scheme context var ──────────────────────────────────────────
+
+
+class TestColorScheme:
+    def test_defaults_to_light(self):
+        out = _render(_make_env())
+        assert '<meta name="color-scheme" content="light" />' in out
+
+    def test_can_be_overridden(self):
+        out = _render(_make_env(), color_scheme="dark")
+        assert '<meta name="color-scheme" content="dark" />' in out
+
+    def test_value_is_html_escaped(self):
+        out = _render(_make_env(), color_scheme='"><script>alert(1)</script>')
+        assert "<script>alert(1)</script>" not in out
+
+
+# ── canonical_url context var ─────────────────────────────────────────
+
+
+class TestCanonicalUrl:
+    def test_omitted_when_unset(self):
+        out = _render(_make_env())
+        assert 'rel="canonical"' not in out
+
+    def test_renders_when_set(self):
+        out = _render(_make_env(), canonical_url="https://example.com/post/42")
+        assert '<link rel="canonical" href="https://example.com/post/42" />' in out
+
+    def test_value_is_html_escaped(self):
+        out = _render(
+            _make_env(),
+            canonical_url='https://x"><script>alert(1)</script>',
+        )
+        assert "<script>alert(1)</script>" not in out
+
+
+# ── font_preloads context var ─────────────────────────────────────────
+
+
+class TestFontPreloads:
+    def test_omitted_when_unset(self):
+        out = _render(_make_env())
+        assert 'rel="preload"' not in out
+
+    def test_renders_each_entry(self):
+        out = _render(
+            _make_env(),
+            font_preloads=[
+                {
+                    "href": "/fonts/brand.woff2",
+                    "type": "font/woff2",
+                    "crossorigin": "anonymous",
+                },
+                {
+                    "href": "/fonts/mono.woff2",
+                    "type": "font/woff2",
+                },
+            ],
+        )
+        # djlint may reformat the <link> tag onto multiple lines, so collapse
+        # whitespace before checking that all expected attributes appear in
+        # one tag.
+        flat = " ".join(out.split())
+        assert 'rel="preload" as="font" href="/fonts/brand.woff2"' in flat
+        assert 'href="/fonts/brand.woff2"' in flat
+        assert 'type="font/woff2"' in flat
+        assert 'crossorigin="anonymous"' in flat
+        assert 'href="/fonts/mono.woff2"' in flat
+
+    def test_crossorigin_omitted_when_falsy(self):
+        out = _render(
+            _make_env(),
+            font_preloads=[{"href": "/f.woff2", "type": "font/woff2"}],
+        )
+        assert "crossorigin=" not in out
+
+
+# ── extension blocks ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "block,marker",
+    [
+        ("extra_head_links", "<!-- HEADLINK -->"),
+        ("extra_scripts", "<!-- SCRIPT -->"),
+        ("before_main", "<!-- BEFORE -->"),
+        ("after_main", "<!-- AFTER -->"),
+    ],
+)
+def test_extension_block_renders_when_overridden(block: str, marker: str):
+    """Each new block accepts content from a child template."""
+    env = _make_env(child_body=f"{{% block {block} %}}{marker}{{% endblock {block} %}}")
+    rendered = _render(env)
+    assert marker in rendered
+
+
+def test_extension_blocks_empty_by_default():
+    """No new block renders any content when not overridden."""
+    out = _render(_make_env())
+    # There should be no stray HTML comments leaking from the new blocks.
+    for marker in (
+        "<!-- HEADLINK -->",
+        "<!-- SCRIPT -->",
+        "<!-- BEFORE -->",
+        "<!-- AFTER -->",
+    ):
+        assert marker not in out
+
+
+# ── cascade-order invariants ─────────────────────────────────────────
+
+
+def test_canonical_and_font_preloads_render_before_bundle_css():
+    """Preload scanner needs <link rel="preload"> before the stylesheet."""
+    out = _render(
+        _make_env(),
+        canonical_url="https://example.com/",
+        font_preloads=[{"href": "/f.woff2", "type": "font/woff2"}],
+    )
+    css_idx = out.index("bundle.css")
+    canonical_idx = out.index('rel="canonical"')
+    preload_idx = out.index('rel="preload"')
+    assert canonical_idx < css_idx
+    assert preload_idx < css_idx
+
+
+def test_extra_head_links_block_renders_before_bundle_css():
+    env = _make_env(
+        child_body=(
+            "{% block extra_head_links %}<!-- EXTRAS -->{% endblock extra_head_links %}"
+        )
+    )
+    out = _render(env)
+    assert out.index("<!-- EXTRAS -->") < out.index("bundle.css")
+
+
+def test_extra_scripts_block_renders_after_bundle_js():
+    env = _make_env(
+        child_body=(
+            "{% block extra_scripts %}<!-- AFTER_BUNDLE -->{% endblock extra_scripts %}"
+        )
+    )
+    out = _render(env)
+    assert out.index("bundle.js") < out.index("<!-- AFTER_BUNDLE -->")
+
+
+def test_before_main_and_after_main_wrap_body():
+    """before_main precedes the body block; after_main follows it."""
+    env = _make_env(
+        child_body=(
+            "{% block before_main %}<!-- PRE -->{% endblock before_main %}"
+            "{% block content %}<!-- BODY -->{% endblock content %}"
+            "{% block after_main %}<!-- POST -->{% endblock after_main %}"
+        )
+    )
+    out = _render(env)
+    pre = out.index("<!-- PRE -->")
+    body = out.index("<!-- BODY -->")
+    post = out.index("<!-- POST -->")
+    assert pre < body < post


### PR DESCRIPTION
Closes #1712.

## Summary

Adds extension blocks and context variables to `base/skeleton.html.jinja` so projects can slot in customisations in specific spots without copying the whole skeleton. Reducing the override surface means upstream changes (CSP nonce, theming, etc.) flow through automatically.

**Blocks added:**

- `extra_head_links` — between `<title>` and `bundle.css`. For `<link rel="alternate">` feeds, custom meta tags. Sits before the stylesheet so the preload scanner picks them up early.
- `extra_scripts` — after `bundle.js` (and optional umami). For per-app scripts that don't replace `bundle.js`.
- `before_main` / `after_main` — siblings of the body block, inside `<body>`. For dev banners, sticky overlays, persistent mini-players outside the swap target.

**Context variables added:**

- `color_scheme` (default `"light"`) — drives `<meta name="color-scheme">`.
- `canonical_url` — when set, renders `<link rel="canonical" href="…">`. No auto-default; opt-in to avoid wrong canonicals.
- `font_preloads` (default `[]`) — list of `{href, type, crossorigin}` dicts rendered as `<link rel="preload" as="font" …>` before `bundle.css`.

## Coverage of radio's listed needs

| Radio's need (from issue body) | New surface |
| --- | --- |
| `<link rel="canonical">` per page | `canonical_url` ✓ |
| `<meta color-scheme="dark">` | `color_scheme` ✓ |
| Two `<link rel="preload" ... woff2>` font tags | `font_preloads` ✓ |
| Extra `audio-player.js` script | `extra_scripts` ✓ |
| Dev podcast banner inside `<body>` after `start_of_body` | `before_main` (or existing `start_of_body`) ✓ |
| Mini-player markup outside the swap target | `after_main` ✓ |
| `defer` on bundle.js | Still requires overriding the `scripts` block — out of scope per issue |
| `hx-boost="true"` on body + `<div id="main-content">` wrapper | Out of scope per issue |

## Backwards compatibility

- All new blocks render empty when unoverridden. No structural change to existing markup.
- All new context variables default safely (`color_scheme` → `"light"`, the rest → no output). Existing renderers that don't pass them get the previous behavior.
- Existing block names (`title`, `head`, `scripts`, `start_of_body`, `header`, `body`, `content`, `footer`, `end_of_body`) are untouched.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_skeleton_extension_points.py` (18 new tests; default behaviors, overrides, HTML-escape defenses, cascade-order invariants)
- [x] `uv run python -m pytest tests/` (full suite, 756 passed)
- [x] `just format && just lint && just type-check` clean
- [ ] Once merged, migrate radio's bespoke skeleton to extend the upstream one and confirm the diff shrinks to the 3-4 blocks listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)