### PR TITLE
feat: adopt htmx hx-live as default-on for client-side reactivity

### DIFF
--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -557,6 +557,8 @@ the changes specific to beta3 (which is the 4.0 release candidate).
   proxy, sigil-syntax `toggle('@attr')` / `toggle('*display=none|block')`,
   per-element `debounce(ms[, fn])`, and `htmx.live.q` /
   `htmx.live.take(target, className, source)` outside expression scope.
+  **Default-on in vibetuner** as of `@alltuner/vibetuner` 10.15.0 — see
+  [Live Reactivity](#live-reactivity-with-hx-live) below.
 
 ### New Swap Style: `outerSync`
 
@@ -607,7 +609,110 @@ for history snapshots, the same as in htmx 2.
 the new `hx-live` extension and are exposed via the `htmx.live`
 namespace (e.g. `htmx.live.take(target, className, source)`). If you
 were calling them directly, import the `hx-live` extension or migrate
-to native equivalents.
+to native equivalents. Vibetuner loads `hx-live` by default, so
+`htmx.live.take(...)` is available without extra setup.
+
+## Live Reactivity with `hx-live`
+
+`@alltuner/vibetuner` 10.15.0 imports `hx-live` by default from
+`config.js` (in the framework-managed block, alongside `hx-preload`).
+This is vibetuner's recommended path for client-side reactivity —
+chip lists, derived form fields, live filters, paired controls.
+Reach for it before adding Alpine.js, Stimulus, or hand-rolled
+event-listener boilerplate.
+
+### Why it fits vibetuner
+
+Vibetuner's CSP runs `script-src 'nonce-X' 'strict-dynamic'` with
+no `'unsafe-inline'`, which blocks inline `onclick="..."` /
+`onchange="..."` attributes at the spec level. htmx attributes
+(`hx-on:`, `hx-live`) evaluate through htmx's nonced TrustedTypes
+pipeline, so they work where raw handler attributes do not. If you
+also enable `hx-nonce`, every `hx-live` expression gets the same
+defence-in-depth as `hx-get` / `hx-post`.
+
+### Idiomatic patterns
+
+**Derive a hidden field from a chip list** (the OAuth scope editor
+in `debug/oauth_app_form.html.jinja` uses this exact shape):
+
+```jinja
+<div id="scopes-tags"
+     hx-on:click="
+       const btn = event.target.closest('button[data-action=remove-scope]');
+       if (btn) btn.closest('.badge').remove();
+     ">
+  {% for scope in scopes %}
+    <span class="badge" data-scope="{{ scope }}">
+      <span data-text>{{ scope }}</span>
+      <button type="button" data-action="remove-scope">×</button>
+    </span>
+  {% endfor %}
+</div>
+<input type="hidden" name="scopes"
+       hx-live="this.value = q('#scopes-tags .badge').arr()
+                             .map(b => b.dataset.scope).join(',')">
+```
+
+The hidden input recomputes its `value` on every mutation under
+`#scopes-tags` — add and remove both stay in sync without manual
+wiring. Event delegation on the container handles remove clicks
+on both initially-rendered and dynamically-inserted badges
+(`q().insert()` is raw `insertAdjacentHTML` — htmx does not
+re-process inserted nodes).
+
+**Conditional CSS class from a sibling input:**
+
+```jinja
+<input id="age" type="number" value="0">
+<p hx-live="this.classList.toggle('text-error',
+                                  q('#age').valueAsNumber < 18)">
+  Adult content
+</p>
+```
+
+**Debounced live search:**
+
+```jinja
+<input id="q" placeholder="search">
+<output hx-live="
+  let term = q('#q').value;
+  if (!term) { this.textContent = ''; return; }
+  await debounce(250);
+  this.textContent = await fetch('/search?q=' +
+    encodeURIComponent(term)).then(r => r.text());
+"></output>
+```
+
+The `await debounce(250)` is per-element — successive keystrokes
+cancel the in-flight call via async rejection, so only the final
+term hits the server.
+
+### Rough edges to know
+
+- **The DOM is the only source of truth.** No JS-variable reactivity.
+  Share state via `data-*` attributes or hidden inputs. Alpine.js
+  refugees will expect refs — `hx-live` deliberately doesn't have them.
+- **Expressions re-run on *any* DOM mutation.** Cheap by default, but
+  unconditional side effects (a bare `fetch()`, mutating the DOM tree
+  the expression reads) will tank performance or trip the >50/s
+  self-mutation cutoff (the expression deactivates with a console
+  warning). Guard with `debounce` or a value-change check.
+- **Set-property writes broadcast silently.** `q('.field').value = ''`
+  writes to every matching element. A selector that accidentally
+  widens (e.g. an `:inherited` attribute unexpectedly inheriting)
+  clobbers things you didn't intend. Prefer narrow selectors and
+  add `data-*` markers where ambiguity is possible.
+- **`next` / `prev` / `closest` anchor to `this`.** Inside `hx-live`
+  they mean "relative to the owner element". Calling
+  `htmx.live.q('next .foo')` from a free-floating script is undefined.
+- **`q().insert(pos, html)` does not run `htmx.process()`** on the
+  inserted markup. Dynamic `hx-on:` / `hx-live` attributes won't be
+  wired. Use event delegation on a stable parent (as in the chip-list
+  pattern above) or call `htmx.process(elt)` after insertion.
+- **`hx-config` no longer accepts request `mode` overrides** in beta3
+  (security fix). Unrelated to `hx-live` itself but ships together —
+  drop `hx-config="mode:..."` attributes if you have them.
 
 ## Common Migration Issues
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1837,6 +1837,96 @@ file only ships with `htmx.org@4.0.0-beta3`, pulled transitively by
 `@alltuner/vibetuner` 10.11.0+; on older versions the bundler errors
 with `Could not resolve "./node_modules/htmx.org/dist/ext/hx-nonce.js"`.
 
+**htmx Live Reactivity (default-on, requires `@alltuner/vibetuner` ≥ 10.15.0):**
+htmx 4.0.0-beta3's `hx-live` extension is loaded by default from the
+framework-managed block of `config.js`, alongside `hx-preload`. This is
+vibetuner's recommended path for client-side reactivity — chip lists,
+derived form fields, live filters, paired controls, inline validation.
+Reach for it before adding Alpine.js, Stimulus, or hand-rolled
+event-listener boilerplate.
+
+**Why it fits the stack.** Vibetuner's `script-src 'nonce-X' 'strict-dynamic'`
+CSP blocks inline `onclick="..."` / `onchange="..."` attributes at the spec
+level. `hx-on:` and `hx-live` evaluate through htmx's nonced TrustedTypes
+pipeline, so they work where raw handler attributes do not. Pair with the
+opt-in `hx-nonce` extension for defence-in-depth.
+
+**Primitives** (full reference at <https://four.htmx.org/extensions/hx-live/>):
+
+- `hx-live="<expr>"` — JS expression re-run on any `input`/`change`/mutation,
+  with `q()`, `wait`, `trigger`, `debounce`, and the htmx public API in scope.
+  Async function body (top-level `await` allowed).
+- `q(selector)` — jQuery-like proxy. Selector grammar: `next` / `prev` /
+  `closest`, `'.foo in #scope'`, `'.foo in this'`, chained `.q(...)`. Reads
+  return the first match; assigns write to all matches. `q('.x').arr()`
+  for a real `Array<Element>`.
+- Built-in shortcuts: `.trigger(name, detail)`, `.insert(pos, html)` (raw
+  `insertAdjacentHTML` — does not run `htmx.process()`), `.take(class, from)`
+  (move class from peers).
+- Sigil `toggle('@attr')` / `toggle('*display=none|block')` for attribute /
+  style flips.
+- `debounce(ms)` — per-element, cancels prior in-flight via async rejection.
+- `htmx.live.*` — same primitives outside expression scope (e.g.
+  `htmx.live.take(target, className, source)` for the migrated
+  `htmx.takeClass()`).
+
+**Pattern: chip-list with derived hidden input** (the OAuth scope editor in
+`debug/oauth_app_form.html.jinja` is the canonical in-tree example):
+
+```jinja
+<div id="scopes-tags"
+     hx-on:click="
+       const btn = event.target.closest('button[data-action=remove-scope]');
+       if (btn) btn.closest('.badge').remove();
+     ">
+  {% for scope in scopes %}
+    <span class="badge" data-scope="{{ scope }}">
+      <span data-text>{{ scope }}</span>
+      <button type="button" data-action="remove-scope">×</button>
+    </span>
+  {% endfor %}
+</div>
+<input type="hidden" name="scopes"
+       hx-live="this.value = q('#scopes-tags .badge').arr()
+                             .map(b => b.dataset.scope).join(',')">
+```
+
+The hidden input recomputes on every mutation under `#scopes-tags` — add
+and remove paths stay in sync without manual wiring. Event delegation on
+the container handles both initially-rendered and dynamically-inserted
+badges (`q().insert()` does not re-process inserted nodes).
+
+**Pattern: debounced live search:**
+
+```jinja
+<output hx-live="
+  let term = q('#q').value;
+  if (!term) { this.textContent = ''; return; }
+  await debounce(250);
+  this.textContent = await fetch('/search?q=' +
+    encodeURIComponent(term)).then(r => r.text());
+"></output>
+```
+
+**Rough edges:**
+
+- **The DOM is the only source of truth.** No JS-variable reactivity; share
+  state via `data-*` attributes or hidden inputs.
+- **Expressions re-run on every DOM mutation.** Idempotent or
+  cheap-or-guarded only. The runtime deactivates expressions that mutate
+  more than 50 times per second.
+- **Set-property writes broadcast silently** to all matched elements.
+  Narrow your selectors.
+- **`next` / `prev` / `closest` anchor to `this`.** Undefined when called
+  from `htmx.live.q(...)` outside an expression.
+- **`q().insert()` is raw `insertAdjacentHTML`.** Dynamic `hx-on:` /
+  `hx-live` attributes on inserted markup won't be wired. Use event
+  delegation on a stable parent or call `htmx.process(elt)` after insertion.
+- **Breaking from beta2:** `htmx.takeClass()` / `htmx.forEvent()` moved
+  out of core. Use `htmx.live.take(...)` / `htmx.live.forEvent(...)`.
+  Framework code has no usages, so this is a non-event for users on the
+  default scaffolding; user code calling those globals will need an update.
+
 ### Background Tasks
 
 Run long-running or scheduled work outside the request cycle using Vibetuner's
@@ -2274,9 +2364,11 @@ relevant to vibetuner projects:
   enable. Framework templates already follow the pattern. Elements
   without a matching nonce are stripped (fail-closed)
 - **`hx-live` extension** — DOM-reactivity via `hx-live="..."` plus a
-  richer `hx-on` JS surface (`q()`, `toggle()`, `debounce()`). Note:
-  `htmx.takeClass` and `htmx.forEvent` moved out of core into this
-  extension (now `htmx.live.take(...)` etc.)
+  richer `hx-on` JS surface (`q()`, `toggle()`, `debounce()`). **Default-on
+  in vibetuner** since `@alltuner/vibetuner` 10.15.0; see the Live
+  Reactivity section above for patterns. Note: `htmx.takeClass` and
+  `htmx.forEvent` moved out of core into this extension (now
+  `htmx.live.take(...)` etc.)
 - **`hx-history-elt` restored** — was removed in earlier 4.x pre-releases,
   brought back in beta3 alongside an improved `hx-history-cache`
   extension

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -123,6 +123,16 @@ Important notes:
   enable. Elements without a matching `hx-nonce` are stripped (fail-closed). Requires
   `@alltuner/vibetuner` ≥ 10.11.0 (older releases pull `htmx.org@4.0.0-beta2` which
   does not ship the extension file)
+- **htmx Live Reactivity (default-on)**: htmx 4.0.0-beta3's `hx-live` extension is
+  loaded by default from `config.js` since `@alltuner/vibetuner` 10.15.0. Use
+  `hx-live="<expr>"` for derived state that recomputes on any DOM mutation,
+  `hx-on:event="..."` with the `q()` proxy / sigil-`toggle()` / per-element
+  `debounce()` for richer event handlers. CSP-clean (evaluates through htmx's
+  nonced TrustedTypes path) where raw inline `onclick=` is not. Vibetuner's
+  preferred path for chip lists, paired controls, live filters, and inline
+  form-field validation — use this before reaching for Alpine.js or Stimulus.
+  See `vibetuner-docs/docs/htmx-migration.md#live-reactivity-with-hx-live` for
+  idiomatic patterns and rough edges
 - **Health Checks**: `/health`, `/health/ping`, `/health/ready`, `/health/id` endpoints
   with service connectivity checks
 - **Robust Tasks**: `@robust_task()` decorator with exponential backoff retries and

--- a/vibetuner-js/htmx-live.js
+++ b/vibetuner-js/htmx-live.js
@@ -1,0 +1,3 @@
+// ABOUTME: Re-exports the htmx hx-live extension via @alltuner/vibetuner/htmx/live
+// ABOUTME: so scaffolded projects don't need a direct htmx.org dep to enable it.
+import "htmx.org/dist/ext/hx-live.js";

--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -26,7 +26,8 @@
     "./core.css": "./core.css",
     "./htmx": "./htmx.js",
     "./htmx/preload": "./htmx-preload.js",
-    "./htmx/sse": "./htmx-sse.js"
+    "./htmx/sse": "./htmx-sse.js",
+    "./htmx/live": "./htmx-live.js"
   },
   "bin": {
     "tailwindcss": "./bin/tailwindcss.js"

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_app_form.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_app_form.html.jinja
@@ -8,24 +8,18 @@
         <!-- Header -->
         <header class="mb-8">
             <div class="flex items-center gap-2 mb-2">
-                <a href="{{ url_for('debug_oauth_apps') }}"
-                   class="btn btn-ghost btn-sm">
+                <a href="{{ url_for('debug_oauth_apps') }}" class="btn btn-ghost btn-sm">
                     <svg xmlns="http://www.w3.org/2000/svg"
                          class="h-4 w-4"
                          fill="none"
                          viewBox="0 0 24 24"
                          stroke="currentColor">
-                        <path stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M15 19l-7-7 7-7" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
                     </svg>
                     Back
                 </a>
             </div>
-            <h1 class="text-3xl font-bold text-base-content mb-2">
-                {{ 'Edit' if app else 'Create' }} OAuth App
-            </h1>
+            <h1 class="text-3xl font-bold text-base-content mb-2">{{ 'Edit' if app else 'Create' }} OAuth App</h1>
         </header>
         {% if not DEBUG %}
             <div class="alert alert-info mb-6">
@@ -33,10 +27,7 @@
                      class="stroke-current shrink-0 h-6 w-6"
                      fill="none"
                      viewBox="0 0 24 24">
-                    <path stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <span>OAuth app editing is disabled in production mode.</span>
             </div>
@@ -51,9 +42,7 @@
                             <label class="label">
                                 <span class="label-text">Provider</span>
                             </label>
-                            <select name="provider"
-                                    class="select select-bordered w-full"
-                                    required>
+                            <select name="provider" class="select select-bordered w-full" required>
                                 <option value="" disabled {{ 'selected' if not app else '' }}>
                                     Select a provider
                                 </option>
@@ -65,9 +54,7 @@
                                 {% endfor %}
                             </select>
                             <label class="label">
-                                <span class="label-text-alt text-base-content/60">
-                                    Must be registered in tune.py or as a builtin
-                                </span>
+                                <span class="label-text-alt text-base-content/60">Must be registered in tune.py or as a builtin</span>
                             </label>
                         </div>
                         <!-- Name -->
@@ -107,9 +94,7 @@
                                    {{ '' if app else 'required' }} />
                             {% if app %}
                                 <label class="label">
-                                    <span class="label-text-alt text-base-content/60">
-                                        Leave empty to keep current secret
-                                    </span>
+                                    <span class="label-text-alt text-base-content/60">Leave empty to keep current secret</span>
                                 </label>
                             {% endif %}
                         </div>
@@ -133,43 +118,60 @@
                             </label>
                             <div id="scopes-container">
                                 <div class="flex flex-wrap gap-2 mb-2"
-                                     id="scopes-tags">
+                                     id="scopes-tags"
+                                     hx-on:click="const btn = event.target.closest('button[data-action=remove-scope]'); if (btn) btn.closest('.badge').remove();">
                                     {% if app and app.scopes %}
                                         {% for scope in app.scopes %}
-                                            <span class="badge badge-lg gap-1">
-                                                {{ scope }}
+                                            <span class="badge badge-lg gap-1" data-scope="{{ scope }}">
+                                                <span data-text>{{ scope }}</span>
                                                 <button type="button"
+                                                        data-action="remove-scope"
                                                         class="btn btn-ghost btn-xs px-0"
-                                                        onclick="removeScope(this)"
                                                         aria-label="Remove {{ scope }}">
                                                     <svg xmlns="http://www.w3.org/2000/svg"
                                                          class="h-3 w-3"
                                                          fill="none"
                                                          viewBox="0 0 24 24"
                                                          stroke="currentColor">
-                                                        <path stroke-linecap="round"
-                                                              stroke-linejoin="round"
-                                                              stroke-width="2"
-                                                              d="M6 18L18 6M6 6l12 12" />
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                                                     </svg>
                                                 </button>
                                             </span>
                                         {% endfor %}
                                     {% endif %}
                                 </div>
+                                <template id="scope-badge-template">
+                                    <span class="badge badge-lg gap-1">
+                                        <span data-text></span>
+                                        <button type="button"
+                                                data-action="remove-scope"
+                                                class="btn btn-ghost btn-xs px-0">
+                                            <svg xmlns="http://www.w3.org/2000/svg"
+                                                 class="h-3 w-3"
+                                                 fill="none"
+                                                 viewBox="0 0 24 24"
+                                                 stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </template>
                                 <div class="join w-full">
                                     <input type="text"
                                            id="scope-input"
                                            class="input input-bordered join-item w-full"
                                            placeholder="e.g. openid"
-                                           onkeydown="handleScopeKey(event)" />
+                                           hx-on:keydown="if (event.key !== 'Enter' && event.key !== ',') return; event.preventDefault(); addScope(this.value); this.value = '';" />
                                     <button type="button"
                                             class="btn btn-neutral join-item"
-                                            onclick="addScopeFromInput()">
+                                            hx-on:click="const input = q('#scope-input'); addScope(input.value); input.value = ''; input.focus();">
                                         Add
                                     </button>
                                 </div>
-                                <input type="hidden" name="scopes" id="scopes-hidden" />
+                                <input type="hidden"
+                                       name="scopes"
+                                       id="scopes-hidden"
+                                       hx-live="this.value = q('#scopes-tags .badge').arr().map(b => b.dataset.scope).join(',')" />
                             </div>
                             <label class="label">
                                 <span class="label-text-alt text-base-content/60">
@@ -201,11 +203,8 @@
                         </div>
                         <!-- Submit -->
                         <div class="card-actions justify-end">
-                            <a href="{{ url_for('debug_oauth_apps') }}"
-                               class="btn btn-ghost">Cancel</a>
-                            <button type="submit" class="btn btn-primary">
-                                {{ 'Save Changes' if app else 'Create App' }}
-                            </button>
+                            <a href="{{ url_for('debug_oauth_apps') }}" class="btn btn-ghost">Cancel</a>
+                            <button type="submit" class="btn btn-primary">{{ 'Save Changes' if app else 'Create App' }}</button>
                         </div>
                     </form>
                 </div>
@@ -216,48 +215,19 @@
 
     </div>
     <script>
-        function syncScopesHidden() {
-            const tags = document.getElementById("scopes-tags");
-            const hidden = document.getElementById("scopes-hidden");
-            const scopes = Array.from(tags.querySelectorAll(".badge"))
-                .map(badge => badge.firstChild.textContent.trim());
-            hidden.value = scopes.join(",");
-        }
-
         function addScope(value) {
             const scope = value.trim();
             if (!scope) return;
             const tags = document.getElementById("scopes-tags");
             const existing = Array.from(tags.querySelectorAll(".badge"))
-                .map(badge => badge.firstChild.textContent.trim());
+                .map(badge => badge.dataset.scope);
             if (existing.includes(scope)) return;
-
-            const span = document.createElement("span");
-            span.className = "badge badge-lg gap-1";
-            span.innerHTML = `${scope}<button type="button" class="btn btn-ghost btn-xs px-0" onclick="removeScope(this)" aria-label="Remove ${scope}"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg></button>`;
-            tags.appendChild(span);
-            syncScopesHidden();
+            const tpl = document.getElementById("scope-badge-template");
+            const node = tpl.content.firstElementChild.cloneNode(true);
+            node.dataset.scope = scope;
+            node.querySelector("[data-text]").textContent = scope;
+            node.querySelector("button").setAttribute("aria-label", `Remove ${scope}`);
+            tags.appendChild(node);
         }
-
-        function addScopeFromInput() {
-            const input = document.getElementById("scope-input");
-            addScope(input.value);
-            input.value = "";
-            input.focus();
-        }
-
-        function removeScope(button) {
-            button.closest(".badge").remove();
-            syncScopesHidden();
-        }
-
-        function handleScopeKey(event) {
-            if (event.key === "Enter" || event.key === ",") {
-                event.preventDefault();
-                addScopeFromInput();
-            }
-        }
-
-        syncScopesHidden();
     </script>
 {% endblock body %}

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -77,6 +77,53 @@ Add `import "./node_modules/htmx.org/dist/ext/hx-nonce.js";` to your
 `hx-nonce` will be stripped (fail-closed). See the
 [CSP/htmx docs](https://vibetuner.alltuner.com/development-guide/#htmx-nonce-protection-opt-in).
 
+## htmx Live Reactivity (default-on)
+
+`hx-live` is loaded by default from the framework-managed block of
+`config.js`. **Use it before reaching for Alpine.js or Stimulus** —
+it covers the same client-side-reactivity ground (chip lists, derived
+fields, live filters, paired controls, inline validation) without
+adding a separate library or breaking the project's "no JavaScript
+frameworks" stance.
+
+Quick patterns:
+
+```jinja
+{# Derived field that recomputes on every DOM mutation #}
+<input type="hidden" name="scopes"
+       hx-live="this.value = q('#scopes-tags .badge').arr()
+                             .map(b => b.dataset.scope).join(',')">
+
+{# Conditional class from a sibling input #}
+<p hx-live="this.classList.toggle('text-error',
+                                  q('#age').valueAsNumber < 18)">
+  Adult content
+</p>
+
+{# Debounced live search (per-element debounce cancels prior calls) #}
+<output hx-live="
+  let term = q('#q').value;
+  if (!term) { this.textContent = ''; return; }
+  await debounce(250);
+  this.textContent = await fetch('/search?q=' +
+    encodeURIComponent(term)).then(r => r.text());
+"></output>
+```
+
+CSP-safe by design — `hx-on:` / `hx-live` attributes evaluate
+through htmx's nonced TrustedTypes path, where raw inline
+`onclick="..."` would be blocked by the project's `script-src`
+policy.
+
+Gotchas to remember: the DOM is the only source of truth (no
+JS-variable reactivity, share state via `data-*` or hidden inputs);
+expressions re-run on **any** mutation so guard expensive work with
+`debounce`; set-property writes (`q('.x').value = ''`) broadcast to
+every match; `q().insert()` is raw `insertAdjacentHTML` and does
+not run `htmx.process()` — use event delegation on a stable parent
+for handlers on dynamically-inserted elements. Full reference:
+<https://four.htmx.org/extensions/hx-live/>.
+
 ## Response Caching (Server-Side)
 
 `from vibetuner.cache import cache, invalidate, invalidate_pattern`.

--- a/vibetuner-template/config.js
+++ b/vibetuner-template/config.js
@@ -3,6 +3,7 @@
 import htmx from "@alltuner/vibetuner/htmx";
 window.htmx = htmx;
 import "@alltuner/vibetuner/htmx/preload";
+import "@alltuner/vibetuner/htmx/live";
 // Do not change anything between this comment and the previous one
 
 // Add your custom imports below:


### PR DESCRIPTION
## Summary

Closes #1777.

- Adds htmx 4's `hx-live` extension as a default import in `vibetuner-template/config.js`, alongside `hx-preload`. Mirrors the existing `hx-preload` / `hx-sse` re-export pattern in `@alltuner/vibetuner` (new `htmx-live.js` + `./htmx/live` export entry).
- Rewrites the OAuth scope chip editor (`debug/oauth_app_form.html.jinja`) to use `hx-on:` + `hx-live`, dropping inline `onclick` / `onkeydown` handlers and 26 of the 40 lines of inline sync script. The new pattern works under vibetuner's strict `script-src 'nonce-X' 'strict-dynamic'` CSP (which blocks raw inline handler attributes at the spec level).
- Documents the idiomatic patterns and rough edges in `htmx-migration.md`, the `llms.txt` / `llms-full.txt` feature catalogues, and the scaffolded `.claude/rules/frontend.md`.

## Why default-on

- **CSP fit.** Inline `onclick=` / `onchange=` attributes are blocked by vibetuner's CSP. `hx-on:` and `hx-live` evaluate through htmx's nonced TrustedTypes pipeline.
- **Bundle cost is small.** One re-export wrapper + one `exports` entry. Extension auto-registers on import.
- **Plugs the "users reach for Alpine" hole** that #1777 explicitly calls out. Vibetuner stays "HTMX + Tailwind + DaisyUI. No JavaScript frameworks."
- **Breaking change in beta3 is a non-event** for framework code. `htmx.takeClass` / `htmx.forEvent` (moved out of core into this extension) have zero call sites across `vibetuner-py` / `vibetuner-template` / `vibetuner-jinja` / `vibetuner-js`.

## Test plan

- [x] `just lint-jinja` — passes (47/47 files, 0 errors)
- [x] `just lint-md` — my files clean (only unrelated README.md issues remain)
- [x] `vibetuner-js/package.json` JSON valid; `./htmx/live` export resolves to existing file
- [x] Pre-commit hooks (rumdl, djlint, etc.) — all passed
- [ ] Full scaffold-and-build smoke is blocked locally by an in-flight `@alltuner/vibetuner-jinja@10.14.2` publish lag (Renovate-style transitive). CI will resolve from the registry once the release publishes — verify CI green before merge.
- [ ] Post-merge: manual OAuth scope editor verification (add chip, remove chip, dedup, hidden-input sync) in a newly scaffolded project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)