### PR TITLE
feat(vibetuner-js): expose tailwindcss bin via wrapper

### DIFF
--- a/vibetuner-js/bin/tailwindcss.js
+++ b/vibetuner-js/bin/tailwindcss.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+// ABOUTME: Re-exposes the `tailwindcss` CLI bin from @tailwindcss/cli so scaffolded
+// ABOUTME: projects can `bun tailwindcss ...` without declaring it as a direct dep.
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const pkgPath = require.resolve("@tailwindcss/cli/package.json");
+const { bin } = require("@tailwindcss/cli/package.json");
+
+await import(join(dirname(pkgPath), bin.tailwindcss));

--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -27,6 +27,9 @@
     "./htmx": "./htmx.js",
     "./htmx/preload": "./htmx-preload.js"
   },
+  "bin": {
+    "tailwindcss": "./bin/tailwindcss.js"
+  },
   "dependencies": {
     "@alltuner/vibetuner-jinja": "^10.11.0",
     "concurrently": "^9.2.1",


### PR DESCRIPTION
## Summary

Adds a `tailwindcss` bin to `@alltuner/vibetuner` that re-exposes the CLI from the bundled `@tailwindcss/cli` dep. Resolves item 2 of #1796 — the phantom CLI binary that broke `bun tailwindcss ...` in scaffolded projects under Bun's isolated linker mode.

Combined with #1804 (item 1), this closes #1796.

## How it works

`@tailwindcss/cli`'s `exports` field is locked down to only `./package.json`, so we can't `import "@tailwindcss/cli/dist/index.mjs"` directly. The wrapper:

1. Reads the CLI's `package.json` (only path the exports field allows)
2. Extracts the `bin.tailwindcss` path
3. Resolves it against the package directory
4. Dynamic-imports the absolute filesystem path (bypassing exports, since fs-path imports don't apply exports)

Six lines of code, no subprocess overhead, pinned to whatever `@tailwindcss/cli` version `vibetuner-js` ships. Consumer scripts stay identical — `bun tailwindcss ...` already resolves via `node_modules/.bin/tailwindcss`, which now symlinks to our wrapper.

## Why not bunx, or option (a) from the issue

Discussed in #1796 — short version:

- `bunx tailwindcss` fails outright (`tailwindcss` package has no `bin`; CLI lives in `@tailwindcss/cli`)
- `bunx --package=@tailwindcss/cli tailwindcss` works but pulls fresh from npm, drifts from `vibetuner-js`'s pinned version, and requires touching every consumer's package.json scripts
- Option (a) — `@tailwindcss/cli` as a direct consumer dep — works, but contradicts the framing in #1796 itself: *\"Single-source dep updates are the whole point of vibetuner-js. Moving deps into every consumer's package.json defeats that.\"* That logic applies to the CLI just as much as to htmx (#1804).

The bin wrapper preserves the single-dep promise and skips churning consumer package.json files.

## Test plan

Smoke-tested via `bun pm pack` tarball installed into a sandbox mirroring the scaffolded layout:

- [x] Hoisted (default Bun linker): `bun run build:css` produces 89.9 KB bundle, daisyUI loaded, jinja-template classes (`alert-info`) scanned, consumer-template classes scanned. `bun run build:js` clean (80.86 KB).
- [x] Isolated (`linker = \"isolated\"`): identical CSS output (89.9 KB byte-for-byte), daisyUI loaded, jinja templates scanned via the symlinked virtual store. JS bundle clean (81.0 KB). **Closes #1796's acceptance criterion**: `vibetuner-template` builds cleanly under `linker = \"isolated\"`.
- [x] `bun tailwindcss --help` passes argv through cleanly, shows pinned v4.3.0.
- [x] `node_modules/.bin/tailwindcss` symlinks to our wrapper under both modes.

## Note on release coordination

End-to-end isolated build requires `@alltuner/vibetuner-jinja` shipping with `sources.css`. The currently-published `vibetuner-jinja@10.11.0` doesn't ship it yet (sources.css was added by #1803 but hasn't been released), so my smoke test patches it in manually. **Release Please #1801** will publish both `vibetuner-jinja@10.12.0` (with `sources.css`) and `vibetuner-js@10.12.0` (with this PR's bin), making the published flow work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)