### PR TITLE
fix: reserve scrollbar gutter to prevent horizontal layout shift

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -20,6 +20,12 @@
         {% endfor %}
         {% block extra_head_links %}
         {% endblock extra_head_links %}
+        {# Reserve the vertical scrollbar gutter so centered chrome doesn't
+           shift horizontally when navigating between short and long pages.
+           Inline (with the CSP nonce) rather than in bundle.css so the rule
+           applies to existing projects on framework upgrade without
+           rebuilding their CSS bundle. -#}
+        <style nonce="{{ csp_nonce }}">html { scrollbar-gutter: stable; }</style>
         <link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
         {% include "base/theme.html.jinja" %}
 

--- a/vibetuner-py/tests/unit/test_skeleton_extension_points.py
+++ b/vibetuner-py/tests/unit/test_skeleton_extension_points.py
@@ -231,3 +231,32 @@ def test_before_main_and_after_main_wrap_body():
     body = out.index("<!-- BODY -->")
     post = out.index("<!-- POST -->")
     assert pre < body < post
+
+
+# ── scrollbar gutter ─────────────────────────────────────────────────
+
+
+class TestScrollbarGutter:
+    def test_emits_stable_gutter_rule(self):
+        out = _render(_make_env())
+        compact = "".join(out.split())
+        assert "html{scrollbar-gutter:stable" in compact
+
+    def test_uses_csp_nonce(self):
+        out = _render(_make_env())
+        # The inline <style> for the gutter rule must carry the nonce so it
+        # passes the CSP style-src directive.
+        assert 'nonce="n"' in out
+        # Locate the gutter rule and check the nearest preceding <style> tag
+        # carries a nonce attribute.
+        gutter_idx = out.index("scrollbar-gutter")
+        style_open = out.rfind("<style", 0, gutter_idx)
+        assert style_open != -1
+        style_close = out.index(">", style_open)
+        assert "nonce=" in out[style_open:style_close]
+
+    def test_renders_before_bundle_css(self):
+        """Inline gutter rule must precede bundle.css so the user bundle wins
+        the cascade if a project chooses to override it."""
+        out = _render(_make_env())
+        assert out.index("scrollbar-gutter") < out.index("bundle.css")


### PR DESCRIPTION
## Summary

- Adds `html { scrollbar-gutter: stable; }` as a CSP-nonced inline style in `base/skeleton.html.jinja`
- Stops centered chrome from jiggling by the scrollbar's width when navigating between short and long pages (Windows, Linux, macOS with "Always show scrollbars"); no-op on overlay-scrollbar systems
- Inline in the skeleton rather than `config.css` so existing scaffolded projects pick up the fix on a vibetuner upgrade with no CSS rebuild — rendered before `bundle.css` so a project bundle can still override

Closes #1743.

## Test plan

- [x] New `TestScrollbarGutter` covers presence, CSP nonce, and pre-`bundle.css` cascade order
- [x] `uv run python -m pytest tests/unit/` — 797 passed
- [x] `just lint-jinja` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)