### PR TITLE
perf(ci): default self-hosted docker cache-to to mode=min

### DIFF
--- a/vibetuner-template/.github/workflows/docker.yml
+++ b/vibetuner-template/.github/workflows/docker.yml
@@ -99,4 +99,4 @@ jobs:
         run: >-
           docker buildx bake -f compose.prod.yml --push
           --set "*.cache-from=type=registry,ref=$DOCKER_REGISTRY/$COMPOSE_PROJECT_NAME:buildcache"
-          --set "*.cache-to=type=registry,ref=$DOCKER_REGISTRY/$COMPOSE_PROJECT_NAME:buildcache,mode=max"
+          --set "*.cache-to=type=registry,ref=$DOCKER_REGISTRY/$COMPOSE_PROJECT_NAME:buildcache,mode=min"


### PR DESCRIPTION
## Summary

- Switch `cache-to` mode from `max` to `min` in the scaffolded
  `docker.yml` self-hosted workflow.
- `mode=max` exports every intermediate layer to the registry on each
  release build. On self-hosted runners — the only audience for this
  workflow — buildkit already retains those intermediates locally, so
  the registry cache only needs to cover the final image layers
  (`mode=min`). That cuts ~40s+ off each build's cache-export step.

Closes #1844.

## Test plan

- [ ] After merging, a release build on the alltuner self-hosted runner
      shows a noticeably faster `exporting cache to registry` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)