### PR TITLE
docs(template): document i18n primitives in scaffolded agent rules

### DIFF
--- a/vibetuner-template/.claude/rules/localization.md
+++ b/vibetuner-template/.claude/rules/localization.md
@@ -14,3 +14,54 @@ just new-locale LANG         # New language
 
 Templates: `{% trans %}Welcome{% endtrans %}`.
 Python: `from starlette_babel import gettext_lazy as _`.
+
+## Language switcher (Jinja)
+
+`language_picker()` is registered as a Jinja global. It returns
+`[{code, name}]` with names rendered in the **current request locale**
+(browsing in Spanish gives "inglés / español / catalán").
+
+```jinja
+<select name="language">
+    {% for entry in language_picker() %}
+        <option value="{{ entry.code }}"
+                {% if entry.code == language %}selected{% endif %}>
+            {{ entry.name }}
+        </option>
+    {% endfor %}
+</select>
+```
+
+Pass an explicit locale to override: `{% for e in language_picker("es") %}`.
+
+## Forcing a language mid-request
+
+After login or a tenant switch, use `set_request_language` so
+`{% trans %}`, `<html lang>` and `Content-Language` stay in sync:
+
+```python
+from vibetuner.i18n import set_request_language
+
+set_request_language(request, user.preferred_language)
+```
+
+## Custom locale resolvers (per-tenant, per-domain)
+
+Register a resolver to inject a custom selector at the front of the
+locale chain. Returns a code or `None` to defer:
+
+```python
+from vibetuner.i18n import register_locale_resolver
+
+def tenant_locale(conn):
+    tenant = conn.scope.get("state", {}).get("tenant")
+    return tenant.language if tenant else None
+
+register_locale_resolver(tenant_locale)
+```
+
+Resolvers must be synchronous; do DB lookups in upstream middleware.
+Fail-soft: a raising resolver is logged and the chain falls through.
+
+Full reference:
+<https://vibetuner.alltuner.com/development-guide/#custom-locale-resolvers-register_locale_resolver>


### PR DESCRIPTION
## Summary

Expand `vibetuner-template/.claude/rules/localization.md` to cover the new `vibetuner.i18n` primitives shipped in #1718 so scaffolded projects (and their AI assistants) discover them.

Adds three sections to the rules file:

- **Language switcher (Jinja)** — `language_picker()` Jinja global, with example
- **Forcing a language mid-request** — `set_request_language(request, code)`
- **Custom locale resolvers** — `register_locale_resolver(getter, *, priority=0)`

Plus a deep link to https://vibetuner.alltuner.com/development-guide/#custom-locale-resolvers-register_locale_resolver for full details.

`AGENTS.md` is unchanged — its existing pointer to the framework `llms.txt` covers the high-level reference; the rules file is the canonical home for agent-targeted detail.

## Test plan

- [x] `just lint-md` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)