### PR TITLE
perf(template): drop linux/arm64 from default prod build

### DIFF
--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -160,9 +160,10 @@ Important notes:
   `override_config`, `vibetuner_db` pytest fixtures
 - **Error Messages**: Actionable error messages with env var examples, Docker
   commands, and documentation links
-- **Docker Builds**: Multi-platform Docker image builds via `just release` using
-  `compose.prod.yml` bake configuration. Optional GitHub Actions workflow for
-  self-hosted runners (enabled via `use_self_hosted_runner` scaffold prompt)
+- **Docker Builds**: Production Docker image builds (linux/amd64) via
+  `just release` using `compose.prod.yml` bake configuration. Optional GitHub
+  Actions workflow for self-hosted runners (enabled via
+  `use_self_hosted_runner` scaffold prompt)
 
 ## Reference
 

--- a/vibetuner-template/.github/workflows/docker.yml
+++ b/vibetuner-template/.github/workflows/docker.yml
@@ -81,10 +81,6 @@ jobs:
           registry=$(uv run --with pyyaml python -c "import yaml; print(yaml.safe_load(open('.copier-answers.yml')).get('docker_registry', 'localhost:5050'))")
           echo "docker_registry=$registry" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        if: steps.version.outputs.skip != 'true'
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         if: steps.version.outputs.skip != 'true'
         uses: docker/setup-buildx-action@v4

--- a/vibetuner-template/compose.prod.yml
+++ b/vibetuner-template/compose.prod.yml
@@ -18,7 +18,6 @@ services:
       x-bake:
         platforms:
           - linux/amd64
-          - linux/arm64
         push: true
         tags:
           - ${DOCKER_REGISTRY:-localhost:5050}/${COMPOSE_PROJECT_NAME}:${VERSION:-0.0.0}


### PR DESCRIPTION
## Summary

- Drop `linux/arm64` from `vibetuner-template/compose.prod.yml`'s
  `x-bake.platforms` so the default prod build is single-arch (linux/amd64).
- Remove the `Set up QEMU` step from `vibetuner-template/.github/workflows/docker.yml`;
  it was only needed to cross-build arm64 and the buildx setup step that follows does
  not require QEMU for native amd64 builds.
- Update `vibetuner-docs/docs/llms.txt` so it no longer describes the template as
  producing multi-platform images.

The AllTuner self-hosted runner has no native arm64, so every release was emulating
arm64 under QEMU (~2 min per build) for an image that prod hosts never consumed.
Option B (a copier prompt to opt back into multi-arch) was deferred.

## Test plan

- [ ] `docker compose -f vibetuner-template/compose.prod.yml config` no longer lists
  `linux/arm64` under `x-bake.platforms`.
- [ ] Next release run of the `Build and Push Docker Images` workflow succeeds without
  the `Set up QEMU` step and produces an amd64-only image (with a noticeably shorter
  build time).

Closes #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)