### PR TITLE
fix(py): omit timeout when robust_cron caller does not set one

### DIFF
--- a/vibetuner-py/src/vibetuner/tasks/robust.py
+++ b/vibetuner-py/src/vibetuner/tasks/robust.py
@@ -252,12 +252,12 @@ def robust_cron(
             backoff_max=backoff_max,
             on_failure=on_failure,
         )
-        return worker.cron(
-            tab,
-            name=task_name,
-            max_tries=max_retries,
-            timeout=timeout,
-            **cron_kwargs,
-        )(fn)
+        cron_call_kwargs: dict[str, Any] = {
+            "name": task_name,
+            "max_tries": max_retries,
+        }
+        if timeout is not None:
+            cron_call_kwargs["timeout"] = timeout
+        return worker.cron(tab, **cron_call_kwargs, **cron_kwargs)(fn)
 
     return decorator

--- a/vibetuner-py/tests/unit/test_robust_cron.py
+++ b/vibetuner-py/tests/unit/test_robust_cron.py
@@ -24,13 +24,18 @@ def _make_mock_worker():
     worker = MagicMock()
     worker.middleware = lambda fn: fn
 
-    def fake_cron(tab, *, max_tries=3, name=None, timeout=None, **kwargs):
+    def fake_cron(tab, **kwargs):
         def decorator(fn):
             fn._cron_tab = tab
-            fn._cron_name = name
-            fn._cron_max_tries = max_tries
-            fn._cron_timeout = timeout
-            fn._cron_kwargs = kwargs
+            fn._cron_name = kwargs.get("name")
+            fn._cron_max_tries = kwargs.get("max_tries", 3)
+            fn._cron_timeout = kwargs.get("timeout")
+            fn._cron_call_kwargs = kwargs
+            fn._cron_kwargs = {
+                k: v
+                for k, v in kwargs.items()
+                if k not in {"name", "max_tries", "timeout"}
+            }
             return fn
 
         return decorator
@@ -102,6 +107,21 @@ class TestRobustCron:
             pass
 
         assert my_cron._cron_timeout == 60
+
+    @patch("vibetuner.tasks.worker.get_worker")
+    def test_omits_timeout_when_not_provided(self, mock_get_worker):
+        """Without an explicit timeout, robust_cron must not forward
+        timeout=None to worker.cron(); unique cron tasks would otherwise
+        fail with 'Unique tasks must have a timeout set!'.
+        """
+        worker = _make_mock_worker()
+        mock_get_worker.return_value = worker
+
+        @robust_cron("*/5 * * * *")
+        async def my_cron():
+            pass
+
+        assert "timeout" not in my_cron._cron_call_kwargs
 
     @patch("vibetuner.tasks.worker.get_worker")
     def test_custom_retry_config(self, mock_get_worker):


### PR DESCRIPTION
## Summary

- `robust_cron` was forwarding `timeout=timeout` to `worker.cron()` unconditionally, so the default `timeout=None` overrode Streaq's `timedelta(hours=1)` default. With `unique=True` (also a default), decoration raised `StreaqError: Unique tasks must have a timeout set!`.
- Only forward `timeout` when the caller explicitly sets one, letting Streaq's own default apply otherwise.

Fixes #1837.

## Test plan

- [x] Added `test_omits_timeout_when_not_provided` — confirmed it fails before the fix and passes after.
- [x] Existing `test_forwards_timeout` still passes (explicit timeout is still forwarded).
- [x] Full `vibetuner-py` unit suite passes (809 tests).
- [x] End-to-end repro against a real Streaq `Worker.cron(...)`: `@robust_cron("*/5 * * * *", max_retries=3)` no longer raises at decoration time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)