### PR TITLE
ci: allow revert as a conventional PR title type

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -27,6 +27,7 @@ jobs:
             perf
             ci
             build
+            revert
           # Require a colon after the type
           requireScope: false
           # Allow uppercase in subject (e.g., "API" is fine)

--- a/vibetuner-template/.github/workflows/pr-title-check.yml
+++ b/vibetuner-template/.github/workflows/pr-title-check.yml
@@ -27,6 +27,7 @@ jobs:
             perf
             ci
             build
+            revert
           # Require a colon after the type
           requireScope: false
           # Allow uppercase in subject (e.g., "API" is fine)


### PR DESCRIPTION
## Summary

Adds `revert` to the allowed types in both the canonical PR title check (`alltuner/vibetuner` itself) and the scaffold template (`vibetuner-template/`), so future scaffolds inherit it.

## Why

`git revert` produces commits like `Revert "feat: foo"` and Conventional Commits lists `revert` as a standard type. Without it, revert PRs fail the title check and need manual title editing.

## Context

Followup to the recent org-wide PR title check rollout (tracked in #1734). Equivalent change already merged in 11 alltuner/davidpoblador repos that had the workflow added without `revert`:

- alltuner: backstack, cookietuner, factoryfloor, gitcabin, infrastructure, nameplate, silicate, switchyard, vaultuner
- davidpoblador: diafan, nextcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)