### PR TITLE
fix(debug): correct route names in users.html.jinja template (closes #1860)

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/users.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/users.html.jinja
@@ -37,7 +37,7 @@
                         User ID: <code>{{ current_user_id }}</code>
                     </p>
                     <div class="card-actions justify-end">
-                        <form method="post" action="{{ url_for('debug.stop_impersonation') }}">
+                        <form method="post" action="{{ url_for('debug_stop_impersonation') }}">
                             <button type="submit" class="btn btn-secondary btn-sm">Stop Impersonation</button>
                         </form>
                     </div>
@@ -106,7 +106,7 @@
                                         <td class="text-center">
                                             {% if current_user_id != user.id|string %}
                                                 <form method="post"
-                                                      action="{{ url_for('debug.impersonate_user', user_id=user.id) }}"
+                                                      action="{{ url_for('debug_impersonate_user', user_id=user.id) }}"
                                                       class="inline">
                                                     <button type="submit" class="btn btn-outline btn-sm">Impersonate</button>
                                                 </form>


### PR DESCRIPTION
## Summary

Fixes `NoMatchFound` 500 error when rendering `GET /debug/users`. The template referenced two
non-existent Starlette route names; replaced with the correct underscore-style handler names.

Closes #1860.

## Root cause

`vibetuner-py/src/vibetuner/templates/frontend/debug/users.html.jinja` called
`url_for('debug.stop_impersonation')` and `url_for('debug.impersonate_user', user_id=...)`.
The routes in `vibetuner-py/src/vibetuner/frontend/routes/debug.py` are registered without
explicit `name=` arguments, so Starlette resolves the route names from the handler function
names: `debug_stop_impersonation` and `debug_impersonate_user`. Every other template in
`templates/frontend/debug/` already uses the underscore form.

## Fix

Two `url_for` argument changes in `users.html.jinja`:

- `'debug.stop_impersonation'` -> `'debug_stop_impersonation'`
- `'debug.impersonate_user'` -> `'debug_impersonate_user'`

No other changes.

## Test plan

No existing automated test covers the `/debug/users` template rendering path. The existing
`tests/unit/test_debug_auth.py` only exercises the access-control function logic, not full
route rendering. Adding a test would require ASGI/TestClient setup with a session middleware,
a populated `UserModel`, and the debug router wired up, none of which has a precedent in the
unit-test layout — so this PR ships the fix without a new test rather than inventing a
one-off pattern. Follow-up to add a render-smoke test for debug routes is worth filing
separately.

Manual verification:

- [ ] Scaffold a fresh project from this branch, set `DEBUG=true`, browse to `/debug/users`,
      confirm the page renders (200) and both impersonate / stop-impersonation forms post
      successfully.
- [ ] Confirm `djlint` template lint still passes (`just lint-jinja`).

Generated with Claude Opus 4.7 (1M context).