### PR TITLE
docs(i18n): clarify locale_names vs language_picker overlap

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -969,6 +969,21 @@ The following language-related variables are available in templates:
 
 A `language_picker()` Jinja global is also available — see below.
 
+#### When to use which
+
+`locale_names` and `language_picker()` overlap but solve different problems:
+
+- **`locale_names`** — locale-independent map of native names, frozen at app startup
+  and sorted by name. Use it when every language must always render in its own script
+  (e.g. a footer that reads "English / Català / Español" regardless of the visitor's
+  language).
+- **`language_picker()`** — `[{code, name}]` list with names rendered in the current
+  request locale (or an explicit `display_locale`). Use it for switchers that should
+  render themselves in the user's active language.
+
+If you want native names but prefer a single source of truth, call
+`language_picker(code)` once per language instead of reading `locale_names`.
+
 #### Using `language_picker()` for Locale-Aware Switchers
 
 `language_picker()` is a Jinja global (also importable as

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1481,6 +1481,19 @@ The existing `locale_names` template variable (locale-independent native
 names — `{"ca": "Català", "en": "English"}`) and the `supported_languages`
 template variable (set of codes) are unchanged.
 
+`locale_names` and `language_picker()` overlap but cover different cases:
+
+- `locale_names` — each language always rendered in its own script,
+  regardless of the request locale. Use for footers or chrome that must
+  read the same in every locale.
+- `language_picker()` — names rendered in the active (or explicit)
+  display locale. Use for switchers that should render themselves in
+  the user's current language.
+
+Need native names but want a single source of truth? Call
+`language_picker(code)` once per language instead of reading
+`locale_names`.
+
 ### Service Dependency Injection
 
 Vibetuner provides FastAPI `Depends()` wrappers for built-in services:

--- a/vibetuner-py/src/vibetuner/context.py
+++ b/vibetuner-py/src/vibetuner/context.py
@@ -24,7 +24,14 @@ class Context(BaseModel):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def locale_names(self) -> dict[str, str]:
-        """Language codes mapped to native display names, sorted alphabetically."""
+        """Language codes mapped to native display names, sorted alphabetically.
+
+        Locale-independent: each language renders in its own script (e.g.
+        ``{"ca": "Català", "en": "English"}``). For names rendered in the
+        active request locale, use :func:`vibetuner.i18n.language_picker`;
+        call ``language_picker(code)`` per language for native names from
+        a single source of truth.
+        """
         if self._locale_names_cache is None:
             self._locale_names_cache = dict(
                 sorted(


### PR DESCRIPTION
## Summary

- `locale_names` (locale-independent native names) and `language_picker()` (names in the active display locale) overlap but solve different problems. Soft-clarify the distinction without removing or runtime-deprecating either.
- Add a docstring note on the `locale_names` computed field pointing callers at `language_picker()` for native-from-single-source or current-locale rendering.
- Add a "When to use which" subsection to the i18n template-context block in `development-guide.md`.
- Mirror the guidance in `llms-full.txt`.

No runtime behavior changes; `locale_names` stays in the `Context` model.

## Test plan

- [x] `uv run python -m pytest tests/unit/ -q` (773 passed)
- [x] `just lint-py`
- [x] `just lint-md`
- [x] `just type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)