### PR TITLE
fix(ci): make deps-pr cleanup robust and PR self-documenting

### DIFF
--- a/.justfiles/deps.justfile
+++ b/.justfiles/deps.justfile
@@ -62,11 +62,20 @@ deps-pr:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    # Capture the repo root before any cd. The cleanup trap needs a git
+    # repo in cwd to invoke `git worktree remove`; cd-ing to / (as we did
+    # previously) put the trap outside any repo and it bailed with exit
+    # 128 on every run, leaving worktrees and local branches behind.
+    REPO_ROOT=$(git rev-parse --show-toplevel)
     DATE_STAMP=$(date +%Y-%m-%d)
     BRANCH="chore/update-deps-${DATE_STAMP}-$(date +%H%M)"
     WORKTREE_DIR=$(mktemp -d)
 
-    cleanup() { cd /; git worktree remove --force "$WORKTREE_DIR" 2>/dev/null; git branch -D "$BRANCH" 2>/dev/null || true; }
+    cleanup() {
+        cd "$REPO_ROOT"
+        git worktree remove --force "$WORKTREE_DIR" || true
+        git branch -D "$BRANCH" 2>/dev/null || true
+    }
     trap cleanup EXIT
 
     git fetch origin main
@@ -81,7 +90,22 @@ deps-pr:
         exit 0
     fi
 
+    # Build a self-documenting PR body: the commit subjects produced by
+    # update-and-commit (one for prek auto-update, one for the actual
+    # dependency bumps) plus a diffstat against main so reviewers can see
+    # at a glance which lockfiles / manifests moved.
+    PR_BODY=$(printf "## Updated\n\n%s\n\n## Files\n\n\`\`\`\n%s\n\`\`\`\n" \
+        "$(git log --reverse --pretty=format:'- %s' "origin/main..HEAD")" \
+        "$(git diff --stat "origin/main..HEAD")")
+
     git push -u origin "$BRANCH"
-    gh pr create --title "chore: update deps ${DATE_STAMP}" --body "" --base main
-    gh pr merge --squash --subject "chore: update deps ${DATE_STAMP}"
+    gh pr create --title "chore: update deps ${DATE_STAMP}" --body "$PR_BODY" --base main
+    # --auto queues the squash-merge for when required checks pass. Today
+    # nothing required-blocks merge so this returns immediately, but it
+    # makes the recipe robust against future branch protection rules.
+    gh pr merge --auto --squash --subject "chore: update deps ${DATE_STAMP}"
+    # Remote branch deletion is handled by GitHub's auto-delete-on-merge
+    # setting; if it's off this is the fallback. Failure is fine — the
+    # branch may already be gone or the merge may not have completed yet
+    # (under --auto we return before merge lands).
     git push origin --delete "$BRANCH" 2>/dev/null || true


### PR DESCRIPTION
## Summary

The `just deps-pr` recipe has been silently leaving orphan worktrees and local branches behind on every run since April. Yesterday's run produced this output:

```
remote: ...
https://github.com/alltuner/vibetuner/pull/1767
error: Recipe `deps-pr` failed with exit code 128
```

PR was created and merged fine; the recipe still exited 128.

### Root cause

The cleanup trap did `cd /` before invoking `git worktree remove`. Outside any git repository the worktree command exits 128 with `fatal: not a git repository`, and there's no `|| true` on it (only on the `git branch -D`), so the failure propagates as the script's final exit. Net effect: every `just deps-pr` run leaves an orphan worktree + local branch behind even though the actual PR is created and merged successfully.

Four leftover worktrees had accumulated since the last successful invocation in April. (Manually cleaned out before this PR.)

### Fix

- Capture `REPO_ROOT` before any `cd`, have cleanup return there so git operations have a repo context.
- Add `|| true` to the worktree remove so a still-busy worktree (or an already-pruned one) can't override the script's exit code.

### Drive-by improvements you said you wanted

- `gh pr merge --auto --squash` instead of plain `--squash`. Functionally identical today (no required checks block merge), but lets future branch protection rules queue rather than reject the merge.
- Self-documenting PR body: the commit subjects produced by `update-and-commit` (the `prek auto-update` commit + the `update dependencies` commit) plus a `git diff --stat` against main, so the PR is reviewable from its own description without clicking through to the file changes.

### Test plan

- [ ] Merge this. Next `just deps-pr` invocation should:
  1. Exit 0 cleanly.
  2. Leave no orphan worktree (`git worktree list` should not show any `chore/update-deps-*` entries afterwards).
  3. Open a PR with a populated body (no more `Body: (empty)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)