### PR TITLE
docs: gate htmx-nonce + strict style-src behind a min-version note

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -702,6 +702,14 @@ Configure extra allowed sources via environment variables:
 
 ### htmx Nonce Protection (opt-in)
 
+!!! note "Requires `@alltuner/vibetuner` ≥ 10.11.0"
+    The `hx-nonce` extension file ships with `htmx.org@4.0.0-beta3`, which
+    is pulled transitively by `@alltuner/vibetuner@10.11.0` and later. On
+    older versions the bundler will fail with
+    `Could not resolve "./node_modules/htmx.org/dist/ext/hx-nonce.js"`.
+    Bump `@alltuner/vibetuner` in `package.json` and re-run `bun install`
+    before enabling.
+
 htmx 4.0.0-beta3 ships an `hx-nonce` extension that gates htmx attribute
 processing behind the page CSP nonce. Elements without a matching
 `hx-nonce` attribute are stripped at init time, providing a
@@ -749,6 +757,14 @@ the extension replaces htmx's `new Function()` eval with nonce-based
 script injection so the features work without `unsafe-eval`.
 
 ### Strict `style-src` (opt-in)
+
+!!! note "Requires `vibetuner` ≥ 10.11.0"
+    `SecurityHeadersSettings` only learned about `CSP_STYLE_SRC_STRICT`
+    in 10.11.0. On older releases the env var is silently ignored
+    (pydantic's `extra="ignore"` discards unknown CSP options), so the
+    `style-src` directive keeps emitting `'unsafe-inline'` without any
+    warning. Bump `vibetuner` in `pyproject.toml` and re-run `uv sync`
+    before relying on the flag.
 
 By default, `style-src` is `'self' 'unsafe-inline'` so that inline
 `style="..."` attributes and unnonced `<style>` tags work. This is the

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1816,21 +1816,27 @@ instead. Configure extra sources via `CSP_EXTRA_SCRIPT_SRC`,
 `CSP_EXTRA_STYLE_SRC`, `CSP_EXTRA_IMG_SRC`, `CSP_EXTRA_CONNECT_SRC`,
 `CSP_EXTRA_FONT_SRC`, `CSP_EXTRA_MEDIA_SRC` environment variables.
 
-**Strict `style-src` (opt-in):** Set `CSP_STYLE_SRC_STRICT=true` to drop
-`'unsafe-inline'` from `style-src` and use the request nonce instead.
-Inline `style="..."` attributes will be blocked by the browser and every
-`<style>` tag must carry `nonce="{{ csp_nonce }}"`. Framework templates
-already follow this pattern; htmx 4.0.0-beta3's indicator stylesheet
-uses a constructable `CSSStyleSheet` so no inline style is needed there
-either. Audit user templates for inline `style="..."` before flipping.
+**Strict `style-src` (opt-in, requires `vibetuner` ≥ 10.11.0):** Set
+`CSP_STYLE_SRC_STRICT=true` to drop `'unsafe-inline'` from `style-src`
+and use the request nonce instead. Inline `style="..."` attributes will
+be blocked by the browser and every `<style>` tag must carry
+`nonce="{{ csp_nonce }}"`. Framework templates already follow this
+pattern; htmx 4.0.0-beta3's indicator stylesheet uses a constructable
+`CSSStyleSheet` so no inline style is needed there either. Audit user
+templates for inline `style="..."` before flipping. On older releases
+the env var is silently ignored, so bump `vibetuner` in `pyproject.toml`
+and re-run `uv sync` first.
 
-**htmx Nonce Protection (opt-in):** htmx 4.0.0-beta3 ships an `hx-nonce`
-extension that strips htmx attributes from elements without a matching
-`hx-nonce`. Stamp `hx-nonce="{{ csp_nonce }}"` on every htmx-bearing
-element and add `import "htmx.org/dist/ext/hx-nonce.js";` to `config.js`
-custom imports. Framework templates already include the attribute. Useful
-defence-in-depth even though vibetuner already enforces strict
-script-src.
+**htmx Nonce Protection (opt-in, requires `@alltuner/vibetuner` ≥ 10.11.0):**
+htmx 4.0.0-beta3 ships an `hx-nonce` extension that strips htmx
+attributes from elements without a matching `hx-nonce`. Stamp
+`hx-nonce="{{ csp_nonce }}"` on every htmx-bearing element and add
+`import "htmx.org/dist/ext/hx-nonce.js";` to `config.js` custom imports.
+Framework templates already include the attribute. Useful defence-in-depth
+even though vibetuner already enforces strict script-src. The extension
+file only ships with `htmx.org@4.0.0-beta3`, pulled transitively by
+`@alltuner/vibetuner` 10.11.0+; on older versions the bundler errors
+with `Could not resolve "./node_modules/htmx.org/dist/ext/hx-nonce.js"`.
 
 ### Background Tasks
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -114,12 +114,15 @@ Important notes:
   `Content-Security-Policy-Report-Only` in debug. Configure extra sources via `CSP_*`
   environment variables (e.g., `CSP_EXTRA_SCRIPT_SRC`). Set `CSP_STYLE_SRC_STRICT=true`
   to drop `'unsafe-inline'` from `style-src` and require nonces on `<style>` tags
-  (opt-in hardening; framework templates already nonce every `<style>`)
+  (opt-in hardening; framework templates already nonce every `<style>`). Requires
+  `vibetuner` ≥ 10.11.0 (older releases silently ignore the env var)
 - **htmx Nonce Protection (opt-in)**: htmx 4.0.0-beta3 ships an `hx-nonce` extension
   that gates htmx attribute processing behind the page CSP nonce. Framework templates
   stamp `hx-nonce="{{ csp_nonce }}"` on htmx-bearing elements; mirror that pattern in
   user templates and add `import "htmx.org/dist/ext/hx-nonce.js";` to `config.js` to
-  enable. Elements without a matching `hx-nonce` are stripped (fail-closed)
+  enable. Elements without a matching `hx-nonce` are stripped (fail-closed). Requires
+  `@alltuner/vibetuner` ≥ 10.11.0 (older releases pull `htmx.org@4.0.0-beta2` which
+  does not ship the extension file)
 - **Health Checks**: `/health`, `/health/ping`, `/health/ready`, `/health/id` endpoints
   with service connectivity checks
 - **Robust Tasks**: `@robust_task()` decorator with exponential backoff retries and


### PR DESCRIPTION
Closes #1778.

## Summary

Both htmx-nonce and `CSP_STYLE_SRC_STRICT` were documented in the same wave that introduced them (#1773, #1774, #1776), but they don't yet work on a freshly scaffolded project today because the released packages predate those PRs:

- `@alltuner/vibetuner@10.10.0` on npm pulls `htmx.org@4.0.0-beta2`, which doesn't ship `dist/ext/hx-nonce.js`. The bundler fails with `Could not resolve "./node_modules/htmx.org/dist/ext/hx-nonce.js"`.
- `vibetuner==10.10.0` on PyPI predates the `style_src_strict` settings field. Pydantic's `extra="ignore"` swallows `CSP_STYLE_SRC_STRICT` silently; the CSP header keeps emitting `'unsafe-inline'`.

Both self-resolve as soon as release-please cuts 10.11.0. Until then, point readers at the version requirement so they don't burn time debugging.

This adds:

- An admonition note above each opt-in subsection in `development-guide.md` calling out the minimum version and the failure mode users will see.
- The same min-version constraint inline in `llms-full.txt` and `llms.txt`, since those are LLM-targeted and need to be self-contained.

No framework code changes. Confirmed during the post-merge smoke test (issue #1778) that with the framework installed editable from `main`, both opt-ins work end-to-end: strict CSP becomes `style-src 'self' 'nonce-…'`, the bundle build succeeds, and `htmx:security:strip`/`htmx:security:violation` identifiers all appear in `bundle.js`.

## Test plan

- [x] `rumdl` lint passes (pre-commit)
- [x] No new long-line violations in edited regions
- [ ] Spot-check rendered docs site (admonitions look reasonable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)