### PR TITLE
fix(py): auto-register settings.project as a template global

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -464,18 +464,26 @@ Vibetuner provides these variables in every template automatically:
 
 | Variable | Type | Value |
 |----------|------|-------|
+| `request` | `Request` | The current Starlette `Request` |
+| `language` | `str` | Resolved request language (e.g. `"en"`, `"ca"`) |
+| `DEBUG` | `bool` | Mirrors `settings.debug` |
 | `now` | `datetime` | `datetime.now(timezone.utc)` — timezone-aware UTC datetime |
 | `today` | `str` | `date.today().isoformat()` — ISO date string (e.g., `"2026-04-07"`) |
+| `project` | `ProjectConfiguration` | `settings.project` — `project_name`, `company_name`, `copyright`, `fqdn`, … |
+| `brand` | `BrandSettings` | `settings.brand` — see [Brand Configuration](#brand-configuration) |
+| `csp_nonce` | `str` | Per-request CSP nonce (see [Security Headers and CSP Nonce](#security-headers-and-csp-nonce)) |
+| `hotreload` | `callable` | Dev-mode hot-reload helper |
 
 ```html
 <p>Page rendered at {{ now | format_datetime }}</p>
 <p>Today is {{ today }}</p>
-<footer>&copy; {{ now.year }} My Company</footer>
+<footer>{{ project.copyright }}</footer>
+<title>{{ project.project_name }}</title>
 ```
 
-These are re-evaluated on every render, so `now` reflects the current
-request time. For custom globals, see
-[Template Context Providers](#template-context-providers).
+`now` and `csp_nonce` are re-evaluated on every render; `project` and
+`brand` are app-level config snapshots resolved at startup. For custom
+globals, see [Template Context Providers](#template-context-providers).
 
 ### Built-in Template Filters
 
@@ -650,10 +658,14 @@ settings.brand.email_button         # email_button_color or primary_color
 
 `settings.brand` is exposed in every Jinja render via the shipped
 `_brand_context` provider, so templates read `{{ brand.primary_color }}`
-without wiring anything up. `BrandSettings` is deliberately app-level
-(favicon assets are static files served before tenant resolution; the
-email service does not see request context). For per-tenant in-page
-colors, use `TenantTheme`.
+without wiring anything up. The companion `_project_context` provider
+does the same for `settings.project`, so branded chrome (header logos,
+footers, OpenGraph defaults) can reference `{{ project.project_name }}`,
+`{{ project.copyright }}`, `{{ project.fqdn }}`, etc. without per-route
+context boilerplate. `BrandSettings` is deliberately app-level (favicon
+assets are static files served before tenant resolution; the email
+service does not see request context). For per-tenant in-page colors,
+use `TenantTheme`.
 
 ### Security Headers and CSP Nonce
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -398,12 +398,23 @@ player without touching upstream markup:
 
 These variables are available in every template automatically:
 
+- `request` — current Starlette `Request`
+- `language` — resolved request language (e.g. `"en"`, `"ca"`)
+- `DEBUG` — mirrors `settings.debug`
 - `now` — `datetime.now(timezone.utc)`, timezone-aware UTC datetime
 - `today` — `date.today().isoformat()`, ISO date string (e.g., `"2026-04-07"`)
+- `project` — `settings.project` (`ProjectConfiguration` loaded from
+  `config_vars.yaml`); use `project.project_name`, `project.company_name`,
+  `project.copyright`, `project.fqdn`, etc.
+- `brand` — `settings.brand` (`BrandSettings` from `BRAND_*` env vars);
+  see [Brand Configuration](#brand-configuration)
+- `csp_nonce` — per-request CSP nonce
+- `hotreload` — dev-mode hot-reload helper
 
 ```html
+<title>{{ project.project_name }}</title>
 <p>Page rendered at {{ now | format_datetime }}</p>
-<footer>&copy; {{ now.year }} My Company</footer>
+<footer>{{ project.copyright }}</footer>
 ```
 
 #### Built-in Template Filters
@@ -1578,6 +1589,13 @@ without wiring anything up. The framework's bundled
 `meta/browserconfig.xml.jinja` already do this; the magic-link email
 template receives `button_color=settings.brand.email_button` from
 `send_magic_link_email()`.
+
+The companion `_project_context` provider exposes `settings.project`
+(`ProjectConfiguration` loaded from `config_vars.yaml`) under the
+`project` template global, so branded chrome can reference
+`{{ project.project_name }}`, `{{ project.company_name }}`,
+`{{ project.copyright }}`, `{{ project.fqdn }}`, etc. without per-route
+context boilerplate.
 
 ### Service Dependency Injection
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -61,8 +61,10 @@ Important notes:
   `hx_push_url()`, `hx_reswap()`, `hx_retarget()`, `hx_refresh()`,
   `hx_replace_url()`, `hx_trigger_after_settle()`, `hx_trigger_after_swap()`.
   Handles JSON serialization internally. Import from `vibetuner.htmx`
-- **Built-in Template Globals**: `now` (UTC datetime) and `today` (ISO date string)
-  are available in all templates automatically
+- **Built-in Template Globals**: `request`, `language`, `DEBUG`, `now`
+  (UTC datetime), `today` (ISO date string), `project` (`settings.project`),
+  `brand` (`settings.brand`), `csp_nonce`, and `hotreload` are available
+  in all templates automatically
 - **Skeleton Extension Points**: `base/skeleton.html.jinja` exposes blocks
   (`extra_head_links`, `extra_scripts`, `before_main`, `after_main`) and
   context variables (`color_scheme`, `canonical_url`, `font_preloads`) so

--- a/vibetuner-py/src/vibetuner/rendering.py
+++ b/vibetuner-py/src/vibetuner/rendering.py
@@ -762,6 +762,23 @@ def _brand_context() -> dict[str, Any]:
 
 register_context_provider(_brand_context)
 
+
+def _project_context() -> dict[str, Any]:
+    """Expose project configuration (``settings.project``) to every template.
+
+    See :class:`vibetuner.config.ProjectConfiguration` for the fields backed
+    by ``config_vars.yaml``. Templates can reference ``{{ project.project_name }}``,
+    ``{{ project.company_name }}``, ``{{ project.copyright }}``, etc., so
+    branded chrome (header logos, footers, OpenGraph defaults) can be wired
+    without per-route context boilerplate.
+    """
+    from vibetuner.config import settings
+
+    return {"project": settings.project}
+
+
+register_context_provider(_project_context)
+
 # Global Vars
 jinja_env.globals.update({"DEBUG": data_ctx.DEBUG})
 

--- a/vibetuner-py/tests/unit/test_brand_settings.py
+++ b/vibetuner-py/tests/unit/test_brand_settings.py
@@ -247,3 +247,22 @@ def test_brand_context_provider_exposes_settings_brand():
     ctx = _collect_provider_context(request=request)
     assert "brand" in ctx
     assert isinstance(ctx["brand"], BrandSettings)
+
+
+def test_project_context_provider_exposes_settings_project():
+    """The shipped _project_context provider hands settings.project to every render.
+
+    Regression for #1827: scaffolded templates/frontend/CLAUDE.md promises project
+    settings are auto-available in every template, but `project` was never
+    registered. Templates referencing `{{ project.project_name }}` (e.g. branded
+    chrome) crashed with `UndefinedError: 'project' is undefined`.
+    """
+    from vibetuner.config import ProjectConfiguration
+    from vibetuner.rendering import _collect_provider_context
+
+    request = _StubRequest()
+    ctx = _collect_provider_context(request=request)
+    assert "project" in ctx
+    assert isinstance(ctx["project"], ProjectConfiguration)
+    # Sanity: the attribute the failing template touched is reachable.
+    assert hasattr(ctx["project"], "project_name")

--- a/vibetuner-template/.claude/rules/development.md
+++ b/vibetuner-template/.claude/rules/development.md
@@ -146,8 +146,13 @@ via `runtime_config={...}`. Read with `await get_config("key")`.
 Write with `await set_config("key", value)`.
 Debug UI at `/debug/config`. CLI: `vibetuner config list|set|delete`.
 
-**Built-in template globals**: `now` (UTC datetime), `today` (ISO
-date string) — available in all templates automatically.
+**Built-in template globals** (available in every template
+automatically): `request`, `language`, `DEBUG`, `now` (UTC datetime),
+`today` (ISO date string), `project` (`settings.project` —
+`project.project_name`, `project.company_name`, `project.copyright`,
+`project.fqdn`, …), `brand` (`settings.brand` — `brand.primary_color`,
+`brand.browser_theme_color`, `brand.email_button`), `csp_nonce`, and
+`hotreload`.
 
 ## Template Override
 

--- a/vibetuner-template/templates/frontend/AGENTS.md
+++ b/vibetuner-template/templates/frontend/AGENTS.md
@@ -109,11 +109,19 @@ Run `just lint-jinja` to check templates before committing.
 
 All templates automatically receive:
 
-- `request` - Current request object
-- `DEBUG` - Debug mode flag
-- `hotreload` - Hot reload function (dev mode)
-- Project settings from configuration
-- Current language/locale info
+- `request` — Current request object
+- `DEBUG` — Debug mode flag
+- `hotreload` — Hot reload function (dev mode)
+- `language` — Current request language (e.g. `"en"`, `"ca"`)
+- `project` — `settings.project` (`ProjectConfiguration` from
+  `config_vars.yaml`): `project.project_name`, `project.company_name`,
+  `project.copyright`, `project.fqdn`, etc.
+- `brand` — `settings.brand` (`BrandSettings` from `BRAND_*` env vars):
+  `brand.primary_color`, `brand.browser_theme_color`, `brand.email_button`
+- `now` / `today` — UTC datetime and ISO date string
+
+Need more globals? Use `register_globals({...})` or
+`@register_context_provider` from `vibetuner.rendering`.
 
 ## Template Inheritance
 


### PR DESCRIPTION
## Summary

- Add `_project_context` provider (mirror of `_brand_context`) so
  `settings.project` is exposed in every Jinja render as `project`,
  matching the promise scaffolded templates have been making for a
  while.
- Refresh built-in-template-globals docs (development-guide,
  `llms.txt`, `llms-full.txt`, scaffolded `templates/frontend/AGENTS.md`
  + `.claude/rules/development.md`) to enumerate the auto-available
  globals concretely (`project`, `brand`, `request`, `language`,
  `now`, `today`, `csp_nonce`, `hotreload`) instead of the vague
  "project settings from configuration" line.
- Pin the behavior with a regression test alongside the existing
  brand-provider test.

Before: a project that overrode `base/skeleton.html.jinja` to include
a `base/platform_header.html.jinja` referencing
`{{ project.project_name }}` 500'd on every framework-mounted route
with `UndefinedError: 'project' is undefined` — and because the
text/plain 500 page hit a URL with no extension (`/auth/login`),
Chromium tried to *download* it, hiding the cause.

Closes #1827

## Test plan

- [x] `uv run python -m pytest tests/unit` — 806 passed
- [x] `uv run python -m pytest tests/unit/test_brand_settings.py::test_project_context_provider_exposes_settings_project` — verifies the provider hands a `ProjectConfiguration` to every render
- [x] `just lint-py` — clean
- [x] pre-commit (ruff, rumdl, trailing whitespace, EOF) — clean
- [ ] Manually verify a scaffolded project rendering `{{ project.project_name }}` in a skeleton override no longer 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)