### PR TITLE
fix(template): pin compose.prod.yml frontend target to runtime

### DIFF
--- a/vibetuner-template/compose.prod.yml
+++ b/vibetuner-template/compose.prod.yml
@@ -11,6 +11,7 @@ services:
   frontend:
     build:
       context: .
+      target: runtime
       args:
         PYTHON_VERSION: ${PYTHON_VERSION}
         ENVIRONMENT: ${ENVIRONMENT:-prod}


### PR DESCRIPTION
## Summary

- `compose.prod.yml` was missing a `target:` directive on `frontend.build`, so buildx picked the last Dockerfile stage by default.
- Since #1759 added `dev-runtime` as the new last stage (extending `runtime` with bun + node_modules + watcher inputs), every release since 2026-05-06 has shipped the dev image to prod.
- Pin the prod build to `target: runtime`, mirroring the existing `target: dev-runtime` on `compose.dev.yml`.

## Test plan

- [ ] `docker compose -f vibetuner-template/compose.prod.yml config` shows `target: runtime` under the `frontend.build` block.
- [ ] A built prod image no longer contains `/usr/local/bin/bun`.
- [ ] A built prod image no longer contains `/app/node_modules/`.

Fixes #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)