### PR TITLE
fix: restore gettext plural-form support in lint-po

### DIFF
--- a/vibetuner-template/.justfiles/linting.justfile
+++ b/vibetuner-template/.justfiles/linting.justfile
@@ -26,7 +26,7 @@ lint-yaml:
 # Lint PO translation files with lint-po
 [group('Code quality: linting')]
 lint-po:
-    @bash -c 'shopt -s nullglob; files=(locales/*/LC_MESSAGES/*.po); if (( ${#files[@]} )); then uvx lint-po "${files[@]}"; else echo "No .po files to lint"; fi'
+    @bash -c 'shopt -s nullglob; files=(locales/*/LC_MESSAGES/*.po); if (( ${#files[@]} )); then uv run --frozen lint-po "${files[@]}"; else echo "No .po files to lint"; fi'
 
 # Type check Python files with ty
 [group('Code quality: linting')]

--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -58,6 +58,6 @@ repos:
     hooks:
       - id: lint-po
         name: lint-po
-        entry: uvx lint-po
+        entry: uv run --frozen lint-po
         language: system
         files: \.po$

--- a/vibetuner-template/pyproject.toml.j2
+++ b/vibetuner-template/pyproject.toml.j2
@@ -25,6 +25,7 @@ vibetuner = "vibetuner.cli:app"
 [dependency-groups]
 dev = [
   "vibetuner[dev]",
+  "lint-po",
 ]
 
 [build-system]
@@ -38,6 +39,10 @@ testpaths = ["tests"]
 [tool.uv]
 cache-keys = [{ file = "pyproject.toml" }]
 
+[tool.uv.sources]
+# Pin to upstream master until himdel/lint-po cuts a PyPI release
+# that includes gettext plural-form support (PRs #3 and #4).
+lint-po = { git = "https://github.com/himdel/lint-po", rev = "efadbcaa50f84135ee4f16efa44d99d2662a74b4" }
+
 # To develop against a local copy of vibetuner-py, add:
-# [tool.uv.sources]
 # vibetuner = { path = "packages/vibetuner-py", editable = true }


### PR DESCRIPTION
## Summary
- Closes #1719 — `lint-po` rejects Babel-generated `msgid_plural` / `msgstr[N]` entries, blocking `just lint` on any locale that uses `{% trans count=… %}{% pluralize %}{% endtrans %}`.
- Root cause: PyPI `lint-po` is still 0.1.4 (Nov 2022), which predates the gettext plural-form support merged upstream as `himdel/lint-po#3` and `#4` (Mar 2026). Switching to PyPI in #1609 silently regressed the feature.
- Pin `lint-po` to upstream master at `efadbcaa50f84135ee4f16efa44d99d2662a74b4` via `[tool.uv.sources]` in the scaffolded `pyproject.toml`.
- Switch the justfile recipe and pre-commit hook from `uvx lint-po` to `uv run --frozen lint-po` so resolution happens once at `uv sync` time instead of hitting GitHub on every invocation — also addresses the transient-failure motivation behind #1609.
- A release-request issue is open upstream at himdel/lint-po#5; once a new version ships to PyPI we can drop the `[tool.uv.sources]` pin in favor of a normal version constraint.

## Test plan
- [x] Reproduced #1719 locally with `uvx lint-po` against a Babel-generated plural `.po` (exit 1, "Unexpected input" warnings).
- [x] Verified the pinned SHA resolves and installs via `uv lock` + `uv sync --frozen` in a smoke-test project.
- [x] Verified the same plural fixture passes with `uv run --frozen lint-po` (exit 0).
- [x] Verified placeholder-mismatch detection still flags a deliberately-broken `msgstr[1]` in a plural entry (exit 1).
- [ ] Smoke `just lint-po` and pre-commit `lint-po` hook on a real scaffolded project after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)