### PR TITLE
fix(scaffolding): stop deps-scaffolding from matching its own grep pattern

### DIFF
--- a/vibetuner-template/.justfiles/scaffolding.justfile
+++ b/vibetuner-template/.justfiles/scaffolding.justfile
@@ -6,9 +6,11 @@ update-scaffolding:
     @echo "Updating project scaffolding..."
     @uvx copier update -A --trust
 
-    # Check package.json and conditionally install
+    # Check package.json and conditionally install.
+    # Pattern is split via adjacent quoted strings so this file doesn't match
+    # itself when deps-scaffolding scans the worktree for conflict markers.
     @if [ -f package.json ]; then \
-        if grep -q "<<<<<<<\|=======\|>>>>>>>" package.json; then \
+        if grep -q "<""<""<""<""<""<""<\|=""=""=""=""=""=""=\|>"">"">"">"">"">"">" package.json; then \
             echo "⚠️  Conflicts detected in package.json - skipping bun install"; \
             echo "Please resolve conflicts manually and run: bun install"; \
         else \
@@ -19,7 +21,7 @@ update-scaffolding:
 
     # Check pyproject.toml and conditionally sync
     @if [ -f pyproject.toml ]; then \
-        if grep -q "<<<<<<<\|=======\|>>>>>>>" pyproject.toml; then \
+        if grep -q "<""<""<""<""<""<""<\|=""=""=""=""=""=""=\|>"">"">"">"">"">"">" pyproject.toml; then \
             echo "⚠️  Conflicts detected in pyproject.toml - skipping uv sync"; \
             echo "Please resolve conflicts manually and run: uv sync --all-extras"; \
         else \


### PR DESCRIPTION
## Summary

- Splits the `<<<<<<<` / `=======` / `>>>>>>>` literals in `vibetuner-template/.justfiles/scaffolding.justfile`'s two `grep -q` patterns via adjacent quoted strings, mirroring the trick already used in `deps.justfile`'s `CONFLICT_MARKER`.
- Without this, `deps-scaffolding`'s tree-wide marker scan always found `scaffolding.justfile` itself and exited 2 with a false-positive "Scaffolding update produced conflicts" message on every run — even when Copier produced no conflicts.

Fixes #1785

## Test plan

- [x] Verify the patched file no longer contains the literal `<<<<<<<` pattern: `grep -l '<<''<<''<<''<' vibetuner-template/.justfiles/scaffolding.justfile` returns nothing.
- [x] Verify the split-pattern grep still matches `<<<<<<<`, `=======`, and `>>>>>>>` and does not match clean text.
- [x] Simulate `deps-scaffolding`'s tree-wide scan (`grep -rl "\$CONFLICT_MARKER"`) from `vibetuner-template/` — clean exit, no matches.
- [ ] Downstream smoke test: run `just deps-scaffolding` on a template-v10.11.1 project after this PR ships in a new template release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)