### PR TITLE
fix(scaffolding): exclude .venv/node_modules from deps-scaffolding conflict scan

### DIFF
--- a/vibetuner-template/.justfiles/deps.justfile
+++ b/vibetuner-template/.justfiles/deps.justfile
@@ -39,10 +39,21 @@ deps-scaffolding:
     # Phase 1: Update scaffolding (copier bumps manifests like package.json and pyproject.toml)
     just update-scaffolding
 
-    # Check for conflict markers in any file (tracked or new)
-    # Pattern is split to avoid matching itself when scanning for unresolved conflicts
+    # Check for conflict markers in any file (tracked or new).
+    # Pattern is split to avoid matching itself when scanning for unresolved conflicts.
+    # `update-scaffolding` above ran `bun install` / `uv sync`, so `.venv/` and
+    # `node_modules/` are populated and would otherwise yield false positives
+    # (copier's own conflict-marker code, beartype, precompiled binaries).
+    # `-I` skips binary files; the directory excludes drop the generated trees.
     CONFLICT_MARKER="<""<""<""<""<""<""<"
-    if grep -rl "$CONFLICT_MARKER" --exclude-dir=.git . >/dev/null 2>&1; then
+    if grep -rIl "$CONFLICT_MARKER" \
+        --exclude-dir=.git \
+        --exclude-dir=.venv \
+        --exclude-dir=node_modules \
+        --exclude-dir=.tmp \
+        --exclude-dir=dist \
+        --exclude-dir=build \
+        . >/dev/null 2>&1; then
         echo ""
         echo "Scaffolding update produced conflicts. Resolve them, then run:"
         echo "  git add -A && git commit -m 'chore: update scaffolding'"


### PR DESCRIPTION
## Summary

Follow-up to #1787. The `deps-scaffolding` recipe in `vibetuner-template/.justfiles/deps.justfile` runs `update-scaffolding` first, which executes `bun install` and `uv sync`. The tree-wide conflict-marker scan that follows then walks the populated `.venv/` and `node_modules/` and routinely matches unrelated source files — copier's own conflict-marker handling code, beartype, precompiled binaries — so the recipe exits 2 with a false-positive *"Scaffolding update produced conflicts"* message on every clean run.

Switches the outer scan to `grep -rIl` (skip binary files) and excludes `.venv`, `node_modules`, `.tmp`, `dist`, and `build` so it inspects only the project sources copier could plausibly have touched.

Refs #1785 (comment).

## Test plan

- [x] Reproduce the false positive: drop a conflict marker into `.venv/lib/copier_main.py`, run the **old** scan from a clean source tree — matches `.venv/lib/copier_main.py` and exits 0 (recipe would `exit 2`).
- [x] Verify the **new** scan on the same tree returns no matches and exits 1 (recipe proceeds).
- [x] Verify the **new** scan still detects a real conflict marker placed inside `src/` and exits 0 (recipe would `exit 2`).
- [ ] Downstream smoke test: run `just deps-scaffolding` on a template-v10.11.x project after this PR ships in a new template release — should no longer false-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)