### PR TITLE
chore(py): use PEP 639 SPDX license expression

### DIFF
--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -4,13 +4,12 @@ description = "Core Python framework and blessed dependencies for production-rea
 version = "10.7.0"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = "MIT"
 authors = [{ name = "All Tuner Labs, S.L." }]
 keywords = ["fastapi", "mongodb", "htmx", "web-framework", "scaffolding", "oauth", "background-jobs"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary

- Replace deprecated `license = { text = "MIT" }` and `License :: OSI Approved :: MIT License` classifier with a SPDX expression `license = "MIT"` per PEP 639.
- Silences the uv build warning: `Found license classifier 'License :: OSI Approved :: MIT License'. License classifiers are ambiguous and deprecated per PEP 639; projects should use 'project.license' and 'project.license-files' instead.`

## Test plan

- [x] `uv build` succeeds with no license-related warnings
- [x] Wheel METADATA contains `License-Expression: MIT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)