### PR TITLE
fix(py): pair nosniff with text/plain fallback for bare Responses

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -712,6 +712,14 @@ Configure extra allowed sources via environment variables:
 | `CSP_ENFORCE_CSP_IN_DEBUG` | Enforce CSP in debug mode (default: `true`) |
 | `CSP_STYLE_SRC_STRICT` | Use the request nonce on `style-src` instead of `'unsafe-inline'` (default: `false`) |
 
+**Nosniff Content-Type guard.** The middleware always sets
+`X-Content-Type-Options: nosniff`. If a response has no `Content-Type`
+header (e.g. a bare `Response(status_code=404)` with no `media_type=`),
+the middleware fills in `text/plain; charset=utf-8` so browsers do not
+turn the response into an error page or a 0-byte download. App code
+should still set `media_type=` explicitly when it matters, but the
+guard prevents the worst-case UX when something slips through.
+
 ### htmx Nonce Protection (opt-in)
 
 !!! note "Requires `@alltuner/vibetuner` ≥ 10.11.0"

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1833,6 +1833,13 @@ instead. Configure extra sources via `CSP_EXTRA_SCRIPT_SRC`,
 `CSP_EXTRA_STYLE_SRC`, `CSP_EXTRA_IMG_SRC`, `CSP_EXTRA_CONNECT_SRC`,
 `CSP_EXTRA_FONT_SRC`, `CSP_EXTRA_MEDIA_SRC` environment variables.
 
+The middleware always sets `X-Content-Type-Options: nosniff`. If a
+response has no `Content-Type` header (e.g. a bare
+`Response(status_code=404)` with no `media_type=`), the middleware fills
+in `text/plain; charset=utf-8`. Without this guard, nosniff combined
+with a missing `Content-Type` makes Safari/Firefox save the response as
+a 0-byte download and Chrome show a generic error page.
+
 **Strict `style-src` (opt-in, requires `vibetuner` ≥ 10.11.0):** Set
 `CSP_STYLE_SRC_STRICT=true` to drop `'unsafe-inline'` from `style-src`
 and use the request nonce instead. Inline `style="..."` attributes will

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -117,7 +117,11 @@ Important notes:
   environment variables (e.g., `CSP_EXTRA_SCRIPT_SRC`). Set `CSP_STYLE_SRC_STRICT=true`
   to drop `'unsafe-inline'` from `style-src` and require nonces on `<style>` tags
   (opt-in hardening; framework templates already nonce every `<style>`). Requires
-  `vibetuner` ≥ 10.11.0 (older releases silently ignore the env var)
+  `vibetuner` ≥ 10.11.0 (older releases silently ignore the env var). The middleware
+  also pairs nosniff with a `text/plain; charset=utf-8` fallback when a response has
+  no `Content-Type` (e.g. a bare `Response(status_code=404)`), so bare responses do
+  not get turned into 0-byte browser downloads (Safari/Firefox) or generic error
+  pages (Chrome)
 - **htmx Nonce Protection (opt-in)**: htmx 4.0.0-beta3 ships an `hx-nonce` extension
   that gates htmx attribute processing behind the page CSP nonce. Framework templates
   stamp `hx-nonce="{{ csp_nonce }}"` on htmx-bearing elements; mirror that pattern in

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -169,6 +169,12 @@ class SecurityHeadersMiddleware:
             "camera=(), microphone=(), geolocation=(), payment=()"
         )
 
+        # Pair nosniff with a fallback Content-Type. A bare Response() with no
+        # media_type sends nosniff + missing Content-Type, which Safari/Firefox
+        # turn into a 0-byte download and Chrome turns into a generic error.
+        if "content-type" not in headers:
+            headers["Content-Type"] = "text/plain; charset=utf-8"
+
         if "server" in headers:
             del headers["server"]
 

--- a/vibetuner-py/tests/unit/test_security_headers_middleware.py
+++ b/vibetuner-py/tests/unit/test_security_headers_middleware.py
@@ -106,6 +106,12 @@ class SecurityHeadersMiddleware:
             "camera=(), microphone=(), geolocation=(), payment=()"
         )
 
+        # Pair nosniff with a fallback Content-Type. A bare Response() with no
+        # media_type sends nosniff + missing Content-Type, which Safari/Firefox
+        # turn into a 0-byte download and Chrome turns into a generic error.
+        if "content-type" not in headers:
+            headers["Content-Type"] = "text/plain; charset=utf-8"
+
         if "server" in headers:
             del headers["server"]
 
@@ -195,6 +201,19 @@ def _make_app(settings: _Settings | None = None, html_body: str | None = None):
     # Stash list on wrapper for test access
     app._captured_nonces = captured_nonces  # type: ignore[attr-defined]
     return app
+
+
+def _make_bare_response_app(settings: _Settings | None = None, status_code: int = 404):
+    """Create an app that returns a bare Response with no media_type set."""
+    from starlette.applications import Starlette
+    from starlette.responses import Response
+    from starlette.routing import Route
+
+    async def bare(_request):
+        return Response(status_code=status_code)
+
+    inner = Starlette(routes=[Route("/{path:path}", bare), Route("/", bare)])
+    return SecurityHeadersMiddleware(inner, settings=settings)
 
 
 class TestSecurityHeadersMiddleware:
@@ -467,3 +486,37 @@ class TestCspNonceAutoInjection:
         with caplog.at_level(logging.WARNING, logger="vibetuner.security"):
             client.get("/")
         assert not any("empty nonce" in r.message for r in caplog.records)
+
+
+class TestBareResponseContentType:
+    """Test the nosniff Content-Type guard for bare responses without media_type."""
+
+    def test_bare_response_gets_default_content_type(self):
+        """A bare Response() with no media_type gets a fallback Content-Type.
+
+        Without this guard, the nosniff header combined with a missing
+        Content-Type makes browsers either error out (Chrome) or save the
+        response as a 0-byte download (Safari/Firefox).
+        """
+        app = _make_bare_response_app()
+        client = TestClient(app)
+        resp = client.get("/blocked")
+        assert resp.status_code == 404
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+        assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
+
+    def test_explicit_content_type_is_preserved(self):
+        """Responses that already set a Content-Type are left alone."""
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+
+        async def handler(_request):
+            return JSONResponse({"ok": True}, status_code=418)
+
+        inner = Starlette(routes=[Route("/", handler)])
+        app = SecurityHeadersMiddleware(inner)
+        client = TestClient(app)
+        resp = client.get("/")
+        assert resp.status_code == 418
+        assert resp.headers["Content-Type"] == "application/json"


### PR DESCRIPTION
## Summary

- `SecurityHeadersMiddleware` now sets `Content-Type: text/plain; charset=utf-8` when a response has no Content-Type header, alongside the existing `X-Content-Type-Options: nosniff` header.
- Closes the browser-confusion vector where a bare `Response(status_code=404)` (or any response without `media_type=`) was being turned into a 0-byte download by Safari/Firefox or a generic `chrome-error://chromewebdata/` page by Chrome.
- Adds unit tests covering both the new fallback path and the preservation of explicit Content-Types.
- Documents the guard in the development guide and the `llms.txt` / `llms-full.txt` LLM references.

Fixes #1833.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_security_headers_middleware.py` — 30 passed
- [x] `uv run ruff check` and `uv run ruff format --check` on the touched files — clean
- [x] Pre-commit hooks (ruff, rumdl) — clean
- [ ] Manual repro: hit a route that returns `Response(status_code=404)` in Safari and confirm a plain 404 instead of a 0-byte download

🤖 Generated with [Claude Code](https://claude.com/claude-code)