### PR TITLE
docs(theming): warn against Tailwind v3 raw-RGB tokens in custom @theme blocks

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1487,6 +1487,17 @@ DaisyUI scopes its theme via `:where(:root)` (zero specificity), so a plain
 - **Inline `<style>` without a CSP nonce.** The shipped partial sets it for
   you; if you write a custom override template, do the same with
   `{{ csp_nonce }}`.
+- **Tailwind v3 raw-RGB tokens in `@theme`.** Custom palettes defined as
+  `@theme { --color-brand-red: 239 68 68; }` with a
+  `.bg-brand-red { background-color: rgb(var(--color-brand-red)); }`
+  cascade-override work for direct utility usage but break under
+  `@apply`. Tailwind v4 expands `@apply bg-brand-red` by inlining its own
+  auto-generated `background-color: var(--color-brand-red)` rule (not
+  the override), which resolves to the raw triplet — invalid, dropped,
+  element renders transparent. Define `@theme` tokens as full color
+  values (`rgb(239 68 68)` / `oklch(...)` / `#ef4444`) and drop the
+  cascade-override; Tailwind v4 auto-generates `.bg-*` / `.text-*` from
+  `@theme`.
 
 **Out of scope:** per-tenant fonts. Font swapping requires `@font-face`
 rules to load the binary before any `--font-display` variable can switch to

--- a/vibetuner-docs/docs/theming.md
+++ b/vibetuner-docs/docs/theming.md
@@ -200,6 +200,50 @@ shade is a brand constant.
 `nonce="{{ csp_nonce }}"` automatically; if you write a custom override
 template, do the same.
 
+**4. Tailwind v3 raw-RGB tokens in `@theme`.** If you extend your project's
+`config.css` with a custom brand palette using the pre-Tailwind-v4
+raw-triplet pattern, the tokens look fine for direct utility usage but
+collapse the moment they flow through `@apply`:
+
+```css
+@theme {
+  --color-brand-red: 239 68 68;
+}
+
+/* Cascade override that recovers a valid color for direct class usage */
+.bg-brand-red { background-color: rgb(var(--color-brand-red)); }
+```
+
+`class="bg-brand-red"` resolves correctly because the cascade-override
+wins on source order. But Tailwind v4 expands
+`@apply bg-brand-red` by inlining its own auto-generated rule for the
+token (`background-color: var(--color-brand-red)`), **not** the
+override:
+
+```css
+@utility btn-brand-primary {
+  @apply bg-brand-red text-white;
+}
+
+/* Compiles to: */
+.btn-brand-primary {
+  background-color: var(--color-brand-red);  /* resolves to "239 68 68" — invalid */
+  color: var(--color-white);
+}
+```
+
+`239 68 68` isn't a valid color value, so the property is
+invalid-at-computed-value-time and dropped — the element renders fully
+transparent. Define `@theme` tokens as full color values instead, and
+drop the cascade-override classes (Tailwind v4 auto-generates the
+`.bg-*` / `.text-*` utilities from `@theme`):
+
+```css
+@theme {
+  --color-brand-red: rgb(239 68 68);  /* or oklch(...) / #ef4444 */
+}
+```
+
 ## What this primitive does *not* cover
 
 - **Fonts.** Per-tenant font swapping is genuinely different from color


### PR DESCRIPTION
## Summary

- Adds a fourth Footguns entry to `theming.md` covering the Tailwind-v3 raw-RGB-triplet pattern in custom `@theme` blocks.
- The pattern (`@theme { --color-foo: 239 68 68; }` + `.bg-foo { background-color: rgb(var(--color-foo)); }` cascade-override) works for direct utility usage but silently breaks under `@apply`: Tailwind v4 expands `@apply bg-foo` by inlining its own auto-generated `background-color: var(--color-foo)` rule (bypassing the override), the raw triplet is invalid-at-computed-value-time, and the property is dropped — elements render fully transparent.
- Directs projects to define `@theme` tokens as full color values (`rgb(...)` / `oklch(...)` / `#hex`) and drop the now-redundant `.bg-*` / `.text-*` cascade-overrides (Tailwind v4 auto-generates those from `@theme`).
- Mirrored into `llms-full.txt` Footguns list so LLM consumers see the same warning.

Closes #1853.

## Test plan

- [ ] `just lint-md` (existing README violations are unrelated)
- [ ] Visual review of rendered theming page
- [ ] Confirm wording aligns with the existing Footguns voice