### PR TITLE
feat(vibetuner-js): re-export htmx via package subpaths

### DIFF
--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -232,12 +232,16 @@ import "htmx.org";
 **After (v4):**
 
 ```javascript
-import htmx from "htmx.org";
+import htmx from "@alltuner/vibetuner/htmx";
 window.htmx = htmx;
 ```
 
 The default import is required, and you must explicitly assign `htmx` to `window` for
 it to be available globally (e.g., in inline scripts or the browser console).
+
+`@alltuner/vibetuner` re-exports htmx as a subpath, so scaffolded projects don't need
+`htmx.org` as a direct dependency. The bare-specifier import works under any package
+manager linker mode (Bun hoisted or isolated, pnpm-style stores, npm v9+ isolated).
 
 ### Preload Extension
 
@@ -252,7 +256,7 @@ import "htmx-ext-preload";
 **After (v4):**
 
 ```javascript
-import "htmx.org/dist/ext/hx-preload.js";
+import "@alltuner/vibetuner/htmx/preload";
 ```
 
 ## Event Names Changed from camelCase to Colon-Separated
@@ -606,7 +610,7 @@ still being loaded, conflicting with htmx v4's built-in SSE support.
 **Fix:** Update your JS entry point:
 
 ```javascript
-import htmx from "htmx.org";
+import htmx from "@alltuner/vibetuner/htmx";
 window.htmx = htmx;
 ```
 
@@ -634,7 +638,7 @@ a parent's `hx-target`, `hx-swap`, or similar attribute.
 
 ```javascript
 // Before: import "htmx-ext-preload";
-import "htmx.org/dist/ext/hx-preload.js";
+import "@alltuner/vibetuner/htmx/preload";
 ```
 
 ```html

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2234,14 +2234,18 @@ In v4, inheritance must be explicitly opted into:
 ```javascript
 // Before (v2): import "htmx.org";
 // After (v4):
-import htmx from "htmx.org";
+import htmx from "@alltuner/vibetuner/htmx";
 window.htmx = htmx;
 
 // Preload extension:
 // Before: import "htmx-ext-preload";
 // After:
-import "htmx.org/dist/ext/hx-preload.js";
+import "@alltuner/vibetuner/htmx/preload";
 ```
+
+`@alltuner/vibetuner` re-exports htmx as a subpath, so scaffolded projects don't need
+`htmx.org` as a direct dependency. The bare-specifier import works under any package
+manager linker mode (Bun hoisted or isolated, pnpm-style stores, npm v9+ isolated).
 
 #### Migration Checklist
 

--- a/vibetuner-js/htmx-preload.js
+++ b/vibetuner-js/htmx-preload.js
@@ -1,0 +1,3 @@
+// ABOUTME: Re-exports the htmx hx-preload extension via @alltuner/vibetuner/htmx/preload
+// ABOUTME: so scaffolded projects don't need a direct htmx.org dep to enable it.
+import "htmx.org/dist/ext/hx-preload.js";

--- a/vibetuner-js/htmx.js
+++ b/vibetuner-js/htmx.js
@@ -1,0 +1,5 @@
+// ABOUTME: Thin re-export of htmx.org so scaffolded projects can import htmx
+// ABOUTME: as `@alltuner/vibetuner/htmx` without depending on it directly.
+import htmx from "htmx.org";
+
+export default htmx;

--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/alltuner/vibetuner/issues"
   },
+  "exports": {
+    "./core.css": "./core.css",
+    "./htmx": "./htmx.js",
+    "./htmx/preload": "./htmx-preload.js"
+  },
   "dependencies": {
     "@alltuner/vibetuner-jinja": "^10.11.0",
     "concurrently": "^9.2.1",

--- a/vibetuner-template/config.js
+++ b/vibetuner-template/config.js
@@ -1,8 +1,8 @@
 // Start of File: do not remove this comment (do not add anything before)
 // Do not change anything between this comment and the next comment
-import htmx from "htmx.org";
+import htmx from "@alltuner/vibetuner/htmx";
 window.htmx = htmx;
-import "./node_modules/htmx.org/dist/ext/hx-preload.js";
+import "@alltuner/vibetuner/htmx/preload";
 // Do not change anything between this comment and the previous one
 
 // Add your custom imports below:


### PR DESCRIPTION
## Summary

Adds `@alltuner/vibetuner/htmx` and `@alltuner/vibetuner/htmx/preload` to
`vibetuner-js`'s `exports`, and migrates `vibetuner-template/config.js` to use them.

Resolves item 1 of #1796 — the phantom-dep imports in scaffolded `config.js` that
break under Bun's isolated linker mode (`linker = "isolated"`).

### What changes for scaffolded projects

`vibetuner-template/config.js` before:

```js
import htmx from "htmx.org";
window.htmx = htmx;
import "./node_modules/htmx.org/dist/ext/hx-preload.js";
```

After:

```js
import htmx from "@alltuner/vibetuner/htmx";
window.htmx = htmx;
import "@alltuner/vibetuner/htmx/preload";
```

Scaffolded projects no longer reach through to `htmx.org` (phantom dep) or path
through `./node_modules/...` (brittle even under hoisted mode).

### How resolution works

Diverges slightly from #1796's literal spec: instead of pointing `exports` at
`./node_modules/htmx.org/...`, the new `htmx.js` / `htmx-preload.js` wrapper files
`import "htmx.org"` by bare specifier. Reason: under hoisted mode `htmx.org` is
hoisted to the consumer's top-level `node_modules/` (not nested under
`@alltuner/vibetuner/node_modules/`), so a direct path-based export would 404
under the default Bun linker. Bare-specifier imports from within the wrapper
let Bun's resolver find `htmx.org` through `@alltuner/vibetuner`'s package
boundary under either mode.

## Out of scope

Items 2 (tailwindcss CLI bin story) and 3 (full isolated-linker acceptance
criterion) of #1796 remain open. This PR also leaves other htmx-extension
references in the docs (`hx-nonce`, `htmx-2-compat`) using the deep-path
`htmx.org/dist/ext/...` pattern — they still work under hoisted (the default)
and can be migrated when isolated adoption becomes a priority.

## Test plan

Smoke-tested by `bun pm pack`'ing this branch's `vibetuner-js` into a tarball,
then installing into a sandbox that mirrors a scaffolded project's `config.js`
and `package.json`:

- [x] Hoisted (default Bun linker): bundle builds, 80.86 KB, htmx core + hx-preload both present
- [x] Isolated (`linker = "isolated"`): bundle builds, 81.0 KB, htmx core + hx-preload both present
- [x] Old `config.js` under isolated: fails with #1796's exact errors
      (`Could not resolve: "htmx.org"`, `Could not resolve: "./node_modules/htmx.org/..."`)
- [x] `window.htmx` set as a side effect of importing `@alltuner/vibetuner/htmx`
      (verified `window.htmx = htmx` appears twice in the bundle — htmx's own
      ESM side effect + our explicit re-affirmation)
- [x] `core.css` from #1803 still resolves through the new `exports` field

## Migration notes

Existing scaffolded projects will pick this up via `just deps-scaffolding-pr`
(Copier diff). The change is one file (`config.js`); the diff is tiny. Their
existing `^10.11.0` constraint on `@alltuner/vibetuner` will resolve to the
new release once it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)