### PR TITLE
chore(deps): drop lint-po git pin in favor of PyPI 0.1.5

### DIFF
--- a/vibetuner-template/pyproject.toml.j2
+++ b/vibetuner-template/pyproject.toml.j2
@@ -25,7 +25,7 @@ vibetuner = "vibetuner.cli:app"
 [dependency-groups]
 dev = [
   "vibetuner[dev]",
-  "lint-po",
+  "lint-po>=0.1.5",
 ]
 
 [build-system]
@@ -40,9 +40,5 @@ testpaths = ["tests"]
 cache-keys = [{ file = "pyproject.toml" }]
 
 [tool.uv.sources]
-# Pin to upstream master until himdel/lint-po cuts a PyPI release
-# that includes gettext plural-form support (PRs #3 and #4).
-lint-po = { git = "https://github.com/himdel/lint-po", rev = "efadbcaa50f84135ee4f16efa44d99d2662a74b4" }
-
 # To develop against a local copy of vibetuner-py, add:
 # vibetuner = { path = "packages/vibetuner-py", editable = true }


### PR DESCRIPTION
## Summary

- `lint-po 0.1.5` shipped to PyPI on **2026-05-05** with gettext plural-form support, resolving the upstream release request at [himdel/lint-po#5](https://github.com/himdel/lint-po/issues/5).
- Drops the temporary `[tool.uv.sources]` git pin introduced in #1725 (which closed #1719) and bumps the dev dep to `lint-po>=0.1.5`.
- The justfile recipe and pre-commit hook already use `uv run --frozen lint-po`, so no other changes are needed.

## Test plan

- [x] Confirmed `lint-po==0.1.5` accepts a Babel-generated plural `.po` (`msgid_plural` / `msgstr[0..1]`) — exit 0.
- [x] Confirmed `lint-po==0.1.5` still flags placeholder mismatches in `msgstr[1]` — exit 1, same diagnostic as the pinned SHA.
- [ ] Smoke `just lint-po` and the pre-commit hook on a freshly scaffolded project after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)