### PR TITLE
Restore ABOUTME header in vibetuner-docs extra.css

### DIFF
--- a/vibetuner-docs/docs/stylesheets/extra.css
+++ b/vibetuner-docs/docs/stylesheets/extra.css
@@ -1,3 +1,6 @@
+/* ABOUTME: All Tuner Labs brand colors and MkDocs Material theme overrides. */
+/* ABOUTME: Provides wine/burgundy color scheme with light/dark mode support. */
+
 /* All Tuner Labs Brand Colors */
 :root {
   --wine: #5B2333;


### PR DESCRIPTION
## Summary
- Restores the two-line `ABOUTME:` comment header that had drifted out of `vibetuner-docs/docs/stylesheets/extra.css`.
- After this change the file matches the canonical brand mkdocs theme byte-for-byte (now hosted at [`alltuner/brand:mkdocs-theme/stylesheets/extra.css`](https://github.com/alltuner/brand/blob/main/mkdocs-theme/stylesheets/extra.css), replacing the now-archived `alltuner/mkdocs-theme`).
- Also re-aligns with the project convention that every file starts with two `ABOUTME:` lines.

## Test plan
- [ ] `mkdocs serve` on `vibetuner-docs/` still renders correctly (header comment only — no functional CSS change).