### PR TITLE
chore(deps): add 2-day cooldown for Renovate and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "chore(deps)"
 
@@ -16,6 +18,8 @@ updates:
     directory: "/vibetuner-py"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "chore(deps)"
 
@@ -24,6 +28,8 @@ updates:
     directory: "/vibetuner-template"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "chore(deps)"
 
@@ -32,6 +38,8 @@ updates:
     directory: "/vibetuner-js"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "chore(deps)"
 
@@ -40,6 +48,8 @@ updates:
     directory: "/vibetuner-template"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "chore(deps)"
 
@@ -48,5 +58,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "chore(deps)"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "minimumReleaseAge": "2 days",
+  "internalChecksFilter": "strict"
 }


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge: "2 days"` (with `internalChecksFilter: "strict"`) in `renovate.json` so Renovate actually waits instead of silently falling back to a newer version.
- Add `cooldown: { default-days: 2 }` to all 6 update entries in `.github/dependabot.yml`.

Defense against smash-and-grab supply-chain attacks: most malicious npm/PyPI releases are caught and yanked within hours, so a 2-day floor filters them out before they ever land in a bot PR. Security advisories still bypass the cooldown on both Dependabot and Renovate, so urgent patches are unaffected.

Closes #1797.

## Test plan
- [ ] Renovate's next run proposes no version published in the last 2 days.
- [ ] Dependabot's next weekly run respects the cooldown on a recently-published package.
- [ ] A synthetic security advisory still produces an immediate Dependabot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)