### PR TITLE
fix(ci): drop bun install from build-js to avoid race with publish-jinja

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,11 +480,15 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Install dependencies
+      - name: Build tarball
         id: build
         working-directory: vibetuner-js
         run: |
-          bun install
+          # `bun pm pack` packs the existing source tree — vibetuner-js has no
+          # build step, no prepare hook, and no bundled output. Running
+          # `bun install` here would hit the public npm registry to resolve
+          # the exact-pinned `@alltuner/vibetuner-jinja@X.Y.Z`, which races
+          # `publish-jinja` and reliably fails on every release (#1817).
           bun pm pack
           echo "Build completed successfully"
 


### PR DESCRIPTION
## Summary

Drop the unused `bun install` from the `build-js` step in
`.github/workflows/release.yml`. Only `bun pm pack` runs there now.

## Why

After #1814 `vibetuner-js` exact-pins `vibetuner-jinja` to the matching
release version. `build-js`'s `bun install` resolves that pin against
the public npm registry, which races `publish-jinja` and reliably fails
on every release:

```text
error: No version matching "10.14.0" found for
  specifier "@alltuner/vibetuner-jinja" (but package exists)
```

That bit us during the v10.14.0 release — a manual rerun of the failed
jobs was the workaround.

`bun pm pack` packs the source tree as-is and doesn't need the
dependency graph resolved. `vibetuner-js` has no build step, no
`prepare` hook, and no bundled output, so `bun install` was doing no
useful work in this job.

Fixes #1817

## Test plan

- [x] `bun pm pack` against the source tree produces a tarball whose
  contents (`tar -tzf`) match the published 10.14.0 artifact byte-for-byte:
  8 files, no `bun.lock`, `package.json` retains the exact pin
  `"@alltuner/vibetuner-jinja": "10.14.0"`.
- [ ] Next release run completes without manual rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)