### PR TITLE
feat(security): add CSP_STYLE_SRC_STRICT to drop 'unsafe-inline' from style-src

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -698,6 +698,34 @@ Configure extra allowed sources via environment variables:
 | `CSP_EXTRA_FONT_SRC` | Additional font sources |
 | `CSP_EXTRA_MEDIA_SRC` | Additional media sources |
 | `CSP_ENFORCE_CSP_IN_DEBUG` | Enforce CSP in debug mode (default: `true`) |
+| `CSP_STYLE_SRC_STRICT` | Use the request nonce on `style-src` instead of `'unsafe-inline'` (default: `false`) |
+
+### Strict `style-src` (opt-in)
+
+By default, `style-src` is `'self' 'unsafe-inline'` so that inline
+`style="..."` attributes and unnonced `<style>` tags work. This is the
+permissive baseline that lets existing templates ship without changes.
+
+Set `CSP_STYLE_SRC_STRICT=true` to switch `style-src` to
+`'self' 'nonce-<request-nonce>'`. This is a meaningful hardening:
+inline `style="..."` attributes will be **blocked by the browser**,
+and every `<style>` tag must carry `nonce="{{ csp_nonce }}"`.
+
+The framework's own templates already follow this pattern (the inline
+styles in `skeleton.html.jinja` and `theme.html.jinja` are nonced; the
+htmx 4.0.0-beta3 indicator stylesheet uses a constructable
+`CSSStyleSheet` which does not need `'unsafe-inline'`). Before flipping
+this flag in your project:
+
+1. Audit your templates for `style="..."` attributes — convert to
+   utility classes or scoped `<style>` blocks.
+2. Make sure every `<style>` tag carries `nonce="{{ csp_nonce }}"`.
+3. Test interactively: open the browser devtools and look for CSP
+   violations on hover/focus/error states (these often have inline
+   styles set by JS).
+
+This default may flip to `true` in a future major version once the
+ecosystem has had time to migrate.
 
 ## Working with HTMX
 

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -104,6 +104,7 @@ class SecurityHeadersSettings(BaseSettings):
     extra_media_src: str = ""
     frame_ancestors: str = "'self'"
     enforce_csp_in_debug: bool = True
+    style_src_strict: bool = False
 
     model_config = SettingsConfigDict(
         case_sensitive=False,

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -122,7 +122,10 @@ class SecurityHeadersMiddleware:
         if config.extra_script_src:
             script_src += f" {config.extra_script_src}"
 
-        style_src = "'self' 'unsafe-inline'"
+        if config.style_src_strict:
+            style_src = f"'self' 'nonce-{nonce}'"
+        else:
+            style_src = "'self' 'unsafe-inline'"
         if config.extra_style_src:
             style_src += f" {config.extra_style_src}"
 

--- a/vibetuner-py/tests/unit/test_security_headers_middleware.py
+++ b/vibetuner-py/tests/unit/test_security_headers_middleware.py
@@ -23,6 +23,7 @@ class _SecurityHeadersConfig:
     extra_media_src: str = ""
     frame_ancestors: str = "'self'"
     enforce_csp_in_debug: bool = True
+    style_src_strict: bool = False
 
 
 @dataclass
@@ -58,7 +59,10 @@ class SecurityHeadersMiddleware:
         if config.extra_script_src:
             script_src += f" {config.extra_script_src}"
 
-        style_src = "'self' 'unsafe-inline'"
+        if config.style_src_strict:
+            style_src = f"'self' 'nonce-{nonce}'"
+        else:
+            style_src = "'self' 'unsafe-inline'"
         if config.extra_style_src:
             style_src += f" {config.extra_style_src}"
 
@@ -331,6 +335,37 @@ class TestSecurityHeadersMiddleware:
         resp = client.get("/")
         csp = resp.headers["Content-Security-Policy"]
         assert "'strict-dynamic'" in csp
+
+    def test_style_src_default_allows_unsafe_inline(self):
+        """By default, style-src includes 'unsafe-inline' for backwards compatibility."""
+        app = _make_app()
+        client = TestClient(app)
+        resp = client.get("/")
+        csp = resp.headers["Content-Security-Policy"]
+        assert "style-src 'self' 'unsafe-inline'" in csp
+
+    def test_style_src_strict_uses_nonce(self):
+        """When style_src_strict is enabled, style-src uses the request nonce instead of 'unsafe-inline'."""
+        config = _SecurityHeadersConfig(style_src_strict=True)
+        app = _make_app(settings=_Settings(security_headers=config))
+        client = TestClient(app)
+        resp = client.get("/")
+        csp = resp.headers["Content-Security-Policy"]
+        assert "'unsafe-inline'" not in csp.split("style-src")[1].split(";")[0]
+        assert re.search(r"style-src 'self' 'nonce-[\w-]+'", csp)
+
+    def test_style_src_strict_appends_extra_style_src(self):
+        """Extra style-src sources are appended in strict mode too."""
+        config = _SecurityHeadersConfig(
+            style_src_strict=True,
+            extra_style_src="https://fonts.googleapis.com",
+        )
+        app = _make_app(settings=_Settings(security_headers=config))
+        client = TestClient(app)
+        resp = client.get("/")
+        csp = resp.headers["Content-Security-Policy"]
+        assert "https://fonts.googleapis.com" in csp
+        assert "'unsafe-inline'" not in csp.split("style-src")[1].split(";")[0]
 
 
 class TestCspNonceAutoInjection:


### PR DESCRIPTION
## Summary

- Adds a new `CSP_STYLE_SRC_STRICT` env var (default `false`) on `SecurityHeadersSettings`. When enabled, `style-src` switches from `'self' 'unsafe-inline'` to `'self' 'nonce-<request-nonce>'`.
- htmx 4.0.0-beta3 already ships its indicator CSS via a constructable `CSSStyleSheet` and switched the pantry element from inline `style` to `hidden` — there are no remaining htmx-side reasons to keep `'unsafe-inline'` on `style-src`.
- The framework's own templates already nonce every `<style>` tag (`skeleton.html.jinja:28`, `theme.html.jinja:14`), so a strict style-src works out of the box for the framework. The flag is opt-in because user templates may still rely on inline `style="..."` attributes which are blocked under nonce-only `style-src`.
- Documents the new flag and the migration steps in `development-guide.md`.

## Why opt-in (not flip the default)?

Removing `'unsafe-inline'` is a meaningful breaking change for any user template that uses inline `style="..."` attributes (those are blocked under nonce-only style-src — nonces don't cover style attributes). Shipping this as opt-in lets CSP-conscious users harden their setup today; the default may flip in a future major version once the ecosystem migrates.

## Test plan

- [x] `uv run pytest tests/unit/test_security_headers_middleware.py` — 28 passed (3 new tests for strict mode)
- [x] `uv run pytest tests/unit/` — 796 passed
- [x] Pre-commit hooks pass (ruff, rumdl, etc.)
- [ ] Manually flip `CSP_STYLE_SRC_STRICT=true` in a scaffolded project and verify no CSP violations on the default pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)