### PR TITLE
feat(vibetuner-js): re-export htmx hx-sse via package subpath

### DIFF
--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -259,6 +259,26 @@ import "htmx-ext-preload";
 import "@alltuner/vibetuner/htmx/preload";
 ```
 
+### SSE Extension
+
+The SSE extension also moved from a separate package to a built-in module.
+
+**Before (v2):**
+
+```javascript
+import "htmx-ext-sse";
+```
+
+**After (v4):**
+
+```javascript
+import "@alltuner/vibetuner/htmx/sse";
+```
+
+Use `hx-sse:connect="/events"` (and `hx-sse:swap`, `hx-sse:close`) on elements
+that should subscribe to a server-sent events stream. The `hx-ext="sse"`
+attribute is no longer needed — the extension auto-registers on import.
+
 ## Event Names Changed from camelCase to Colon-Separated
 
 All htmx event names switched from camelCase to a colon-separated

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2241,6 +2241,11 @@ window.htmx = htmx;
 // Before: import "htmx-ext-preload";
 // After:
 import "@alltuner/vibetuner/htmx/preload";
+
+// SSE extension:
+// Before: import "htmx-ext-sse";
+// After:
+import "@alltuner/vibetuner/htmx/sse";
 ```
 
 `@alltuner/vibetuner` re-exports htmx as a subpath, so scaffolded projects don't need
@@ -2255,7 +2260,7 @@ manager linker mode (Bun hoisted or isolated, pnpm-style stores, npm v9+ isolate
 - Replace `hx-disable` with `hx-ignore`
 - Add `:inherited` modifier to attributes that rely on inheritance
 - Update JS imports to use default import and `window.htmx = htmx`
-- Update preload extension import path
+- Update preload and SSE extension import paths
 - Remove `htmx-ext-sse` and `htmx-ext-preload` from `package.json`
 
 #### Beta3 Additions

--- a/vibetuner-js/htmx-sse.js
+++ b/vibetuner-js/htmx-sse.js
@@ -1,0 +1,3 @@
+// ABOUTME: Re-exports the htmx hx-sse extension via @alltuner/vibetuner/htmx/sse
+// ABOUTME: so scaffolded projects don't need a direct htmx.org dep to enable it.
+import "htmx.org/dist/ext/hx-sse.js";

--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -25,7 +25,8 @@
   "exports": {
     "./core.css": "./core.css",
     "./htmx": "./htmx.js",
-    "./htmx/preload": "./htmx-preload.js"
+    "./htmx/preload": "./htmx-preload.js",
+    "./htmx/sse": "./htmx-sse.js"
   },
   "bin": {
     "tailwindcss": "./bin/tailwindcss.js"


### PR DESCRIPTION
## Summary

Mirrors the `hx-preload` pattern from #1804: adds `vibetuner-js/htmx-sse.js`
and a `./htmx/sse` entry to `exports`, so scaffolded projects can enable the
htmx SSE extension via:

```js
import "@alltuner/vibetuner/htmx/sse";
```

…without having to declare `htmx.org` as a direct devDependency. The 10.11+
bun consolidation removed the phantom-dep `htmx.org` from scaffolded
projects, which broke the previous `./node_modules/htmx.org/dist/ext/hx-sse.js`
import path used by SSE consumers (see #1807).

## Changes

- `vibetuner-js/htmx-sse.js` — new wrapper that bare-imports
  `htmx.org/dist/ext/hx-sse.js`
- `vibetuner-js/package.json` — adds `"./htmx/sse": "./htmx-sse.js"` to
  `exports`
- `vibetuner-docs/docs/htmx-migration.md` — adds an "SSE Extension" section
  parallel to "Preload Extension", documenting `hx-sse:connect` (the v4
  attribute) and that `hx-ext="sse"` is no longer needed
- `vibetuner-docs/docs/llms-full.txt` — adds the SSE before/after snippet
  to the JavaScript import-changes block and updates the migration checklist

## Test plan

Smoke-tested by `bun pm pack`'ing this branch's `vibetuner-js` into a
tarball, then bundling a sandbox `config.js`-style entry with
`bun build`:

- [x] **Hoisted (default Bun linker):** bundle builds, 92.62 KB, htmx core +
  hx-preload + hx-sse all present (verified by string search for
  `htmx.config`, `preload`, `hx-sse:connect`)
- [x] **Isolated (`linker = "isolated"`):** bundle builds, identical 92.62 KB,
  all three present
- [x] `hx-sse.js` is included in the published tarball (`tar tzf` confirms)
- [x] Pre-commit hooks pass (rumdl, end-of-files, etc.)

Closes #1807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)