### PR TITLE
chore: autoupdate pre-commit hook revs

### DIFF
--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -7,18 +7,18 @@ repos:
       - id: no-commit-to-branch
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.13
+    rev: 0.11.14
     hooks:
       # Update the uv lockfile
       - id: uv-lock
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       # Run the linter (check only, no auto-fix).
       - id: ruff-check
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.91
+    rev: v0.1.93
     hooks:
       - id: rumdl
         name: rumdl check


### PR DESCRIPTION
## Summary

Ran `prek autoupdate` against the shared `vibetuner-template/.pre-commit-config.yaml` (the root `.pre-commit-config.yaml` is a symlink, so one bump covers both repo and scaffold). Bumps:

- `astral-sh/uv-pre-commit`: `0.11.13` → `0.11.14`
- `astral-sh/ruff-pre-commit`: `v0.15.12` → `v0.15.13`
- `rvben/rumdl-pre-commit`: `v0.1.91` → `v0.1.93`

## Heads-up

`ruff v0.15.13` (2026-05-14) and `rumdl v0.1.93` (2026-05-15) are both younger than 2 days. If you have a global `~/.config/uv/uv.toml` with `exclude-newer = "2 days"` (or similar), prek's hook install will reject them locally until they age in. CI has no such filter, so this is purely a local-dev quirk — installs unblock themselves over the next couple of days, or you can set `UV_EXCLUDE_NEWER=<future-date>` for a one-off install.

## Test plan

- [ ] CI passes (no exclude-newer filter on the runner)
- [ ] After hook ages in locally, `prek run --all-files` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)