### PR TITLE
perf(docker): keep buildx alive between runner jobs

### DIFF
--- a/vibetuner-template/.github/workflows/docker.yml
+++ b/vibetuner-template/.github/workflows/docker.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.version.outputs.skip != 'true'
         uses: docker/setup-buildx-action@v4
+        with:
+          name: alltuner-runner
+          cleanup: false
 
       - name: Build and push
         if: steps.version.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

- Adds `with: { name: alltuner-runner, cleanup: false }` to the buildx setup step in `vibetuner-template/.github/workflows/docker.yml`.
- Every scaffolded project benefits: buildkit's local cache survives across jobs on the long-lived DinD daemons, so cached layers no longer have to be re-pulled from the registry on every build.

Refs alltuner/infrastructure#152, which has the full analysis (observed ~17s saved on the cache-hit layer pull, plus ~10s on buildx container boot). Concurrency safety is fine because consumer workflows already serialize with `concurrency: docker-build`.

## Test plan

- [ ] Merge, re-scaffold or update a downstream project, then trigger the Docker workflow twice in a row — second run should skip the buildkit container create step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)