### PR TITLE
fix(ci): expose jinja-needed as plan-release job output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
       version: ${{ steps.plan.outputs.version }}
       python-needed: ${{ steps.plan.outputs.python-needed }}
       js-needed: ${{ steps.plan.outputs.js-needed }}
+      jinja-needed: ${{ steps.plan.outputs.jinja-needed }}
       docs-needed: ${{ steps.plan.outputs.docs-needed }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

The `plan-release` step writes `jinja-needed` to `\$GITHUB_OUTPUT`, but the job's `outputs:` block didn't bind it. Downstream jobs evaluated `needs.plan-release.outputs.jinja-needed` to an empty string, didn't match `'true'`, and skipped `build-jinja` + `publish-jinja`.

That's why the 10.9.0 release published Python/JS/docs but not vibetuner-jinja.

## Test plan

- [ ] Merge this
- [ ] Trigger a manual `workflow_dispatch` of `release.yml` with `version=10.9.0` and `force-jinja=true` to publish jinja retroactively
- [ ] Confirm `@alltuner/vibetuner-jinja@10.9.0` lands on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)