### PR TITLE
fix(vibetuner-js): pin vibetuner-jinja to the matching release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,16 @@ jobs:
             echo "✅ Building Jinja (first release)"
           fi
 
+          # vibetuner-js exact-pins vibetuner-jinja to the matching release
+          # version (see vibetuner-js/package.json), so any release that
+          # publishes js MUST also publish jinja — otherwise the transitive
+          # dep resolves to a non-existent registry entry and `bun install`
+          # 404s in scaffolded projects.
+          if [ "$JS_NEEDED" = "true" ] && [ "$JINJA_NEEDED" != "true" ]; then
+            JINJA_NEEDED="true"
+            echo "✅ Building Jinja (linked to JS — exact-pin invariant)"
+          fi
+
           # Documentation (build for releases and workflow dispatch)
           if [ "$FORCE_DOCS" = "true" ]; then
             DOCS_NEEDED="true"

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -62,6 +62,11 @@
           "jsonpath": "$.project.version"
         },
         "vibetuner-js/package.json",
+        {
+          "type": "json",
+          "path": "vibetuner-js/package.json",
+          "jsonpath": "$.dependencies['@alltuner/vibetuner-jinja']"
+        },
         "vibetuner-jinja/package.json",
         {
           "type": "generic",

--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -32,7 +32,7 @@
     "tailwindcss": "./bin/tailwindcss.js"
   },
   "dependencies": {
-    "@alltuner/vibetuner-jinja": "^10.11.0",
+    "@alltuner/vibetuner-jinja": "10.13.0",
     "concurrently": "^9.2.1",
     "daisyui": "^5.5.19",
     "htmx.org": "4.0.0-beta3",


### PR DESCRIPTION
## Summary

- Pin `@alltuner/vibetuner-jinja` to the exact current release in
  `vibetuner-js/package.json` (was `^10.11.0`, now `10.13.0`).
- Wire release-please's `extra-files` so the pin bumps to the new version
  on every release, keeping the two monorepo packages in lockstep.
- Couple `jinja-needed` to `js-needed` in `release.yml` so we can never
  publish a `vibetuner-js@X.Y.Z` whose pinned `vibetuner-jinja@X.Y.Z`
  doesn't exist on npm (the exact-pin invariant).

## Why

`@alltuner/vibetuner@10.13.0`'s `core.css` does
`@import "@alltuner/vibetuner-jinja/sources.css"`, but `sources.css` only
shipped in `vibetuner-jinja@10.12.0+`. With the previous `^10.11.0` range, a
stale `bun.lock` pinning `vibetuner-jinja@10.11.0` (the version that was a
direct devDependency in older templates) was preserved on update, leaving
projects with a nested `vibetuner-jinja@10.11.0` and a broken build:

```text
Error: Can't resolve '@alltuner/vibetuner-jinja/sources.css'
  in '/.../node_modules/@alltuner/vibetuner'
```

Exact-pinning forces bun to re-resolve (10.11.0 no longer satisfies
`"10.13.0"`), and the release-please entry guarantees the pin stays
current across releases.

The release-workflow change closes the secondary risk: patch releases
that change neither `vibetuner-jinja/` nor
`vibetuner-py/src/vibetuner/templates/frontend/` would otherwise skip the
jinja publish job and ship a `vibetuner-js` that pins a non-existent
`vibetuner-jinja` version. Now any release that publishes js also
publishes jinja.

Fixes #1812

## Test plan

- [x] Scaffold a project from `main`, simulate the broken state
  (`vibetuner-jinja` pinned to 10.11.0 via `overrides`), confirm
  `bun run build-prod` fails with the `sources.css` error.
- [x] Repack `vibetuner-js` with this patch, install into the same repro
  without the override, confirm:
  - Installed `node_modules/.bun/node_modules/@alltuner/vibetuner-jinja`
    is version 10.13.0 and contains `sources.css`.
  - `bun run build-prod` completes successfully (tailwind emits
    `daisyUI 5.5.19`, JS bundle builds).
- [x] Validate the new release-please `jsonpath`
  (`$.dependencies['@alltuner/vibetuner-jinja']`) resolves correctly with
  `jsonpath-plus`, confirming release-please's `Json` updater will be able
  to find and rewrite the value.
- [ ] Post-merge: confirm release-please's 10.13.1 PR rewrites
  `vibetuner-js/package.json`'s `@alltuner/vibetuner-jinja` value to
  `"10.13.1"`, and that the release workflow publishes both `vibetuner-js`
  and `vibetuner-jinja` at the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)