### PR TITLE
feat(ci): make all publish jobs idempotent on duplicate versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,7 +608,11 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
 
       - name: Publish to PyPI
-        run: uv publish
+        # `--check-url` makes uv consult the PyPI simple index for an existing
+        # release of the same version+filename and skip the upload if it's
+        # already there. Keeps force-rerun and split-failure-then-rerun
+        # idempotent (see issue #1758).
+        run: uv publish --check-url https://pypi.org/simple/
 
   # Publish JavaScript package
   publish-js:
@@ -640,6 +644,13 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
         run: |
           TARBALL=$(ls alltuner-vibetuner-*.tgz | grep -v '^alltuner-vibetuner-jinja-')
+          # Look up the version from the tarball-internal package.json so the
+          # idempotent skip applies to the exact target we'd otherwise publish.
+          VERSION=$(tar -xOf "$TARBALL" package/package.json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')
+          if npm view "@alltuner/vibetuner@$VERSION" version >/dev/null 2>&1; then
+            echo "@alltuner/vibetuner@$VERSION already on npm — skipping (issue #1758 guard)"
+            exit 0
+          fi
           echo "Publishing $TARBALL with trusted publishing"
           npm publish "./$TARBALL" --access public
 
@@ -673,6 +684,11 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
         run: |
           TARBALL=$(ls alltuner-vibetuner-jinja-*.tgz)
+          VERSION=$(tar -xOf "$TARBALL" package/package.json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')
+          if npm view "@alltuner/vibetuner-jinja@$VERSION" version >/dev/null 2>&1; then
+            echo "@alltuner/vibetuner-jinja@$VERSION already on npm — skipping (issue #1758 guard)"
+            exit 0
+          fi
           echo "Publishing $TARBALL with trusted publishing"
           npm publish "./$TARBALL" --access public
 


### PR DESCRIPTION
## Summary

Phase 0 of the [decoupled-versioning study (#1758)](https://github.com/alltuner/vibetuner/issues/1758): make publish jobs survive a re-run that targets an already-published version, instead of failing on `npm ERR! cannot publish over the previously published versions` / PyPI's equivalent.

We hit this concretely on the 10.9.0 release: a YAML bug in `plan-release` skipped the jinja publish, the fix triggered a force-rerun, and the JS publish failed because `@alltuner/vibetuner@10.9.0` was already on npm.

### Changes

- **`publish-python`** — pass `--check-url https://pypi.org/simple/` to `uv publish`. uv has native support for this: it reads the simple index and skips the upload if the file is already there.
- **`publish-js` / `publish-jinja`** — query `npm view <pkg>@<version> version` before publishing; if the version exists, exit 0 with a clear message instead of invoking `npm publish`. The version is read from the tarball's own `package.json` so the existence check matches the artefact we'd actually upload (no risk of checking against a different version than what's about to be published).

### Why now / why not just decouple

After studying #1758 in detail, this is the cheapest move with the highest ROI: it solves the operational pain we just hit, costs ~17 lines, and is defense-in-depth that we'd want to keep *even after* full per-package decoupling (manual reruns and force flags still happen). Full decoupling has a bigger blast radius (tag-format change, PR-title-scoping convention, multiple changelogs) and isn't justified by today's pain alone — so deferred per the discussion on #1758.

### Test plan

- [ ] Merge this. The next release-please release PR will exercise the regular path and confirm nothing regressed for first-time publishes.
- [ ] Trigger a manual `workflow_dispatch` with `version=10.9.0` and `force-jinja=true` (or any other force flag). Without this fix the prior run failed; with this fix all three publishes should now no-op cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)