### PR TITLE
docs(theming): document cascade override for DaisyUI brand palette

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -606,19 +606,68 @@ async def signup(email: str):
 
 ### Styling with Tailwind
 
-Vibetuner uses Tailwind CSS + DaisyUI. Edit `assets/config.css` for custom styles:
+Vibetuner uses Tailwind v4 + DaisyUI. The scaffolded `config.css` lives at
+the project root and pulls everything in via the shipped core stylesheet:
 
 ```css
-/* assets/config.css */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-.btn-custom {
-@apply btn btn-primary rounded-full;
+/* config.css */
+@import "@alltuner/vibetuner/core.css";
+@source "templates";
+@source "assets/statics/js";
+
+/* Add your custom styles below: */
+```
+
+`core.css` already imports `tailwindcss` and registers the `daisyui`
+plugin, so you can use any DaisyUI component class and any Tailwind v4
+utility in your templates without further configuration. Define
+Tailwind tokens with `@theme { ... }` and write component classes
+with `@layer components { .btn-custom { @apply btn btn-primary; } }`.
+
+The build process compiles `config.css` to `assets/statics/css/bundle.css`
+on `just dev` / `just local-all` / `bun run build:css`.
+
+#### Brand palette (build-time)
+
+To recolor DaisyUI's `light` / `dark` themes for the whole bundle,
+override the `[data-theme="…"]` selectors below the `@import`:
+
+```css
+@import "@alltuner/vibetuner/core.css";
+@source "templates";
+@source "assets/statics/js";
+
+[data-theme="light"] {
+  --color-primary: oklch(64% 0.21 24);
+  --color-primary-content: oklch(98% 0 0);
+  --color-accent: oklch(82% 0.18 95);
+}
+
+[data-theme="dark"] {
+  --color-primary: oklch(64% 0.21 24);
+  --color-primary-content: oklch(98% 0 0);
+  --color-accent: oklch(82% 0.18 95);
 }
 ```
 
-The build process automatically compiles to `assets/statics/css/bundle.css`.
+`core.css` invokes `@plugin "daisyui"`, which emits rules like
+`:where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light] { … }`.
+The override above shares specificity with the standalone
+`[data-theme=light]` matcher and lands later in the file — cascade
+picks it up automatically. For per-tenant runtime overrides on top of
+this, see the [Theming](theming.md) guide.
+
+!!! note "When a brand-new named theme is needed"
+    DaisyUI's documented `@plugin "daisyui/theme" { name: "my-brand"; … }`
+    form lets projects define entirely new themes, but `daisyui` is a
+    private transitive of `@alltuner/vibetuner`, so resolution from a
+    consumer-side `config.css` fails under bun's isolated linker with
+    `Error: Can't resolve 'daisyui/theme'`. If you genuinely need this
+    (most projects don't — overriding `[data-theme="…"]` is enough),
+    add `daisyui` as a direct devDependency:
+    `bun add -d daisyui` and re-run `bun install`. The top-level
+    symlink makes `@plugin "daisyui/theme"` resolvable from
+    `config.css`.
 
 ### Brand Configuration
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1317,6 +1317,63 @@ def analytics_context() -> dict:
 Values from providers and globals are merged into every `render_template()` call.
 User-provided context in the render call takes precedence.
 
+### Build-time Brand Palette
+
+DaisyUI's `light` and `dark` themes are emitted by `@plugin "daisyui"`
+inside `@alltuner/vibetuner/core.css`. To recolor the four DaisyUI role
+colors across the whole compiled `bundle.css`, override the
+`[data-theme="…"]` selectors directly in your project's `config.css`:
+
+```css
+@import "@alltuner/vibetuner/core.css";
+@source "templates";
+@source "assets/statics/js";
+
+[data-theme="light"] {
+  --color-primary: oklch(64% 0.21 24);
+  --color-primary-content: oklch(98% 0 0);
+  --color-accent: oklch(82% 0.18 95);
+}
+
+[data-theme="dark"] {
+  --color-primary: oklch(64% 0.21 24);
+  --color-primary-content: oklch(98% 0 0);
+  --color-accent: oklch(82% 0.18 95);
+}
+```
+
+DaisyUI emits a rule like
+`:where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light] { … }`.
+The override above shares specificity with the standalone
+`[data-theme=light]` matcher and lands later in the file — cascade
+picks it up. No consumer-side `daisyui` install is required.
+
+**Caveat — DaisyUI theme-controller radio inputs.** If your UI relies on
+DaisyUI's `<input class="theme-controller" value="light">` switcher
+pattern *without* setting `data-theme` on the root element, the
+matching selector is `:root:has(input.theme-controller[value=…]:checked)`
+which has higher specificity than `[data-theme="…"]`. The override is
+bypassed for that path. Set `data-theme="…"` on `<html>` directly to
+keep the override pattern intact.
+
+**Brand-new named themes.** DaisyUI's documented `@plugin "daisyui/theme"
+{ name: "my-brand"; … }` form lets projects register entirely new
+themes. It is **not** resolvable from a consumer-side `config.css` by
+default: `daisyui` is a private transitive of `@alltuner/vibetuner`, so
+bun's isolated linker keeps it scoped to that package only — the
+consumer's `config.css` resolves modules from the project root and
+fails with `Error: Can't resolve 'daisyui/theme'`. Add it explicitly:
+
+```bash
+bun add -d daisyui
+bun install
+```
+
+The top-level symlink makes `@plugin "daisyui/theme"` resolvable.
+
+For per-request runtime overrides on top of the build-time palette
+(per-tenant branding), see the next section.
+
 ### Per-Tenant Theming
 
 Multi-tenant apps can swap DaisyUI role colors per tenant without rebuilding

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -26,7 +26,7 @@ Important notes:
 - [Background Tasks](https://vibetuner.alltuner.com/background-tasks/): Background task system powered by Streaq and Redis with retries, cron scheduling, and SSE integration
 - [Runtime Configuration](https://vibetuner.alltuner.com/runtime-config/): Layered configuration system with MongoDB persistence, debug UI, and feature flags
 - [HTMX v2 to v4 Migration](https://vibetuner.alltuner.com/htmx-migration/): Breaking changes and migration guide for upgrading from HTMX v2 to v4
-- [Per-Tenant Theming](https://vibetuner.alltuner.com/theming/): Embedded `TenantTheme` model + opt-in `register_tenant_theme_provider()` helper + shipped `base/theme.html.jinja` partial that injects DaisyUI role-color overrides at request time
+- [Theming](https://vibetuner.alltuner.com/theming/): Build-time brand palette via cascade override of DaisyUI's `[data-theme="…"]` selectors in `config.css` (no consumer-side `daisyui` dep needed), plus runtime per-tenant overrides via the embedded `TenantTheme` model + opt-in `register_tenant_theme_provider()` helper + shipped `base/theme.html.jinja` partial that injects DaisyUI role-color overrides at request time
 
 ## Features
 

--- a/vibetuner-docs/docs/theming.md
+++ b/vibetuner-docs/docs/theming.md
@@ -1,4 +1,69 @@
-# Per-Tenant Theming
+# Theming
+
+Vibetuner separates **build-time brand palette** (one set of role colors
+baked into `bundle.css`) from **runtime per-tenant overrides** (a small
+`<style>` block injected per request). Both pivot on the same cascade
+trick — overriding the variables DaisyUI emits, not the plugin that emits
+them.
+
+## Build-time brand palette
+
+DaisyUI's `light` and `dark` themes are emitted by `@plugin "daisyui"`
+inside `@alltuner/vibetuner/core.css`. To customise the four role colors
+across the whole bundle, override the `[data-theme="…"]` selectors
+directly in your project's `config.css`:
+
+```css
+@import "@alltuner/vibetuner/core.css";
+@source "templates";
+@source "assets/statics/js";
+
+[data-theme="light"] {
+  --color-primary: oklch(64% 0.21 24);
+  --color-primary-content: oklch(98% 0 0);
+  --color-accent: oklch(82% 0.18 95);
+}
+
+[data-theme="dark"] {
+  --color-primary: oklch(64% 0.21 24);
+  --color-primary-content: oklch(98% 0 0);
+  --color-accent: oklch(82% 0.18 95);
+}
+```
+
+DaisyUI emits a rule like
+`:where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light] { … }`.
+The override above has the same specificity as the standalone
+`[data-theme=light]` matcher and lands later in the file — cascade
+picks the consumer rules.
+
+**Caveat — DaisyUI theme-controller radio inputs.** If your UI uses
+DaisyUI's `<input class="theme-controller" value="light">` switcher
+pattern (without setting `data-theme` on the root element), the
+selector that matches at runtime is
+`:root:has(input.theme-controller[value=light]:checked)`, which has
+higher specificity than `[data-theme="light"]`. The override is then
+bypassed for that path. Most projects set `data-theme` on `<html>`
+directly, where the override pattern works as expected.
+
+**Escape hatch — brand-new named themes.** DaisyUI's documented
+`@plugin "daisyui/theme" { name: "my-brand"; … }` form lets projects
+register entirely new themes. It is **not** reachable from a
+consumer-side `config.css` by default: `daisyui` is a private
+transitive of `@alltuner/vibetuner`, so bun's isolated linker keeps
+it out of the project's root `node_modules`. Add it explicitly when
+you need this:
+
+```bash
+bun add -d daisyui
+bun install
+```
+
+The top-level symlink makes `@plugin "daisyui/theme"` resolvable from
+`config.css`. Most projects don't need this — overriding
+`[data-theme="…"]` is enough.
+
+## Per-tenant theming
 
 Multi-tenant Vibetuner apps often need per-tenant visual identity — at minimum
 the four DaisyUI role colors and their content variants. Vibetuner ships a

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -3,10 +3,47 @@ paths:
   - templates/frontend/**
   - assets/**
   - src/*/frontend/**
+  - config.css
 description: HTMX patterns, SSE, caching, block rendering, and Tailwind/DaisyUI
 ---
 
 # Frontend Patterns
+
+## DaisyUI palette overrides
+
+To recolor the DaisyUI `light` / `dark` themes for the whole bundle,
+override the `[data-theme="…"]` selectors in `config.css` below the
+`@import "@alltuner/vibetuner/core.css"`:
+
+```css
+[data-theme="light"] {
+  --color-primary: oklch(64% 0.21 24);
+  --color-primary-content: oklch(98% 0 0);
+}
+[data-theme="dark"] {
+  --color-primary: oklch(64% 0.21 24);
+  --color-primary-content: oklch(98% 0 0);
+}
+```
+
+`core.css` invokes `@plugin "daisyui"`, which emits a rule of the form
+`:where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light] { … }`.
+The override above shares specificity with the standalone
+`[data-theme=light]` matcher and lands later in `config.css` — cascade
+picks it up. No `daisyui` install on the consumer side is required.
+
+**Do not write `@plugin "daisyui/theme" { … }` in `config.css`.**
+`daisyui` is a private transitive of `@alltuner/vibetuner`; bun's
+isolated linker keeps it scoped to that package, so module resolution
+from the project root fails with `Error: Can't resolve 'daisyui/theme'`.
+Use the `[data-theme="…"]` cascade override above. If a project
+genuinely needs a brand-new named theme, add `daisyui` as a direct
+devDependency (`bun add -d daisyui`) — but for recoloring the existing
+themes, the cascade override is the right tool.
+
+For per-request runtime overrides (per-tenant branding), use
+`register_tenant_theme_provider` — see the
+[theming guide](https://vibetuner.alltuner.com/theming/).
 
 ## SSE
 

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -253,6 +253,15 @@ extend `base/skeleton.html.jinja`.
 (`text-[13px]`, `bg-[#1DB954]`). Define tokens in `config.css`
 `@theme {}`. No inline styles.
 
+**DaisyUI palette**: Override `[data-theme="light"]` / `[data-theme="dark"]`
+in `config.css` (cascade-after the `@import "@alltuner/vibetuner/core.css"`)
+to recolor the role variables. Do **not** add `@plugin "daisyui/theme"`
+in `config.css` — `daisyui` is a private transitive of `@alltuner/vibetuner`
+and bun's isolated linker keeps it scoped, so resolution fails from the
+project root. The cascade-override pattern needs no extra dep. See the
+commented example in the scaffolded `config.css` and
+<https://vibetuner.alltuner.com/theming/#build-time-brand-palette>.
+
 ---
 
 ## Important Rules

--- a/vibetuner-template/config.css
+++ b/vibetuner-template/config.css
@@ -7,4 +7,21 @@
 
 /* Add your custom styles below: */
 
+/* Brand palette overrides. DaisyUI emits its built-in `light` and `dark`
+ * themes from `@plugin "daisyui"` inside core.css; override the
+ * `[data-theme="..."]` selectors below to recolor without re-running the
+ * plugin. CSS cascade does the work — these rules come later in the file
+ * and win on source order. See
+ * https://vibetuner.alltuner.com/theming/#build-time-brand-palette
+ *
+ * [data-theme="light"] {
+ *   --color-primary: oklch(64% 0.21 24);
+ *   --color-primary-content: oklch(98% 0 0);
+ * }
+ * [data-theme="dark"] {
+ *   --color-primary: oklch(64% 0.21 24);
+ *   --color-primary-content: oklch(98% 0 0);
+ * }
+ */
+
 /* End of File: do not remove this comment or add anything below */


### PR DESCRIPTION
## Summary

- Document the cascade-override pattern for recoloring DaisyUI's `light`/`dark` palette from a consumer's `config.css` (override `[data-theme="…"]`, no extra dep needed).
- Call out the bun-isolated-linker resolution failure for `@plugin "daisyui/theme"` and the escape hatch (`bun add -d daisyui`) for projects that need brand-new named themes.
- Replace the stale Tailwind v3 styling example in the development guide with v4-native content.

Updated surfaces:

- `vibetuner-docs/docs/theming.md` — new "Build-time brand palette" section above the existing per-tenant theming content.
- `vibetuner-docs/docs/development-guide.md` — rewrites the "Styling with Tailwind" section (was emitting `@tailwind base/components/utilities` v3 syntax and pointing at the wrong path).
- `vibetuner-docs/docs/llms.txt` + `llms-full.txt` — feature-entry update and a detailed section mirroring the docs page.
- `vibetuner-template/config.css` — commented brand-palette example under "Add your custom styles below:" so the pattern is discoverable in fresh scaffolds.
- `vibetuner-template/AGENTS.md` + `.claude/rules/frontend.md` — agent-facing guidance so future agents working in scaffolded projects use the override pattern instead of `@plugin "daisyui/theme"`.

Refs #1836.

## Test plan

- [x] Built a scaffolded `config.css` with the documented override pattern — clean `daisyUI 5.5.19` build, 90 KB bundle, override emitted after DaisyUI's `[data-theme=light]` rule (verified line ordering in compiled output).
- [x] Confirmed pre-commit hooks pass locally (rumdl, ruff, taplo, djlint, lint-po, uv-lock).
- [x] Verified no Tailwind v3 syntax (`@tailwind base/components/utilities`) remains anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)