### PR TITLE
chore: include revert commits in CHANGELOG

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -18,6 +18,10 @@
           "section": "Bug Fixes"
         },
         {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
           "type": "refactor",
           "section": "Code Refactoring"
         },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ When creating PRs, use **conventional commit format** for PR titles:
 
 - `feat:` New features (triggers MINOR version)
 - `fix:` Bug fixes (triggers PATCH version)
+- `revert:` Reverts of previous changes (triggers PATCH version)
 - `docs:` Documentation changes (triggers PATCH version)
 - `chore:` Maintenance, dependencies (triggers PATCH version)
 - `refactor:` Code refactoring (triggers PATCH version)
@@ -28,6 +29,10 @@ When creating PRs, use **conventional commit format** for PR titles:
 - `perf:` Performance improvements (triggers MINOR version)
 - `ci:` CI/CD changes (triggers PATCH version)
 - `build:` Build system changes (triggers PATCH version)
+
+When reverting a change, use `revert:` (not the default `Revert "..."` subject)
+so Release Please records it under the **Reverts** section of the changelog.
+See `CONTRIBUTING.md` for the full revert workflow.
 
 ### Breaking Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ the **PR title becomes the commit message** that determines version bumps and ch
 |------|-------------|----------------|
 | `feat` | New features | **MINOR** |
 | `fix` | Bug fixes | **PATCH** |
+| `revert` | Reverts of previous changes | **PATCH** |
 | `docs` | Documentation changes | **PATCH** |
 | `chore` | Maintenance, dependencies | **PATCH** |
 | `refactor` | Code refactoring | **PATCH** |
@@ -106,6 +107,20 @@ Add `!` to indicate breaking changes (triggers **MAJOR** version):
 - `feat!: remove deprecated API`
 - `fix!: change database schema`
 
+### Reverting Changes
+
+To make sure a revert appears in the changelog (and offsets the original entry),
+the PR title must start with `revert:` — not the default `Revert "feat: ..."`
+subject that `git revert` produces.
+
+- Preferred: open a PR whose title is `revert: <subject of the reverted change>`
+  (optionally `revert(scope): ...`). The squash commit then matches the
+  conventional-commits revert type and Release Please picks it up under the
+  **Reverts** section.
+- If you ran `git revert` locally, follow up with `git commit --amend` to
+  rewrite the subject to `revert: ...` before pushing, or just rename the PR
+  title — squash merges use the PR title, so that is what Release Please sees.
+
 ### Examples
 
 #### ✅ Good PR Titles
@@ -113,6 +128,7 @@ Add `!` to indicate breaking changes (triggers **MAJOR** version):
 ```text
 feat: add OAuth authentication support
 fix: resolve Docker build failure
+revert: drop OAuth authentication support
 docs: update installation guide
 chore: bump FastAPI dependency
 feat(auth): add Google OAuth provider
@@ -144,7 +160,7 @@ OAuth implementation
 feat: add new feature
 feat(scope): specific feature
 
-# Bug Fixes → PATCH release  
+# Bug Fixes → PATCH release
 fix: resolve issue
 fix(scope): specific fix
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2712,6 +2712,7 @@ This project uses **Release Please** for automated changelog generation. Since w
 |------|-------------|----------------|
 | `feat` | New features | **MINOR** |
 | `fix` | Bug fixes | **PATCH** |
+| `revert` | Reverts of previous changes | **PATCH** |
 | `docs` | Documentation changes | **PATCH** |
 | `chore` | Maintenance, dependencies | **PATCH** |
 | `refactor` | Code refactoring | **PATCH** |
@@ -2720,6 +2721,10 @@ This project uses **Release Please** for automated changelog generation. Since w
 | `perf` | Performance improvements | **MINOR** |
 | `ci` | CI/CD changes | **PATCH** |
 | `build` | Build system changes | **PATCH** |
+
+When reverting a change, the PR title must start with `revert:` (not the default
+`Revert "..."` subject `git revert` produces). Otherwise Release Please silently
+drops the entry and the changelog still shows the reverted feature as added.
 
 **Breaking Changes**
 

--- a/vibetuner-template/.release-please-config.json
+++ b/vibetuner-template/.release-please-config.json
@@ -16,6 +16,10 @@
           "section": "Bug Fixes"
         },
         {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
           "type": "refactor",
           "section": "Code Refactoring"
         },

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -110,11 +110,15 @@ app = VibetunerApp(
 
 ## PR Titles & Releases
 
-Use **conventional commits** for PR titles: `feat:`, `fix:`, `docs:`,
-`chore:`, `refactor:`, `style:`, `test:`, `perf:`, `ci:`, `build:`.
-Add `!` for breaking changes (e.g., `feat!:`). PR titles become squash
-commit messages. Release Please auto-generates changelogs. Versioning
-via git tags + `uv-dynamic-versioning`.
+Use **conventional commits** for PR titles: `feat:`, `fix:`, `revert:`,
+`docs:`, `chore:`, `refactor:`, `style:`, `test:`, `perf:`, `ci:`,
+`build:`. Add `!` for breaking changes (e.g., `feat!:`). PR titles
+become squash commit messages. Release Please auto-generates changelogs.
+Versioning via git tags + `uv-dynamic-versioning`.
+
+**Reverting:** the PR title must start with `revert:` (not the default
+`Revert "..."` subject `git revert` produces) — otherwise Release Please
+silently drops it from the changelog.
 
 > **Stale CI on release PRs:** the scaffolded `release.yml` regenerates
 > `uv.lock` after Release Please bumps `pyproject.toml`, then pushes the


### PR DESCRIPTION
## Summary

- Add `revert` to `.release-please-config.json` under a new "Reverts" section so reverts stop being silently dropped from the generated CHANGELOG
- Document the workflow caveat in `CONTRIBUTING.md`, `AGENTS.md`, and `vibetuner-docs/docs/llms-full.txt`: the PR title must start with `revert:` (not the default `Revert "..."` subject `git revert` produces), otherwise Release Please can't categorize it

The PR title validator (`.github/workflows/pr-title-check.yml`) already accepts `revert`, so no changes were needed there.

Closes #1783

## Test plan

- [ ] CI green (Release Please config still parses, markdown lint passes)
- [ ] On the next merged Release Please PR, confirm any `revert:` commits land under a **Reverts** heading in `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)