### PR TITLE
ci: add Dependabot watch with 2-day cooldown for Dockerfile and Compose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # ABOUTME: Dependabot configuration for automated dependency updates.
-# ABOUTME: Monitors Python (uv), JavaScript (npm), and GitHub Actions dependencies.
+# ABOUTME: Monitors Python (uv), JavaScript (npm), GitHub Actions, and Docker dependencies.
 
 version: 2
 updates:
@@ -48,5 +48,45 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Root Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 2
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Root Compose
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 2
+    commit-message:
+      prefix: "chore(deps)"
+
+  # vibetuner-template Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/vibetuner-template"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 2
+    commit-message:
+      prefix: "chore(deps)"
+
+  # vibetuner-template Compose
+  - package-ecosystem: "docker-compose"
+    directory: "/vibetuner-template"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

- Adds four new Dependabot entries for Docker base images: `docker` and `docker-compose` ecosystems at both `/` and `/vibetuner-template`.
- Each new entry sets `cooldown.default-days: 2` so a malicious base-image tag has to survive 2 days in the wild before Dependabot will propose it. Dependabot still exempts security advisories from the cooldown, so legitimate CVE bumps come through immediately.
- Existing six entries (uv ×3, npm ×2, github-actions ×1) are unchanged — those belong to #1797's scope.

Closes #1798.

## Why

Companion to #1797. Docker base images are the same supply-chain surface as npm/PyPI — a compromised tag push to a popular base (or a typosquat) propagates the same way a malicious package release does. Cooldowns give scanners and the community time to flag obvious badness before the bot starts opening PRs against this repo.

Reference: https://cooldowns.dev/, [Dependabot Docker Compose GA](https://github.blog/changelog/2025-02-25-dependabot-version-updates-now-support-docker-compose-in-general-availability/), [Cooldown changelog](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/).

Renovate already covers Docker/compose through `config:recommended` and inherits the top-level cooldown proposed in #1797 — no Renovate change needed here.

## Test plan

- [ ] Confirm the YAML parses (locally validated: 10 entries total, all new entries carry `cooldown.default-days: 2`).
- [ ] After merge, watch the next Dependabot run cycle and confirm Dockerfile / compose PRs start appearing.
- [ ] Inspect a Dependabot run log for a base image with a release < 2 days old and verify it is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)