### PR TITLE
fix(release): track vibetuner-jinja/package.json in extra-files

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -58,6 +58,7 @@
           "jsonpath": "$.project.version"
         },
         "vibetuner-js/package.json",
+        "vibetuner-jinja/package.json",
         {
           "type": "generic",
           "path": "vibetuner-template/pyproject.toml.j2"


### PR DESCRIPTION
## Summary

The 10.9.0 release PR (#1760) bumped `pyproject.toml`, `vibetuner-py/pyproject.toml`, and `vibetuner-js/package.json`, but not `vibetuner-jinja/package.json`. The entry was meant to be added as part of #1759 (it's even mentioned in that PR's commit message) but the working-tree edit never made it onto the staging step.

Without this entry, release-please leaves `vibetuner-jinja/package.json`'s `version` field stuck at whatever it currently says (`10.8.5`), and the `build-jinja` CI job will tag the published tarball with that stale version on every release.

## Test plan

- [ ] After merging this, release-please should rebase or update PR #1760 and the diff should now include a `vibetuner-jinja/package.json` version bump alongside the existing three.
- [ ] If release-please doesn't auto-rebase, close-and-reopen #1760 (or push an empty commit) to force regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)