### PR TITLE
chore(scaffolding): remove broken just merge recipe from gitflow.justfile

### DIFF
--- a/vibetuner-template/.justfiles/gitflow.justfile
+++ b/vibetuner-template/.justfiles/gitflow.justfile
@@ -19,8 +19,3 @@ pr TITLE:
       --base main \
       --title "{{ TITLE }}" \
       --body "$(git log origin/main..HEAD --pretty=format:'- %s')"
-
-# Merge PR using squash
-[group('gitflow')]
-merge:
-    gh pr merge --squash --delete-branch


### PR DESCRIPTION
## Summary

- Deletes the `merge` recipe from `vibetuner-template/.justfiles/gitflow.justfile`.
- The recipe runs `gh pr merge --squash --delete-branch`, which fails from a git worktree because `gh` tries to checkout the default branch locally for cleanup — but the default branch is already checked out in the main worktree (the dominant workflow for downstream projects).
- Nothing references the recipe: no other justfile target, no CI workflow, no shell script, no docs. Downstream `CLAUDE.md` files have already had to document "use `gh pr merge --squash` directly, not `just merge`", making the recipe net-negative.

Remote branch cleanup is already handled by GitHub's per-repo "Automatically delete head branches" setting; local worktree cleanup is project-specific.

Closes #1789

## Test plan

- [x] `git grep "just merge"` in template — no references remain
- [x] `git grep "gitflow::merge\|gitflow merge"` in repo — no callers
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)