### PR TITLE
fix(i18n): allow clearing user language preference via empty submission

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/routes/user.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/user.py
@@ -65,8 +65,10 @@ async def user_edit_submit(
     # Update user fields
     user.name = name
 
-    # Update language preference if provided
-    if language and language in ctx.supported_languages:
+    # Update language preference: empty string clears it back to auto-detect
+    if language == "":
+        user.user_settings.language = None
+    elif language and language in ctx.supported_languages:
         try:
             user.user_settings.language = LanguageAlpha2(language)
         except ValueError:

--- a/vibetuner-py/tests/unit/test_user_edit_submit.py
+++ b/vibetuner-py/tests/unit/test_user_edit_submit.py
@@ -1,0 +1,155 @@
+# ABOUTME: Tests user_edit_submit handler's language preference handling
+# ABOUTME: Validates the fix for #1862 - empty submission clears language back to auto-detect
+# ruff: noqa: S101
+
+"""
+Tests for user_edit_submit endpoint language handling.
+
+Mocks UserModel.get and the user's save() method so we can exercise the
+handler logic directly without a running database. Asserts that:
+- empty-string language clears the preference back to None (auto-detect)
+- a supported language code is stored as LanguageAlpha2
+- an unsupported language code leaves the existing preference untouched
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_extra_types.language_code import LanguageAlpha2
+from starlette.authentication import AuthCredentials, SimpleUser
+from starlette.requests import Request
+
+
+class _AuthedUser(SimpleUser):
+    """SimpleUser variant with an .id attribute matching UserModel access."""
+
+    def __init__(self, user_id: str) -> None:
+        super().__init__(username=user_id)
+        self.id = user_id
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+
+def _make_request(user_id: str = "u1") -> Request:
+    """Build a minimal authenticated Request with session and user.id."""
+    scope: dict = {
+        "type": "http",
+        "method": "POST",
+        "path": "/user/edit",
+        "headers": [],
+        "session": {},
+        "auth": AuthCredentials(["authenticated"]),
+        "user": _AuthedUser(user_id),
+    }
+    return Request(scope)
+
+
+def _make_user(language: LanguageAlpha2 | None = None) -> MagicMock:
+    """Build a UserModel stub with user_settings.language and async save()."""
+    from vibetuner.models.user import UserModel, UserSettings
+
+    user = MagicMock(spec=UserModel)
+    user.user_settings = UserSettings(language=language)
+    user.name = "Original"
+    user.session_dict = {"id": "u1", "settings": {}}
+    user.save = AsyncMock()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_empty_language_clears_preference():
+    """Submitting language='' resets user_settings.language to None."""
+    from vibetuner.frontend.routes.user import user_edit_submit
+
+    user = _make_user(language=LanguageAlpha2("ca"))
+    request = _make_request()
+
+    with (
+        patch(
+            "vibetuner.frontend.routes.user.UserModel.get",
+            new=AsyncMock(return_value=user),
+        ),
+        patch(
+            "vibetuner.frontend.routes.user.ctx.supported_languages",
+            new={"en", "ca", "es"},
+        ),
+    ):
+        await user_edit_submit(request, name="New Name", language="")
+
+    assert user.user_settings.language is None
+    assert user.name == "New Name"
+    user.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_supported_language_is_saved():
+    """Submitting a supported code stores it as LanguageAlpha2."""
+    from vibetuner.frontend.routes.user import user_edit_submit
+
+    user = _make_user(language=None)
+    request = _make_request()
+
+    with (
+        patch(
+            "vibetuner.frontend.routes.user.UserModel.get",
+            new=AsyncMock(return_value=user),
+        ),
+        patch(
+            "vibetuner.frontend.routes.user.ctx.supported_languages",
+            new={"en", "ca", "es"},
+        ),
+    ):
+        await user_edit_submit(request, name="New Name", language="ca")
+
+    assert user.user_settings.language == LanguageAlpha2("ca")
+    user.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unsupported_language_is_ignored():
+    """Submitting an unsupported code leaves the existing preference intact."""
+    from vibetuner.frontend.routes.user import user_edit_submit
+
+    user = _make_user(language=LanguageAlpha2("ca"))
+    request = _make_request()
+
+    with (
+        patch(
+            "vibetuner.frontend.routes.user.UserModel.get",
+            new=AsyncMock(return_value=user),
+        ),
+        patch(
+            "vibetuner.frontend.routes.user.ctx.supported_languages",
+            new={"en", "ca", "es"},
+        ),
+    ):
+        await user_edit_submit(request, name="New Name", language="xx")
+
+    assert user.user_settings.language == LanguageAlpha2("ca")
+    user.save.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_none_language_leaves_preference_unchanged():
+    """When no language field is submitted (None), preference is not touched."""
+    from vibetuner.frontend.routes.user import user_edit_submit
+
+    user = _make_user(language=LanguageAlpha2("ca"))
+    request = _make_request()
+
+    with (
+        patch(
+            "vibetuner.frontend.routes.user.UserModel.get",
+            new=AsyncMock(return_value=user),
+        ),
+        patch(
+            "vibetuner.frontend.routes.user.ctx.supported_languages",
+            new={"en", "ca", "es"},
+        ),
+    ):
+        await user_edit_submit(request, name="New Name", language=None)
+
+    assert user.user_settings.language == LanguageAlpha2("ca")
+    user.save.assert_awaited_once()


### PR DESCRIPTION
## Summary

- The user edit handler skipped submissions where `language=""`, so once
  a user had set a preference they could never re-select **Use browser
  default** from the dropdown.
- Treat an empty submission as an explicit clear that sets
  `user_settings.language = None` (the auto-detect sentinel that
  `user_preference_selector` checks for).
- The existing branch for supported language codes is unchanged.

Closes #1862

## Test plan

- [x] `uv run python -m pytest tests/unit/test_user_edit_submit.py -v`
- [x] `uv run python -m pytest tests/ -k user -x` (19 user tests pass)
- [x] `just lint-py`
- [x] `just type-check`

Manual verification (not automated here):

- [ ] In a scaffolded project, set a non-default language on
  `/user/edit`, save, then re-open the form, choose **Use browser
  default**, save, and confirm the badge on `/user/` disappears.