### PR TITLE
docs: note tailwind v4 config.css watch quirk in template AGENTS.md

### DIFF
--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -146,6 +146,12 @@ just dev                     # Docker development
 Key commands: `just format` (all code), `just lint` (all code),
 `just format-py` (Python only), `just i18n` (translations).
 
+> **Tailwind v4 watcher quirk:** if you edit `config.css`, restart
+> `just dev` / `just local-all` — Tailwind v4 doesn't watch its own
+> input file. Edits to templates and other `@source`-listed
+> directories rebuild correctly without restart. Tracked upstream at
+> [tailwindlabs/tailwindcss#14726](https://github.com/tailwindlabs/tailwindcss/issues/14726).
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## Summary

Editing `config.css` in a scaffolded project doesn't trigger a tailwind rebuild — by design in tailwind v4 (CSS-first config means `@source`-listed dirs are watched, the input file itself isn't). Tracked upstream at [tailwindlabs/tailwindcss#14726](https://github.com/tailwindlabs/tailwindcss/issues/14726).

Add a short note in the Quick Start section of `vibetuner-template/AGENTS.md` so anyone hitting the silence sees a clear instruction.

Closes #1757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)