### PR TITLE
fix(py): make render_template signature explicit and accept context= alias

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -385,6 +385,22 @@ The same convention applies to `{% extends %}` and `{% include %}` inside templa
 {% extends "frontend/base/skeleton.html.jinja" %} {# wrong #}
 ```
 
+#### Passing Context
+
+The user context dict can be passed positionally, as `ctx=`, or as `context=`
+(the two keywords are aliases — `context=` exists because that's what most
+Flask/Starlette muscle memory reaches for):
+
+```python
+render_template("home.html.jinja", request, {"hero": hero})           # positional
+render_template("home.html.jinja", request, ctx={"hero": hero})       # ctx kwarg
+render_template("home.html.jinja", request, context={"hero": hero})   # alias
+```
+
+Passing both `ctx=` and `context=` raises `TypeError`. Misspelled or unknown
+kwargs (e.g. `contxt=`) also raise `TypeError` — the signature is explicit, so
+typos can't silently render with an empty context.
+
 #### Skeleton Extension Points
 
 The shipped `base/skeleton.html.jinja` exposes blocks and context variables so

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1317,6 +1317,26 @@ def analytics_context() -> dict:
 Values from providers and globals are merged into every `render_template()` call.
 User-provided context in the render call takes precedence.
 
+#### Passing user context
+
+`render_template()`, `render_template_string()`, `render_template_stream()`,
+`render_template_block()` and `render_template_blocks()` all accept the user
+context dict positionally, as `ctx=`, or as `context=` (an alias for `ctx=`).
+
+```python
+render_template("home.html.jinja", request, {"hero": hero})           # positional
+render_template("home.html.jinja", request, ctx={"hero": hero})       # ctx kwarg
+render_template("home.html.jinja", request, context={"hero": hero})   # alias
+```
+
+Passing both `ctx=` and `context=` raises `TypeError`. Unknown kwargs (typos
+like `contxt=` or anything Starlette's `TemplateResponse` doesn't recognise)
+also raise `TypeError` — the signature is explicit, so a misspelled context
+keyword cannot silently render with an empty context.
+
+`render_template()` additionally accepts the response-shaping kwargs forwarded
+to `TemplateResponse`: `status_code`, `headers`, `media_type`, `background`.
+
 ### Build-time Brand Palette
 
 DaisyUI's `light` and `dark` themes are emitted by `@plugin "daisyui"`

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -47,6 +47,9 @@ Important notes:
 - **Block Rendering**: `render_template_block(template, block_name, request, ctx)`
   renders a single `{% block %}` for HTMX partials. `render_template_blocks()` renders
   multiple blocks for OOB swaps. No extra dependencies. Import from `vibetuner`
+- **Context kwarg**: `render_template*` accepts the user context positionally, as
+  `ctx=`, or as `context=` (alias for `ctx=`). Passing both, or any unknown kwarg,
+  raises `TypeError` — typos cannot silently render with an empty context
 - **`@cache` Decorator**: `@cache(expire=60)` caches route responses in Redis.
   Key derived from path + query params. Use `vary_on=lambda r: str(r.state.user.id)`
   for request-dependent keys (per-user, per-tenant). Disabled in debug mode

--- a/vibetuner-py/src/vibetuner/rendering.py
+++ b/vibetuner-py/src/vibetuner/rendering.py
@@ -460,7 +460,12 @@ def render_template(
     template: str,
     request: Request,
     ctx: dict[str, Any] | None = None,
-    **kwargs: Any,
+    *,
+    context: dict[str, Any] | None = None,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+    media_type: str | None = None,
+    background: Any = None,
 ) -> HTMLResponse:
     """Render a Jinja2 template and return an HTMLResponse.
 
@@ -472,7 +477,11 @@ def render_template(
             Use ``"blog/list.html.jinja"``, **not** ``"frontend/blog/list.html.jinja"``.
         request: FastAPI Request object.
         ctx: Optional context dictionary merged into the template context.
-        **kwargs: Extra keyword arguments forwarded to ``TemplateResponse``.
+        context: Alias for ``ctx``. Passing both raises ``TypeError``.
+        status_code: HTTP status code for the response.
+        headers: Optional response headers.
+        media_type: Optional response media type (e.g. ``"application/xml"``).
+        background: Optional Starlette ``BackgroundTask``.
 
     Returns:
         HTMLResponse with the rendered template.
@@ -486,27 +495,25 @@ def render_template(
         # Wrong - "frontend/" prefix is redundant and will cause a TemplateNotFound error
         render_template("frontend/blog/list.html.jinja", request)  # TemplateNotFound!
     """
-    _ensure_custom_filters()
-    ctx = ctx or {}
-    language = getattr(request.state, "language", data_ctx.default_language)
-    with _context_lock:
-        globals_snapshot = dict(_template_globals)
-    merged_ctx = {
-        **data_ctx.model_dump(),
-        **globals_snapshot,
-        **_collect_provider_context(request=request),
-        "request": request,
-        "language": language,
-        **ctx,
-    }
+    ctx = _resolve_render_ctx(ctx, context)
+    merged_ctx = _build_merged_ctx(request, ctx)
 
-    return templates.TemplateResponse(template, merged_ctx, **kwargs)
+    return templates.TemplateResponse(
+        template,
+        merged_ctx,
+        status_code=status_code,
+        headers=headers,
+        media_type=media_type,
+        background=background,
+    )
 
 
 def render_template_string(
     template: str,
     request: Request,
     ctx: dict[str, Any] | None = None,
+    *,
+    context: dict[str, Any] | None = None,
 ) -> str:
     """Render a template to a string instead of HTMLResponse.
 
@@ -517,6 +524,7 @@ def render_template_string(
         template: Path to template file (e.g., "admin/partials/episode.html.jinja")
         request: FastAPI Request object
         ctx: Optional context dictionary to pass to template
+        context: Alias for ``ctx``. Passing both raises ``TypeError``.
 
     Returns:
         str: Rendered template as a string
@@ -528,20 +536,8 @@ def render_template_string(
             {"episode": episode}
         )
     """
-    _ensure_custom_filters()
-    ctx = ctx or {}
-    language = getattr(request.state, "language", data_ctx.default_language)
-    with _context_lock:
-        globals_snapshot = dict(_template_globals)
-    merged_ctx = {
-        **data_ctx.model_dump(),
-        **globals_snapshot,
-        **_collect_provider_context(request=request),
-        "request": request,
-        "language": language,
-        **ctx,
-    }
-
+    ctx = _resolve_render_ctx(ctx, context)
+    merged_ctx = _build_merged_ctx(request, ctx)
     template_obj = templates.get_template(template)
     return template_obj.render(merged_ctx)
 
@@ -550,6 +546,8 @@ def render_template_stream(
     template: str,
     request: Request,
     ctx: dict[str, Any] | None = None,
+    *,
+    context: dict[str, Any] | None = None,
 ) -> StreamingResponse:
     """Render a template as a streaming HTML response.
 
@@ -565,6 +563,7 @@ def render_template_stream(
         template: Path to template file relative to ``templates/frontend/``.
         request: FastAPI Request object.
         ctx: Optional context dictionary merged into the template context.
+        context: Alias for ``ctx``. Passing both raises ``TypeError``.
 
     Returns:
         StreamingResponse with ``media_type="text/html"``.
@@ -583,26 +582,32 @@ def render_template_stream(
         streaming.  Use this for full page loads where the ``<head>`` and
         initial layout should reach the browser as early as possible.
     """
-    _ensure_custom_filters()
-    ctx = ctx or {}
-    language = getattr(request.state, "language", data_ctx.default_language)
-    with _context_lock:
-        globals_snapshot = dict(_template_globals)
-    merged_ctx = {
-        **data_ctx.model_dump(),
-        **globals_snapshot,
-        **_collect_provider_context(request=request),
-        "request": request,
-        "language": language,
-        **ctx,
-    }
-
+    ctx = _resolve_render_ctx(ctx, context)
+    merged_ctx = _build_merged_ctx(request, ctx)
     template_obj = templates.get_template(template)
 
     def _generate():
         yield from template_obj.generate(**merged_ctx)
 
     return StreamingResponse(_generate(), media_type="text/html")
+
+
+def _resolve_render_ctx(
+    ctx: dict[str, Any] | None,
+    context: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Reconcile the ``ctx`` and ``context`` kwargs.
+
+    ``context`` is accepted as an alias for ``ctx`` because that name is what
+    most Flask/Starlette users reach for by default. Passing both at once is
+    almost certainly a mistake, so we raise rather than silently picking one.
+    """
+    if ctx is not None and context is not None:
+        raise TypeError(
+            "render_template() received both 'ctx' and 'context'; "
+            "pass only one (they are aliases)."
+        )
+    return context if ctx is None else ctx
 
 
 def _build_merged_ctx(
@@ -629,6 +634,8 @@ def render_template_block(
     block_name: str,
     request: Request,
     ctx: dict[str, Any] | None = None,
+    *,
+    context: dict[str, Any] | None = None,
 ) -> HTMLResponse:
     """Render a single named ``{% block %}`` from a template.
 
@@ -640,6 +647,7 @@ def render_template_block(
         block_name: Name of the ``{% block %}`` to render.
         request: FastAPI Request object.
         ctx: Optional context dictionary merged into the template context.
+        context: Alias for ``ctx``. Passing both raises ``TypeError``.
 
     Returns:
         HTMLResponse containing only the rendered block content.
@@ -661,6 +669,7 @@ def render_template_block(
 
             return render_template("items/list.html.jinja", request, ctx)
     """
+    ctx = _resolve_render_ctx(ctx, context)
     merged_ctx = _build_merged_ctx(request, ctx)
     template_obj = templates.get_template(template)
 
@@ -680,6 +689,8 @@ def render_template_blocks(
     block_names: list[str],
     request: Request,
     ctx: dict[str, Any] | None = None,
+    *,
+    context: dict[str, Any] | None = None,
 ) -> HTMLResponse:
     """Render multiple named blocks from a template, concatenated.
 
@@ -691,6 +702,7 @@ def render_template_blocks(
         block_names: List of ``{% block %}`` names to render.
         request: FastAPI Request object.
         ctx: Optional context dictionary merged into the template context.
+        context: Alias for ``ctx``. Passing both raises ``TypeError``.
 
     Returns:
         HTMLResponse containing all rendered blocks concatenated together.
@@ -712,6 +724,7 @@ def render_template_blocks(
                 request, ctx,
             )
     """
+    ctx = _resolve_render_ctx(ctx, context)
     merged_ctx = _build_merged_ctx(request, ctx)
     template_obj = templates.get_template(template)
 

--- a/vibetuner-py/tests/unit/test_render_ctx_alias.py
+++ b/vibetuner-py/tests/unit/test_render_ctx_alias.py
@@ -1,0 +1,183 @@
+# ABOUTME: Verifies that render_template* accepts `context=` as an alias for `ctx=`,
+# ABOUTME: rejects passing both at once, and rejects unknown kwargs (issue #1838).
+# ruff: noqa: S101
+"""Regression tests for issue #1838.
+
+The original signature was ``render_template(template, request, ctx=None, **kwargs)``.
+Because of the catch-all ``**kwargs``, callers who naturally typed ``context={...}``
+had their argument silently swallowed (forwarded to ``TemplateResponse``, where the
+positional ``merged_ctx`` already filled the ``context`` slot), and the template
+rendered with no user context. This caused misleading ``UndefinedError`` failures.
+
+The fix:
+
+1. Make ``context=`` an explicit alias for ``ctx=`` (raising if both are given).
+2. Drop the catch-all ``**kwargs`` — unknown keyword arguments now raise
+   ``TypeError`` immediately at the call site.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+
+
+@pytest.fixture
+def mock_request() -> MagicMock:
+    return MagicMock(spec=Request)
+
+
+class TestContextAliasOnRenderTemplate:
+    """`context=` is accepted as an alias for `ctx=` on render_template."""
+
+    @patch("vibetuner.rendering.templates")
+    @patch(
+        "vibetuner.rendering._build_merged_ctx",
+        side_effect=lambda req, ctx: dict(ctx or {}),
+    )
+    def test_context_kwarg_reaches_template(
+        self, mock_build, mock_templates, mock_request
+    ):
+        """`context=` is forwarded into the merged ctx (used to be silently dropped)."""
+        from vibetuner.rendering import render_template
+
+        render_template("home.html.jinja", mock_request, context={"hero": "h"})
+
+        mock_build.assert_called_once_with(mock_request, {"hero": "h"})
+        # And it actually reaches TemplateResponse as the merged context.
+        args, _ = mock_templates.TemplateResponse.call_args
+        assert args[0] == "home.html.jinja"
+        assert args[1] == {"hero": "h"}
+
+    @patch("vibetuner.rendering.templates")
+    @patch(
+        "vibetuner.rendering._build_merged_ctx",
+        side_effect=lambda req, ctx: dict(ctx or {}),
+    )
+    def test_ctx_positional_still_works(self, mock_build, mock_templates, mock_request):
+        from vibetuner.rendering import render_template
+
+        render_template("home.html.jinja", mock_request, {"hero": "h"})
+
+        mock_build.assert_called_once_with(mock_request, {"hero": "h"})
+
+    @patch("vibetuner.rendering.templates")
+    @patch("vibetuner.rendering._build_merged_ctx", return_value={})
+    def test_passing_both_ctx_and_context_raises(
+        self, mock_build, mock_templates, mock_request
+    ):
+        from vibetuner.rendering import render_template
+
+        with pytest.raises(TypeError, match="both 'ctx' and 'context'"):
+            render_template(
+                "home.html.jinja",
+                mock_request,
+                {"a": 1},
+                context={"b": 2},
+            )
+
+    def test_unknown_kwarg_raises_type_error(self, mock_request):
+        """Misspelled kwargs (e.g. `contxt=`) raise TypeError instead of being swallowed."""
+        from vibetuner.rendering import render_template
+
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            render_template("home.html.jinja", mock_request, contxt={"hero": "h"})
+
+
+class TestContextAliasOnRenderTemplateString:
+    @patch("vibetuner.rendering.templates")
+    @patch(
+        "vibetuner.rendering._build_merged_ctx",
+        side_effect=lambda req, ctx: dict(ctx or {}),
+    )
+    def test_context_kwarg_reaches_template(
+        self, mock_build, mock_templates, mock_request
+    ):
+        from vibetuner.rendering import render_template_string
+
+        mock_templates.get_template.return_value = MagicMock(
+            render=MagicMock(return_value="<p>ok</p>")
+        )
+
+        result = render_template_string(
+            "partials/x.html.jinja", mock_request, context={"hero": "h"}
+        )
+
+        assert result == "<p>ok</p>"
+        mock_build.assert_called_once_with(mock_request, {"hero": "h"})
+
+    @patch("vibetuner.rendering.templates")
+    @patch("vibetuner.rendering._build_merged_ctx", return_value={})
+    def test_passing_both_raises(self, mock_build, mock_templates, mock_request):
+        from vibetuner.rendering import render_template_string
+
+        with pytest.raises(TypeError, match="both 'ctx' and 'context'"):
+            render_template_string(
+                "partials/x.html.jinja",
+                mock_request,
+                {"a": 1},
+                context={"b": 2},
+            )
+
+
+class TestContextAliasOnRenderTemplateBlock:
+    @patch("vibetuner.rendering.templates")
+    @patch(
+        "vibetuner.rendering._build_merged_ctx",
+        side_effect=lambda req, ctx: dict(ctx or {}),
+    )
+    def test_context_kwarg_reaches_template(
+        self, mock_build, mock_templates, mock_request
+    ):
+        from vibetuner.rendering import render_template_block
+
+        template_mock = MagicMock()
+        template_mock.blocks = {
+            "body": lambda ctx: iter(["<main>ok</main>"]),
+        }
+        template_mock.new_context.side_effect = lambda ctx: ctx
+        mock_templates.get_template.return_value = template_mock
+
+        render_template_block(
+            "x.html.jinja", "body", mock_request, context={"hero": "h"}
+        )
+
+        mock_build.assert_called_once_with(mock_request, {"hero": "h"})
+
+    @patch("vibetuner.rendering.templates")
+    @patch("vibetuner.rendering._build_merged_ctx", return_value={})
+    def test_passing_both_raises(self, mock_build, mock_templates, mock_request):
+        from vibetuner.rendering import render_template_block
+
+        with pytest.raises(TypeError, match="both 'ctx' and 'context'"):
+            render_template_block(
+                "x.html.jinja",
+                "body",
+                mock_request,
+                {"a": 1},
+                context={"b": 2},
+            )
+
+
+class TestRenderTemplateForwardsResponseKwargs:
+    """Ensure response-shaping kwargs still work after dropping **kwargs."""
+
+    @patch("vibetuner.rendering.templates")
+    @patch("vibetuner.rendering._build_merged_ctx", return_value={})
+    def test_media_type_forwarded(self, mock_build, mock_templates, mock_request):
+        from vibetuner.rendering import render_template
+
+        render_template("meta/robots.txt.jinja", mock_request, media_type="text/plain")
+
+        _, kwargs = mock_templates.TemplateResponse.call_args
+        assert kwargs["media_type"] == "text/plain"
+
+    @patch("vibetuner.rendering.templates")
+    @patch("vibetuner.rendering._build_merged_ctx", return_value={})
+    def test_status_code_forwarded(self, mock_build, mock_templates, mock_request):
+        from vibetuner.rendering import render_template
+
+        render_template("x.html.jinja", mock_request, status_code=404)
+
+        _, kwargs = mock_templates.TemplateResponse.call_args
+        assert kwargs["status_code"] == 404

--- a/vibetuner-template/.claude/rules/development.md
+++ b/vibetuner-template/.claude/rules/development.md
@@ -28,6 +28,10 @@ unchanged.
 
 **Streaming**: `render_template_stream()` for large pages (improves TTFB).
 
+**Context kwarg**: pass user context positionally, as `ctx=`, or as
+`context=` (alias for `ctx=`). Unknown kwargs raise `TypeError`, so
+typos like `contxt=` can't silently render with an empty context.
+
 Register routes in `__init__.py` via `APIRouter.include_router()`, then
 list in `tune.py`.
 


### PR DESCRIPTION
## Summary

- `render_template(template, request, ctx=None, **kwargs)` silently swallowed `context={…}` because Starlette's old-style `TemplateResponse` reads `context` positionally from the second positional arg (our pre-merged ctx). The user's intended context was forwarded into `**kwargs` and never used — templates rendered with no user context and produced misleading `UndefinedError`s.
- Make the signature explicit: drop the catch-all `**kwargs`, list `status_code`, `headers`, `media_type`, `background` as named keyword-only params, and accept `context=` as an alias for `ctx=`.
- Apply the same `ctx=`/`context=` aliasing to `render_template_string`, `_stream`, `_block`, and `_blocks` so the gotcha can't recur through a sibling helper.
- Passing both `ctx=` and `context=`, or any unknown kwarg (e.g. `contxt=`), now raises `TypeError` at the call site.

Closes #1838.

## Test plan

- [x] `uv run python -m pytest tests/unit` — 818 passed
- [x] New `tests/unit/test_render_ctx_alias.py` (10 cases) covers: positional ctx, `ctx=`, `context=` alias, both-raise, unknown-kwarg-raise, plus `status_code`/`media_type` forwarding on `render_template`, and aliasing on `_string` / `_block`
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] Existing `tests/unit/test_render_block.py`, `test_render_stream.py`, `test_render_decorator.py`, `test_template_context.py`, `test_template_globals.py`, `test_circular_import.py` all still pass
- [ ] Confirm callers in scaffolded apps that pass `media_type=` (e.g. `meta/robots.txt.jinja`) still render — covered by `test_media_type_forwarded` but worth a smoke test in a scaffolded project

## Docs

- `vibetuner-docs/docs/development-guide.md`: new "Passing Context" subsection
- `vibetuner-docs/docs/llms-full.txt`: new "Passing user context" subsection
- `vibetuner-docs/docs/llms.txt`: one-line entry under render helpers
- `vibetuner-template/.claude/rules/development.md`: concise note for scaffolded projects' agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)