### PR TITLE
ci: unpin claude-code-action now that symlink bug is fixed upstream

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.88 # Pinned: v1.0.89+ has symlink ENOENT bug (anthropics/claude-code-action#1187)
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"

--- a/vibetuner-template/.github/workflows/claude-code-review.yml
+++ b/vibetuner-template/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.88 # Pinned: v1.0.89+ has symlink ENOENT bug (anthropics/claude-code-action#1187)
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"


### PR DESCRIPTION
## Summary
- Restore floating `@v1` tag for `anthropics/claude-code-action` in both `.github/workflows/claude-code-review.yml` and `vibetuner-template/.github/workflows/claude-code-review.yml`.
- The symlink `cpSync` ENOENT regression that motivated the v1.0.88 pin (#1613) was fixed in [anthropics/claude-code-action#1186](https://github.com/anthropics/claude-code-action/pull/1186) and shipped in [v1.0.123](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.123) on 2026-05-14.

Closes #1616. Supersedes #1820 (which would only have bumped us to v1.0.121, still pre-fix, and would have kept a hard pin instead of returning to the floating tag).

## Test plan
- [ ] CI green
- [ ] Next PR's `claude-review` job runs successfully on `@v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)