### PR TITLE
docs: note stale-CI-on-release-PR wart and the App-token escape hatch

### DIFF
--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -116,6 +116,17 @@ Add `!` for breaking changes (e.g., `feat!:`). PR titles become squash
 commit messages. Release Please auto-generates changelogs. Versioning
 via git tags + `uv-dynamic-versioning`.
 
+> **Stale CI on release PRs:** the scaffolded `release.yml` regenerates
+> `uv.lock` after Release Please bumps `pyproject.toml`, then pushes the
+> fix back to the PR branch with the default `GITHUB_TOKEN`. GitHub's
+> anti-loop protection swallows that push, so no fresh CI runs on the
+> lock-update commit — the PR's checks reflect the *pre*-regeneration
+> state. Harmless if your merge gates aren't lockfile-sensitive.
+> If you gate merge on `uv sync --frozen` (or any check that reads
+> `uv.lock`), swap `GITHUB_TOKEN` for a [GitHub App token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation)
+> via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)
+> in the checkout + push steps so the regenerated commit triggers CI normally.
+
 ---
 
 ## Updating Scaffolding


### PR DESCRIPTION
## Summary

The scaffolded `release.yml` has regenerated `uv.lock` after Release Please bumps `pyproject.toml` since #1303 (refined in #1433 and #1687) — so the substantive ask in #1742 is already shipped. The remaining wart is GitHub's anti-loop rule: pushes made with the default `GITHUB_TOKEN` don't re-trigger workflows, so the PR's check tab keeps showing the *pre*-regen state.

For vibetuner itself this is harmless — none of our gating checks are lockfile-sensitive. For consumers who gate merge on `uv sync --frozen` (or any check that reads `uv.lock`), it blocks the merge with stale CI.

Doc note in `vibetuner-template/AGENTS.md`'s "PR Titles & Releases" section explaining:
- What the wart is
- Why it's usually harmless
- How to fix it if it bites: swap `GITHUB_TOKEN` for a GitHub App token via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) in the checkout + push steps

Closes #1742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)