### PR TITLE
feat(htmx): prepare framework templates for hx-nonce extension

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -699,6 +699,54 @@ Configure extra allowed sources via environment variables:
 | `CSP_EXTRA_MEDIA_SRC` | Additional media sources |
 | `CSP_ENFORCE_CSP_IN_DEBUG` | Enforce CSP in debug mode (default: `true`) |
 
+### htmx Nonce Protection (opt-in)
+
+htmx 4.0.0-beta3 ships an `hx-nonce` extension that gates htmx attribute
+processing behind the page CSP nonce. Elements without a matching
+`hx-nonce` attribute are stripped at init time, providing a
+defence-in-depth layer against HTML injection attacks: even if an
+attacker manages to inject HTML, the browser will not honour any
+`hx-get`/`hx-post`/etc. attributes on injected elements.
+
+The framework's templates already stamp `hx-nonce="{{ csp_nonce }}"` on
+their htmx-bearing elements, so the extension is safe to enable from a
+fresh project as soon as you mirror the pattern in your own templates.
+
+**To enable:**
+
+1. Add the import to your `config.js` custom imports section:
+
+    ```javascript
+    // Add your custom imports below:
+    import "./node_modules/htmx.org/dist/ext/hx-nonce.js";
+    ```
+
+2. Add `hx-nonce="{{ csp_nonce }}"` to every element in your templates
+   that uses any `hx-*` attribute:
+
+    ```html
+    <button hx-post="/save"
+            hx-target="#main-content"
+            hx-nonce="{{ csp_nonce }}">Save</button>
+    ```
+
+The extension reads the page nonce from the first `<script nonce>`
+element on the page. Vibetuner's `SecurityHeadersMiddleware` already
+stamps that nonce on your bundle script, so no extra wiring is required.
+
+**Trusted Types (further hardening):** Once the extension is enabled
+you can also tell the browser to refuse non-htmx HTML sinks by adding
+`require-trusted-types-for 'script'; trusted-types htmx` to your CSP.
+Configure this via `CSP_EXTRA_*` if you need to merge it with other
+directives, or extend `SecurityHeadersMiddleware` directly.
+
+**Safe eval:** vibetuner's CSP does not include `'unsafe-eval'`, so any
+htmx feature that requires `eval` (e.g. `hx-vals` with the `js:` prefix,
+`hx-on:` handlers that reference globals) will be blocked by default.
+If you use those features, set `safeEval:true` in your htmx config —
+the extension replaces htmx's `new Function()` eval with nonce-based
+script injection so the features work without `unsafe-eval`.
+
 ## Working with HTMX
 
 Vibetuner uses HTMX for interactive features without JavaScript:

--- a/vibetuner-py/src/vibetuner/templates/frontend/user/profile.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/user/profile.html.jinja
@@ -108,7 +108,8 @@
                                 <button class="btn btn-primary"
                                         hx-get="/user/edit"
                                         hx-target="#main-content"
-                                        hx-swap="innerHTML">{{ _("Edit Profile") }}</button>
+                                        hx-swap="innerHTML"
+                                        hx-nonce="{{ csp_nonce }}">{{ _("Edit Profile") }}</button>
                                 <a href="{{ url_for('auth_logout') }}" class="btn btn-outline btn-error">{{ _("Sign Out") }}</a>
                             </div>
                         </div>

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -67,6 +67,17 @@ directly to elements or use `hx-on` attributes.
 See the [HTMX migration guide](https://vibetuner.alltuner.com/htmx-migration/)
 for full details.
 
+## htmx Nonce Protection (opt-in)
+
+The `hx-nonce` extension (htmx 4.0.0-beta3+) gates htmx attribute
+processing behind the page CSP nonce. Framework templates already
+stamp `hx-nonce="{{ csp_nonce }}"` on htmx-bearing elements; mirror
+that pattern in your own templates if you enable the extension.
+Add `import "./node_modules/htmx.org/dist/ext/hx-nonce.js";` to your
+`config.js` custom imports section. Elements without a matching
+`hx-nonce` will be stripped (fail-closed). See the
+[CSP/htmx docs](https://vibetuner.alltuner.com/development-guide/#htmx-nonce-protection-opt-in).
+
 ## Response Caching (Server-Side)
 
 `from vibetuner.cache import cache, invalidate, invalidate_pattern`.


### PR DESCRIPTION
## Summary

- htmx 4.0.0-beta3 ships an `hx-nonce` extension that gates htmx attribute processing behind the page CSP nonce. Elements without a matching `hx-nonce` are stripped at init time — defence-in-depth against HTML injection.
- Vibetuner already enforces a nonce-based CSP via `SecurityHeadersMiddleware`, so the extension is a natural fit. This PR makes the framework's templates ready to opt in.
- Stamps `hx-nonce="{{ csp_nonce }}"` on the framework's single htmx-bearing element (Edit Profile button in `user/profile.html.jinja`). The attribute is a no-op when the extension is not loaded — non-breaking.
- Documents the opt-in pattern in `development-guide.md` under the CSP section, and adds a brief reference in `vibetuner-template/.claude/rules/frontend.md`.

## Why opt-in (not auto-enabled)?

Enabling the extension would require every `hx-*` element in user templates to also carry `hx-nonce`. That's a meaningful migration burden for existing projects and shouldn't be flipped silently. We document it; users decide.

## Why not auto-inject in middleware?

Considered but rejected for now: regex-injecting `hx-nonce` over response bodies is fragile, has performance cost, and is hard to audit. If we want this later we can add it as a config flag — but the explicit-attribute approach matches the upstream htmx documentation and keeps templates auditable.

## Follow-ups

- Once `style-src 'unsafe-inline'` is dropped (separate PR), this becomes part of the broader CSP hardening story.
- If users widely enable the extension, evaluate adding an opt-in middleware auto-injector later.

## Test plan

- [x] `uv run pytest tests/unit/` — 793 passed
- [x] Pre-commit hooks pass (djlint, rumdl, ruff, etc.)
- [ ] Spot-check rendered docs site for the new CSP section
- [ ] Manually enable the extension in a scaffolded project and verify the Edit Profile button still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)