### PR TITLE
fix(template): scope babel.cfg python extraction to src/

### DIFF
--- a/vibetuner-template/babel.cfg
+++ b/vibetuner-template/babel.cfg
@@ -1,5 +1,4 @@
-[python: **.py]
-input_paths = src
+[python: src/**.py]
 
 [jinja2: templates/frontend/**.html.jinja]
 input_encoding = utf-8


### PR DESCRIPTION
## Summary

`vibetuner-template/babel.cfg` previously read:

```ini
[python: **.py]
input_paths = src
```

`input_paths = src` is not a real pybabel directive inside an extractor section — it's silently ignored as an unknown method keyword. The effective pattern `**.py` matches every Python file under the walk root passed to `pybabel extract`, so `just extract-translations` (which runs `pybabel extract -F babel.cfg -o locales/messages.pot .`) was pulling translatable strings from `tests/`, `scripts/`, and anything else outside `src/`.

## Fix

Scope the python pattern to `src/**.py` and drop the bogus line:

```ini
[python: src/**.py]

[jinja2: templates/frontend/**.html.jinja]
input_encoding = utf-8
```

## Verification

Ran `pybabel extract` against the template directory before and after:

- **Before:** walks `src/{{ project_slug | replace('-', '_') }}/__init__.py` *and* `tests/__init__.py`.
- **After:** walks only `src/{{ project_slug | replace('-', '_') }}/__init__.py`.

## Note for existing scaffolded projects

This file lives in `vibetuner-template/`, so existing user projects won't auto-update. If you've scaffolded a project from a prior version of the template, manually update your `babel.cfg` to match (or run a Copier update / `just deps-scaffolding` if you have that wired up).

Closes #1717

## Test plan

- [x] `pybabel extract -F vibetuner-template/babel.cfg -o /tmp/test.pot vibetuner-template/` walks only `src/`-scoped files
- [x] Pre-commit hooks pass