### PR TITLE
fix(blob): warn when BlobService falls back to global R2_DEFAULT_BUCKET_NAME

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -1799,6 +1799,14 @@ async def upload(
     await blobs.put_object(...)
 ```
 
+When `BlobService()` is constructed without an explicit `default_bucket`, it
+falls back to `R2_DEFAULT_BUCKET_NAME` from the environment and logs a one-time
+process warning naming the resolved bucket. Watch deploy logs for that warning
+on first boot — if the bucket name doesn't match what this project should write
+to, the env var has leaked in from another project and uploads will silently
+land in the wrong bucket. Either set `R2_DEFAULT_BUCKET_NAME` explicitly for
+the deploy, or pass `default_bucket=...` to `BlobService()`.
+
 ### Runtime Config
 
 ```python

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1710,6 +1710,14 @@ async def settings_page(config=Depends(get_runtime_config)):
     value = await config.get("features.dark_mode")
 ```
 
+`BlobService()` falls back to `R2_DEFAULT_BUCKET_NAME` when no explicit
+`default_bucket` is passed, and logs a one-time process warning naming the
+resolved bucket. Watch deploy logs on first boot: if the bucket isn't yours,
+the env var has leaked from another deploy and uploads will silently land in
+the wrong place. Set `R2_DEFAULT_BUCKET_NAME` explicitly for the deploy, or
+pass `default_bucket=...` to `BlobService()` to suppress the warning and
+guarantee the bucket.
+
 ### Health Check Endpoints
 
 Built-in health check routes are mounted at `/health`:

--- a/vibetuner-py/src/vibetuner/services/blob.py
+++ b/vibetuner-py/src/vibetuner/services/blob.py
@@ -10,9 +10,13 @@ from pathlib import Path
 import aioboto3
 
 from vibetuner.config import settings
+from vibetuner.logging import logger
 from vibetuner.models import BlobModel
 from vibetuner.models.blob import BlobStatus
 from vibetuner.services.s3_storage import DEFAULT_CONTENT_TYPE, S3StorageService
+
+
+_implicit_fallback_warned = False
 
 
 class BlobService:
@@ -29,6 +33,20 @@ class BlobService:
             from vibetuner.services.errors import s3_not_configured
 
             raise ValueError(s3_not_configured(log=False))
+
+        if default_bucket is None and settings.r2_default_bucket_name is not None:
+            global _implicit_fallback_warned
+            if not _implicit_fallback_warned:
+                _implicit_fallback_warned = True
+                logger.warning(
+                    "BlobService is using the process-wide R2_DEFAULT_BUCKET_NAME "
+                    "fallback bucket {bucket!r}. If this is not the bucket this "
+                    "deploy should be writing to, the env var has leaked from "
+                    "another project; uploads will silently land in the wrong "
+                    "bucket. Set R2_DEFAULT_BUCKET_NAME explicitly for this "
+                    "deploy, or pass default_bucket=... to BlobService().",
+                    bucket=settings.r2_default_bucket_name,
+                )
 
         bucket = default_bucket or settings.r2_default_bucket_name
         if bucket is None:

--- a/vibetuner-py/tests/unit/test_blob_service.py
+++ b/vibetuner-py/tests/unit/test_blob_service.py
@@ -1,10 +1,11 @@
-# ABOUTME: Unit tests for BlobService.object_exists method
-# ABOUTME: Tests check_bucket flag behavior for verifying blob existence in storage
+# ABOUTME: Unit tests for BlobService construction and object_exists method
+# ABOUTME: Covers default-bucket resolution warnings and check_bucket existence checks
 # ruff: noqa: S101
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import HttpUrl, SecretStr
 
 
 @pytest.fixture
@@ -97,3 +98,90 @@ async def test_object_exists_blob_found_in_mongo_but_not_s3(blob_service):
         blob_service.storage.object_exists.assert_called_once_with(
             key="test/path", bucket="test-bucket"
         )
+
+
+@pytest.fixture
+def configured_r2_settings():
+    """Patch settings with valid R2 credentials and a default bucket name."""
+    from vibetuner.services import blob as blob_module
+
+    with patch.object(blob_module, "settings") as mock_settings:
+        mock_settings.r2_bucket_endpoint_url = HttpUrl("https://example.r2.com")
+        mock_settings.r2_access_key = SecretStr("access")
+        mock_settings.r2_secret_key = SecretStr("secret")
+        mock_settings.r2_default_region = "auto"
+        mock_settings.r2_default_bucket_name = "settings-bucket"
+        yield mock_settings
+
+
+@pytest.fixture
+def reset_fallback_warning():
+    """Reset the module-level flag that gates the implicit-fallback warning."""
+    from vibetuner.services import blob as blob_module
+
+    blob_module._implicit_fallback_warned = False
+    yield
+    blob_module._implicit_fallback_warned = False
+
+
+def test_init_warns_on_implicit_default_bucket_fallback(
+    configured_r2_settings, reset_fallback_warning, log_sink
+):
+    """BlobService() without default_bucket logs a warning naming the fallback bucket."""
+    from vibetuner.services.blob import BlobService
+
+    with patch("vibetuner.services.blob.S3StorageService"):
+        service = BlobService()
+
+    assert service.default_bucket == "settings-bucket"
+    assert any(
+        "settings-bucket" in m and "R2_DEFAULT_BUCKET_NAME" in m for m in log_sink
+    ), f"Expected fallback warning naming the bucket, got: {log_sink}"
+
+
+def test_init_warning_logged_only_once_per_process(
+    configured_r2_settings, reset_fallback_warning, log_sink
+):
+    """The implicit-fallback warning fires once per process, not per instance."""
+    from vibetuner.services.blob import BlobService
+
+    with patch("vibetuner.services.blob.S3StorageService"):
+        BlobService()
+        BlobService()
+        BlobService()
+
+    matches = [m for m in log_sink if "R2_DEFAULT_BUCKET_NAME" in m]
+    assert len(matches) == 1, (
+        f"Expected exactly one fallback warning, got {len(matches)}: {matches}"
+    )
+
+
+def test_init_no_warning_with_explicit_default_bucket(
+    configured_r2_settings, reset_fallback_warning, log_sink
+):
+    """Passing default_bucket explicitly suppresses the fallback warning."""
+    from vibetuner.services.blob import BlobService
+
+    with patch("vibetuner.services.blob.S3StorageService"):
+        service = BlobService(default_bucket="my-bucket")
+
+    assert service.default_bucket == "my-bucket"
+    assert not any("R2_DEFAULT_BUCKET_NAME" in m for m in log_sink), (
+        f"Did not expect fallback warning, got: {log_sink}"
+    )
+
+
+def test_init_raises_when_no_bucket_configured(reset_fallback_warning):
+    """No default_bucket arg and no settings.r2_default_bucket_name raises ValueError."""
+    from vibetuner.services import blob as blob_module
+    from vibetuner.services.blob import BlobService
+
+    with patch.object(blob_module, "settings") as mock_settings:
+        mock_settings.r2_bucket_endpoint_url = HttpUrl("https://example.r2.com")
+        mock_settings.r2_access_key = SecretStr("access")
+        mock_settings.r2_secret_key = SecretStr("secret")
+        mock_settings.r2_default_region = "auto"
+        mock_settings.r2_default_bucket_name = None
+
+        with pytest.raises(ValueError, match="Default bucket name"):
+            BlobService()


### PR DESCRIPTION
## Summary

- `BlobService.__init__` now logs a one-time-per-process warning when `default_bucket` is omitted and the bucket is resolved implicitly from `settings.r2_default_bucket_name`. The warning names the resolved bucket so a leaked env var (shared base image, sibling project, etc.) shows up in deploy logs on first boot instead of as 404s at the CDN edge weeks later.
- Passing `default_bucket=...` explicitly suppresses the warning.
- Adds unit tests covering: implicit fallback warns, explicit arg does not, warning is emitted at most once per process, and missing bucket still raises `ValueError`.
- Documents the behavior in `development-guide.md` and `llms-full.txt`.

Fixes #1856.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_blob_service.py -v` — 8 passed
- [x] `uv run python -m pytest tests/` — 823 passed (3 unrelated docker integration errors)
- [x] `uv run ruff check src/vibetuner/services/blob.py tests/unit/test_blob_service.py` — clean
- [x] `uv run ty check src/vibetuner/services/blob.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)