### PR TITLE
docs: sync llms.txt, llms-full.txt, and frontend rules with htmx beta3

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1816,6 +1816,22 @@ instead. Configure extra sources via `CSP_EXTRA_SCRIPT_SRC`,
 `CSP_EXTRA_STYLE_SRC`, `CSP_EXTRA_IMG_SRC`, `CSP_EXTRA_CONNECT_SRC`,
 `CSP_EXTRA_FONT_SRC`, `CSP_EXTRA_MEDIA_SRC` environment variables.
 
+**Strict `style-src` (opt-in):** Set `CSP_STYLE_SRC_STRICT=true` to drop
+`'unsafe-inline'` from `style-src` and use the request nonce instead.
+Inline `style="..."` attributes will be blocked by the browser and every
+`<style>` tag must carry `nonce="{{ csp_nonce }}"`. Framework templates
+already follow this pattern; htmx 4.0.0-beta3's indicator stylesheet
+uses a constructable `CSSStyleSheet` so no inline style is needed there
+either. Audit user templates for inline `style="..."` before flipping.
+
+**htmx Nonce Protection (opt-in):** htmx 4.0.0-beta3 ships an `hx-nonce`
+extension that strips htmx attributes from elements without a matching
+`hx-nonce`. Stamp `hx-nonce="{{ csp_nonce }}"` on every htmx-bearing
+element and add `import "htmx.org/dist/ext/hx-nonce.js";` to `config.js`
+custom imports. Framework templates already include the attribute. Useful
+defence-in-depth even though vibetuner already enforces strict
+script-src.
+
 ### Background Tasks
 
 Run long-running or scheduled work outside the request cycle using Vibetuner's
@@ -2232,6 +2248,46 @@ import "htmx.org/dist/ext/hx-preload.js";
 - Update JS imports to use default import and `window.htmx = htmx`
 - Update preload extension import path
 - Remove `htmx-ext-sse` and `htmx-ext-preload` from `package.json`
+
+#### Beta3 Additions
+
+htmx 4.0.0-beta3 (the 4.0 release candidate) ships several additions
+relevant to vibetuner projects:
+
+- **`hx-nonce` extension** — gates htmx attribute processing behind the
+  page CSP nonce. Stamp `hx-nonce="{{ csp_nonce }}"` on every htmx-bearing
+  element and import `htmx.org/dist/ext/hx-nonce.js` in `config.js` to
+  enable. Framework templates already follow the pattern. Elements
+  without a matching nonce are stripped (fail-closed)
+- **`hx-live` extension** — DOM-reactivity via `hx-live="..."` plus a
+  richer `hx-on` JS surface (`q()`, `toggle()`, `debounce()`). Note:
+  `htmx.takeClass` and `htmx.forEvent` moved out of core into this
+  extension (now `htmx.live.take(...)` etc.)
+- **`hx-history-elt` restored** — was removed in earlier 4.x pre-releases,
+  brought back in beta3 alongside an improved `hx-history-cache`
+  extension
+- **`htmx:response:error` event** — fires for HTTP 4xx/5xx responses,
+  restoring htmx 2's `htmx:responseError` convenience
+- **`outerSync` swap style** — copies attributes onto target and replaces
+  children, useful for clean `<body>` swaps in history replacement
+- **`htmx.config.prefix` defaults to `"data-hx-"`** — both `hx-*` and
+  `data-hx-*` work out of the box. Framework uses the canonical `hx-*`;
+  no change needed
+- **`hx-download` auto-detection** — extension now triggers a download
+  when the response carries a `Content-Disposition` header, no per-element
+  attribute required
+- **`hx-preload` boost knobs** — added `boostEvent`, `boostTimeout`,
+  `autoBoost` config keys for tighter `hx-boost` integration
+- **Constructable indicator stylesheet** — htmx now uses a
+  `CSSStyleSheet` instance for its indicator CSS, removing the last
+  htmx-side reason to allow `'unsafe-inline'` on `style-src`. Pair with
+  `CSP_STYLE_SRC_STRICT=true` to drop `'unsafe-inline'`
+- **`hx-config` mode override removed** — security fix preventing a
+  swap from downgrading origin enforcement
+- **`hx-on::` shorthand fixed** — works in beta1+ (was broken in alpha8)
+
+See [HTMX v2 to v4 Migration Guide](https://vibetuner.alltuner.com/htmx-migration/)
+for the full list and the dedicated "Beta1 to Beta3 Changes" section.
 
 ### Import Ordering in tune.py
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -112,7 +112,14 @@ Important notes:
   CSP is enforced in both production and debug mode by default so violations break the
   page locally; set `CSP_ENFORCE_CSP_IN_DEBUG=false` to fall back to
   `Content-Security-Policy-Report-Only` in debug. Configure extra sources via `CSP_*`
-  environment variables (e.g., `CSP_EXTRA_SCRIPT_SRC`)
+  environment variables (e.g., `CSP_EXTRA_SCRIPT_SRC`). Set `CSP_STYLE_SRC_STRICT=true`
+  to drop `'unsafe-inline'` from `style-src` and require nonces on `<style>` tags
+  (opt-in hardening; framework templates already nonce every `<style>`)
+- **htmx Nonce Protection (opt-in)**: htmx 4.0.0-beta3 ships an `hx-nonce` extension
+  that gates htmx attribute processing behind the page CSP nonce. Framework templates
+  stamp `hx-nonce="{{ csp_nonce }}"` on htmx-bearing elements; mirror that pattern in
+  user templates and add `import "htmx.org/dist/ext/hx-nonce.js";` to `config.js` to
+  enable. Elements without a matching `hx-nonce` are stripped (fail-closed)
 - **Health Checks**: `/health`, `/health/ping`, `/health/ready`, `/health/id` endpoints
   with service connectivity checks
 - **Robust Tasks**: `@robust_task()` decorator with exponential backoff retries and

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -43,13 +43,12 @@ htmx 4 changed event handling significantly. Key differences:
 **Event names** use colon-separated format (not camelCase):
 `htmx:after:request`, `htmx:before:swap`, `htmx:after:settle`.
 
-**`hx-on` attributes** — the `hx-on::` shorthand is broken in
-alpha8. Use the explicit long form:
+**`hx-on` attributes** — the `hx-on::` shorthand works in beta1+
+(it was broken in alpha8). Both forms are valid:
 
 ```html
-<!-- BROKEN: hx-on::after-request="..." -->
-<!-- WORKS: -->
 <form hx-on:htmx:after:request="this.reset()">
+<form hx-on::after-request="this.reset()">
 ```
 
 **`event.detail`** was restructured. `event.detail.successful` no


### PR DESCRIPTION
## Summary

Catches up the LLM-targeted docs (`llms.txt`, `llms-full.txt`) and the scaffolded `vibetuner-template/.claude/rules/frontend.md` with the htmx beta3 features that landed in #1771, #1773, and #1774. The project's `CLAUDE.md` requires every feature PR to update those alongside the docs site, and I missed them in the original three.

- **`llms.txt`** — extends the CSP bullet with `CSP_STYLE_SRC_STRICT` and adds an `hx-nonce` opt-in bullet
- **`llms-full.txt`** — adds strict style-src + hx-nonce paragraphs to the Security Headers section, and a "Beta3 Additions" subsection under the HTMX migration coverage
- **`vibetuner-template/.claude/rules/frontend.md`** — drops the stale "`hx-on::` shorthand is broken in alpha8" claim (works in beta1+)

## Test plan

- [x] `rumdl` lint passes (pre-commit)
- [x] No new long-line violations in edited regions
- [ ] Spot-check rendered docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)