### PR TITLE
fix: derive OAuth relay return URL from incoming request

### DIFF
--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -19,7 +19,6 @@ from pydantic import (
     SecretStr,
     UrlConstraints,
     computed_field,
-    model_validator,
 )
 from pydantic_extra_types.color import Color as _PydanticColor
 from pydantic_extra_types.language_code import LanguageAlpha2
@@ -391,16 +390,6 @@ class CoreConfiguration(BaseSettings):
     # When set, OAuth flows use this stable URL instead of the app's own URL.
     # Example: "https://oauth.localdev.alltuner.com:28000"
     oauth_relay_url: HttpUrl | None = None
-
-    # External URL where this app is reachable (e.g. via Tailscale expose).
-    # Read from EXPOSE_URL env var. When unset, defaults to http://localhost:{port}.
-    expose_url: HttpUrl | None = None
-
-    @model_validator(mode="after")
-    def _default_expose_url(self) -> "CoreConfiguration":
-        if self.expose_url is None:
-            self.expose_url = HttpUrl(f"http://localhost:{self.resolved_port}")
-        return self
 
     @cached_property
     def trusted_proxy_hosts_list(self) -> list[str]:

--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -1,6 +1,7 @@
 # ABOUTME: OAuth provider integration using Authlib.
 # ABOUTME: Handles provider registration, builtin configs, and auth flow handlers.
 from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.starlette_client import OAuth
@@ -325,6 +326,23 @@ async def _create_new_user_with_oauth(
     return account
 
 
+def _wrap_oauth_relay_state(location: str, public_origin: str) -> str:
+    """Prefix the OAuth ``state`` param with the app's public origin so the
+    relay can redirect back to the originating app after authentication.
+
+    The relay parses ``state`` as ``{return_url}|{original_state}``. Returns
+    the location unchanged if no ``state`` param is present.
+    """
+    parsed = urlparse(location)
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    if "state" not in params:
+        return location
+    original_state = params["state"][0]
+    params["state"] = [f"{public_origin}|{original_state}"]
+    new_query = urlencode(params, doseq=True)
+    return urlunparse(parsed._replace(query=new_query))
+
+
 def _create_auth_login_handler(provider_name: str):
     async def auth_login(
         request: Request, next: str | None = None, app_id: str | None = None
@@ -352,19 +370,15 @@ def _create_auth_login_handler(provider_name: str):
             response = await client.authorize_redirect(
                 request, redirect_uri, hl=request.state.language
             )
-            # Wrap the state param with the app URL so the relay
-            # can redirect back: {scheme}://{host}:{port}|{original_state}
-            from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
-
+            # Derive the return URL from the incoming request so ad-hoc tunnels
+            # (frpc subdomain mode, ngrok, Cloudflare quick tunnels, tailscale
+            # funnel) that publish a public URL after the app boots work
+            # without injecting it into the environment.
+            public_origin = str(request.base_url).rstrip("/")
             location = response.headers.get("location", "")
-            parsed = urlparse(location)
-            params = parse_qs(parsed.query, keep_blank_values=True)
-            if "state" in params:
-                original_state = params["state"][0]
-                params["state"] = [f"{settings.expose_url}|{original_state}"]
-                new_query = urlencode(params, doseq=True)
-                new_location = urlunparse(parsed._replace(query=new_query))
-                response.headers["location"] = new_location
+            response.headers["location"] = _wrap_oauth_relay_state(
+                location, public_origin
+            )
             return response
 
         redirect_uri = request.url_for(f"auth_with_{provider_name}")

--- a/vibetuner-py/tests/unit/test_oauth_relay.py
+++ b/vibetuner-py/tests/unit/test_oauth_relay.py
@@ -1,0 +1,61 @@
+# ABOUTME: Tests for the OAuth relay state-wrapping helper.
+# ABOUTME: Verifies that the relay return URL is derived correctly from the request.
+# ruff: noqa: S101
+from urllib.parse import parse_qs, urlparse
+
+from vibetuner.frontend.oauth import _wrap_oauth_relay_state
+
+
+class TestWrapOauthRelayState:
+    """Tests for _wrap_oauth_relay_state()."""
+
+    def test_prefixes_state_with_public_origin(self):
+        location = (
+            "https://accounts.google.com/o/oauth2/v2/auth"
+            "?response_type=code"
+            "&client_id=abc"
+            "&state=opaque-token"
+            "&redirect_uri=https://relay.example.com/auth/provider/google"
+        )
+
+        wrapped = _wrap_oauth_relay_state(
+            location, "https://app.tunnel.example.com"
+        )
+
+        params = parse_qs(urlparse(wrapped).query)
+        assert params["state"] == [
+            "https://app.tunnel.example.com|opaque-token"
+        ]
+
+    def test_preserves_other_query_params(self):
+        location = (
+            "https://accounts.google.com/o/oauth2/v2/auth"
+            "?response_type=code"
+            "&client_id=abc"
+            "&state=opaque-token"
+            "&scope=openid+email"
+        )
+
+        wrapped = _wrap_oauth_relay_state(location, "https://app.example.com")
+
+        params = parse_qs(urlparse(wrapped).query)
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == ["abc"]
+        assert params["scope"] == ["openid email"]
+
+    def test_returns_location_unchanged_when_no_state_param(self):
+        location = "https://accounts.google.com/o/oauth2/v2/auth?response_type=code"
+
+        wrapped = _wrap_oauth_relay_state(location, "https://app.example.com")
+
+        assert wrapped == location
+
+    def test_handles_localhost_origin(self):
+        location = (
+            "https://accounts.google.com/o/oauth2/v2/auth?state=opaque-token"
+        )
+
+        wrapped = _wrap_oauth_relay_state(location, "http://localhost:28000")
+
+        params = parse_qs(urlparse(wrapped).query)
+        assert params["state"] == ["http://localhost:28000|opaque-token"]


### PR DESCRIPTION
## Summary

- `OAuth relay` flow no longer depends on `EXPOSE_URL` — the return URL is
  derived from `request.base_url`, so ad-hoc tunnels (frpc subdomain mode,
  ngrok, Cloudflare quick tunnels, tailscale funnel) that publish a public
  URL *after* the app boots now work without env injection.
- Removes `expose_url` from `CoreConfiguration` entirely. It had a single
  consumer (the relay handler) and a silent `http://localhost:{port}`
  fallback that caused the bug described in #1786.
- Extracts the state-rewriting into a pure `_wrap_oauth_relay_state` helper
  and adds unit tests covering the state prefix, query-param preservation,
  the no-state-param early return, and a localhost-origin case.

Closes #1786.

## Why

`expose_url` was set once at app startup. Wrappers like `expose -- just
local-all` learn the public URL only *after* the child has bound a port,
so they cannot inject `EXPOSE_URL` before launch. The relay dutifully
redirected users back to `http://localhost:{port}` instead of the public
tunnel URL they came in on.

The login request always arrives via the actual public origin, so
`request.base_url` is the right source. The existing Granian
`wrap_asgi_with_proxy_headers` (gated by `trusted_proxy_hosts`) already
normalises `X-Forwarded-Proto` / `X-Forwarded-Host`.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_oauth_relay.py -v` — 4 new tests pass
- [x] `uv run python -m pytest tests/unit/` — full unit suite green (800 passed)
- [x] `just lint-py` — clean
- [x] `just type-check` — clean
- [ ] Manual: run `expose -- just local-all`, sign in via Google, confirm the post-OAuth redirect lands on the public tunnel URL (not localhost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)