### PR TITLE
fix(template): run uv-lock only on pre-commit

### DIFF
--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     hooks:
       # Update the uv lockfile
       - id: uv-lock
-        stages: [pre-commit, post-checkout, post-merge, post-rewrite]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.15.12


### PR DESCRIPTION
## Summary

- The scaffolded `uv-lock` hook ran on `post-checkout`, `post-merge`, and `post-rewrite` in addition to `pre-commit`. With the hook pinned to a specific `uv` version, any skew against the user's installed CLI silently rewrites `uv.lock` on every branch switch / worktree create / merge / rebase, producing dirty diffs unrelated to the user's work (e.g. `[options].exclude-newer-span` toggling in and out of the lockfile).
- Drop the post-* stages and rely on `pre-commit` alone. The safety net (blocking commits when `pyproject.toml` and `uv.lock` are out of sync) is preserved; the lockfile churn on checkouts/merges/rebases is gone.

Closes #1830

## Test plan

- [ ] `git worktree add` from a freshly scaffolded project no longer produces a dirty `uv.lock`
- [ ] `pre-commit run uv-lock` still validates the lockfile on commit
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)