### PR TITLE
fix: format .copier-answers.yml after scaffold/update

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -100,6 +100,21 @@ enable_watchtower:
   when: "{{ fqdn }}"
 
 _tasks:
+  # Copier's `to_nice_yaml` filter emits single-quoted strings and
+  # zero-indented sequence items, which the scaffolded `lint-yaml` recipe
+  # rejects. Format the answers file with the same dprint plugin the
+  # template uses so `just lint` passes on a fresh checkout and after
+  # every `copier update`.
+  - command:
+      - uvx
+      - --from
+      - dprint-py
+      - dprint
+      - fmt
+      - --plugins
+      - https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm
+      - --
+      - "{{ _copier_conf.answers_file }}"
   - command: [uv, sync]
     when: "{{ _copier_operation == 'copy' }}"
   - command: [bun, install]


### PR DESCRIPTION
## Summary

- Copier's `to_nice_yaml` filter writes `.copier-answers.yml` with single-quoted strings and zero-indented sequence items, which the scaffolded `lint-yaml` recipe (dprint + pretty_yaml plugin) rejects.
- Result: a fresh `copier copy` (and every `copier update`) leaves the project failing `just lint` until the user runs `just format-yaml`.
- Fix: add a copier `_task` that runs `dprint fmt` against the answers file using the same plugin version the template's lint recipe pins. Runs on both `copy` and `update`.

Fixes #1808

## Test plan

- [x] Scaffold a fresh project from this branch; confirm `.copier-answers.yml` lands with double-quoted strings and 2-space-indented sequence items.
- [x] Run `just lint-yaml` in the scaffolded project — passes (exit 0).
- [x] Run `just lint-yaml` at repo root — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)