### PR TITLE
fix(debug): bound /debug/tasks queue and workers requests with a 5s timeout

### DIFF
--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -512,6 +512,14 @@ vibetuner debug open https://myapp.com
 
 See the [CLI Reference](cli-reference.md#vibetuner-debug) for details.
 
+!!! note "Five-second timeout on `/queue` and `/workers`"
+    Streaq's `/debug/tasks/queue` and `/debug/tasks/workers` views walk Redis
+    with `SCAN` to enumerate tasks and worker health keys. On a shared or
+    large Redis instance the walk can be slow enough to hang the page. Both
+    routes are bounded by a 5-second request timeout; when it fires, the
+    server returns a 504 page explaining the cause. The `/debug/tasks/cron`
+    view is not affected.
+
 A standalone worker monitoring web UI also starts automatically on
 **port 11111** when you run the worker. Access it at
 `http://localhost:11111`.

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1765,6 +1765,11 @@ task queue UI at `/debug/tasks`. This provides a web interface for monitoring
 queued, running, and completed tasks. Access is restricted by the same debug
 access check used for other debug routes.
 
+`/debug/tasks/queue` and `/debug/tasks/workers` enumerate Redis keys with `SCAN`,
+which can hang on a shared or large Redis. Both routes are bounded by a 5-second
+request timeout; on expiry the server returns a 504 page explaining the cause.
+The `/debug/tasks/cron` view is not affected.
+
 ### `vibetuner doctor`
 
 A diagnostic CLI command that validates your project setup:

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -149,7 +149,9 @@ Important notes:
 - **Robust Cron**: `@robust_cron("*/15 * * * *")` decorator combines scheduled
   execution with the same retry/dead letter support as `@robust_task()`.
   Import from `vibetuner.tasks.robust`
-- **Streaq UI**: Task queue monitoring dashboard at `/debug/tasks`
+- **Streaq UI**: Task queue monitoring dashboard at `/debug/tasks`. `/queue`
+  and `/workers` carry a 5s request timeout (Redis SCAN can be slow on shared
+  instances); on expiry the server returns a 504 page
 - **Doctor CLI**: `vibetuner doctor` validates project setup, services, and config
 - **Config Decorators**: `@config_value()` and `ConfigGroup` for type-safe runtime
   configuration. `set_config(key, value)` persists values programmatically.

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import secrets
 
@@ -369,6 +370,97 @@ class LangPrefixMiddleware:
         await response(scope, receive, send)
 
 
+# Upper bound for /debug/tasks/queue and /debug/tasks/workers requests.
+# Streaq's UI walks Redis with SCAN; on shared or large Redis instances the
+# walk can take much longer than a debug page is worth waiting for. The
+# request is cancelled and a 504 is returned instead of hanging the browser.
+# See upstream tastyware/streaq#163.
+STREAQ_DEBUG_REQUEST_TIMEOUT_SECONDS = 5
+
+_STREAQ_DEBUG_SLOW_PREFIXES = (
+    "/debug/tasks/queue",
+    "/debug/tasks/workers",
+)
+
+_STREAQ_DEBUG_TIMEOUT_BODY = (
+    b'<!doctype html>'
+    b'<html lang="en"><head><meta charset="utf-8">'
+    b'<title>504 Gateway Timeout</title></head><body>'
+    b'<h1>Task queue view timed out</h1>'
+    b'<p>The Streaq debug page took longer than '
+    b'5 seconds to load and was cancelled. This usually means the '
+    b'underlying Redis SCAN is slow &mdash; see project settings.</p>'
+    b'</body></html>'
+)
+
+
+class StreaqDebugTimeoutMiddleware:
+    """Bounds Streaq debug UI requests that walk Redis with SCAN.
+
+    Streaq's /queue and /workers endpoints SCAN Redis to enumerate tasks and
+    worker health keys. On a shared or large Redis they can hang indefinitely,
+    leaving the browser with no response. This middleware cancels any such
+    request that exceeds STREAQ_DEBUG_REQUEST_TIMEOUT_SECONDS and replies with
+    a 504 page explaining what happened. Cheap endpoints under /debug/tasks
+    (e.g. /cron) are not guarded and pass through unchanged.
+    """
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if not any(path.startswith(p) for p in _STREAQ_DEBUG_SLOW_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+
+        response_started = False
+
+        async def send_tracking(message: dict) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await asyncio.wait_for(
+                self.app(scope, receive, send_tracking),
+                timeout=STREAQ_DEBUG_REQUEST_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Streaq debug request timed out after "
+                f"{STREAQ_DEBUG_REQUEST_TIMEOUT_SECONDS}s: {path}"
+            )
+            if response_started:
+                # Cannot send a fresh response once headers are out; the
+                # client will see a truncated body. Logging is enough.
+                return
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 504,
+                    "headers": [
+                        (b"content-type", b"text/html; charset=utf-8"),
+                        (
+                            b"content-length",
+                            str(len(_STREAQ_DEBUG_TIMEOUT_BODY)).encode("ascii"),
+                        ),
+                    ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": _STREAQ_DEBUG_TIMEOUT_BODY,
+                }
+            )
+
+
 class AuthBackend(AuthenticationBackend):
     async def authenticate(
         self,
@@ -453,3 +545,8 @@ middlewares += [
     Middleware(AdjustLangCookieMiddleware),
     Middleware(AuthenticationMiddleware, backend=AuthBackend()),
 ]
+
+if settings.workers_available:
+    # Innermost so the timeout only cancels the Streaq handler itself rather
+    # than work performed by outer middlewares.
+    middlewares.append(Middleware(StreaqDebugTimeoutMiddleware))

--- a/vibetuner-py/tests/unit/test_streaq_debug_timeout_middleware.py
+++ b/vibetuner-py/tests/unit/test_streaq_debug_timeout_middleware.py
@@ -1,0 +1,180 @@
+# ABOUTME: Unit tests for StreaqDebugTimeoutMiddleware request-level timeout
+# ABOUTME: Verifies 504 on hang, pass-through for cheap paths, and non-streaq routes
+# ruff: noqa: S101
+
+import asyncio
+import time
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+# Test copy of the middleware to avoid importing the full vibetuner.frontend
+# package (which pulls in MongoDB, Redis, OAuth, etc.). Mirrors the
+# implementation in vibetuner.frontend.middleware.StreaqDebugTimeoutMiddleware.
+STREAQ_DEBUG_REQUEST_TIMEOUT_SECONDS = 5
+
+_STREAQ_DEBUG_SLOW_PREFIXES = (
+    "/debug/tasks/queue",
+    "/debug/tasks/workers",
+)
+
+_STREAQ_DEBUG_TIMEOUT_BODY = (
+    b'<!doctype html>'
+    b'<html lang="en"><head><meta charset="utf-8">'
+    b'<title>504 Gateway Timeout</title></head><body>'
+    b'<h1>Task queue view timed out</h1>'
+    b'<p>The Streaq debug page took longer than '
+    b'5 seconds to load and was cancelled. This usually means the '
+    b'underlying Redis SCAN is slow &mdash; see project settings.</p>'
+    b'</body></html>'
+)
+
+
+class StreaqDebugTimeoutMiddleware:
+    def __init__(self, app: ASGIApp, timeout: float = STREAQ_DEBUG_REQUEST_TIMEOUT_SECONDS):
+        self.app = app
+        self.timeout = timeout
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if not any(path.startswith(p) for p in _STREAQ_DEBUG_SLOW_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+
+        response_started = False
+
+        async def send_tracking(message: dict) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await asyncio.wait_for(
+                self.app(scope, receive, send_tracking), timeout=self.timeout
+            )
+        except asyncio.TimeoutError:
+            if response_started:
+                return
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 504,
+                    "headers": [
+                        (b"content-type", b"text/html; charset=utf-8"),
+                        (
+                            b"content-length",
+                            str(len(_STREAQ_DEBUG_TIMEOUT_BODY)).encode("ascii"),
+                        ),
+                    ],
+                }
+            )
+            await send(
+                {"type": "http.response.body", "body": _STREAQ_DEBUG_TIMEOUT_BODY}
+            )
+
+
+def _make_app(*, fast: bool, timeout: float = 5.0):
+    """Wrap a Starlette inner app with StreaqDebugTimeoutMiddleware.
+
+    The inner app hangs for 10s when `fast=False`, mimicking a stuck Redis
+    SCAN. When `fast=True`, it returns immediately so cheap paths can be
+    exercised.
+    """
+
+    async def hang(request):
+        await asyncio.sleep(10)
+        return PlainTextResponse("never")  # pragma: no cover
+
+    async def quick(request):
+        return PlainTextResponse("OK")
+
+    handler = quick if fast else hang
+    inner = Starlette(
+        routes=[
+            Route("/debug/tasks/queue", handler),
+            Route("/debug/tasks/workers", handler),
+            Route("/debug/tasks/cron", handler),
+            Route("/debug/tasks/", handler),
+            Route("/health/live", quick),
+        ]
+    )
+    return StreaqDebugTimeoutMiddleware(inner, timeout=timeout)
+
+
+class TestStreaqDebugTimeoutMiddleware:
+    def test_hang_on_queue_returns_504_within_timeout(self):
+        """A hung /debug/tasks/queue request is cancelled and returns 504."""
+        app = _make_app(fast=False, timeout=1.0)
+        client = TestClient(app)
+        start = time.monotonic()
+        resp = client.get("/debug/tasks/queue")
+        elapsed = time.monotonic() - start
+
+        assert resp.status_code == 504
+        assert "text/html" in resp.headers["content-type"]
+        assert b"Task queue view timed out" in resp.content
+        assert b"Redis SCAN" in resp.content
+        # Allow generous slack but well below the 10s inner hang.
+        assert elapsed < 3.0, f"Timeout did not fire in time (elapsed={elapsed:.2f}s)"
+
+    def test_hang_on_workers_returns_504(self):
+        """A hung /debug/tasks/workers request is cancelled and returns 504."""
+        app = _make_app(fast=False, timeout=1.0)
+        client = TestClient(app)
+        resp = client.get("/debug/tasks/workers")
+        assert resp.status_code == 504
+        assert b"Task queue view timed out" in resp.content
+
+    def test_cron_path_is_not_guarded(self):
+        """/debug/tasks/cron passes through unchanged (not a slow path)."""
+        app = _make_app(fast=True, timeout=1.0)
+        client = TestClient(app)
+        resp = client.get("/debug/tasks/cron")
+        assert resp.status_code == 200
+        assert resp.text == "OK"
+
+    def test_non_streaq_path_passes_through(self):
+        """Paths outside /debug/tasks/queue|workers are not affected."""
+        app = _make_app(fast=True, timeout=1.0)
+        client = TestClient(app)
+        resp = client.get("/health/live")
+        assert resp.status_code == 200
+        assert resp.text == "OK"
+
+    def test_fast_streaq_request_passes_through(self):
+        """A fast /debug/tasks/queue request returns the original response."""
+        app = _make_app(fast=True, timeout=1.0)
+        client = TestClient(app)
+        resp = client.get("/debug/tasks/queue")
+        assert resp.status_code == 200
+        assert resp.text == "OK"
+
+
+@pytest.mark.asyncio
+async def test_lifespan_passes_through():
+    """Non-http scopes (e.g. lifespan) are forwarded without modification."""
+    called: list[str] = []
+
+    async def inner_app(scope: Scope, receive: Receive, send: Send) -> None:
+        called.append(scope["type"])
+
+    mw = StreaqDebugTimeoutMiddleware(inner_app)
+
+    async def noop_receive() -> dict:  # pragma: no cover - never invoked
+        return {"type": "lifespan.startup"}
+
+    async def noop_send(message: dict) -> None:  # pragma: no cover - never invoked
+        return
+
+    await mw({"type": "lifespan"}, noop_receive, noop_send)
+    assert called == ["lifespan"]


### PR DESCRIPTION
## Summary

- `/debug/tasks/queue` and `/debug/tasks/workers` walk Redis with `SCAN`, which can hang
  indefinitely on a shared or large Redis instance — see upstream `tastyware/streaq#163`.
- Adds a pure-ASGI `StreaqDebugTimeoutMiddleware` that path-filters those two endpoints,
  cancels the handler after 5s with `asyncio.wait_for`, and returns a 504 HTML page that
  explains the cause and points users at project settings.
- Cheap routes under `/debug/tasks` (e.g. `/cron`) are not guarded and pass through unchanged.
- Registered last in the middleware list so the timeout only cancels the Streaq handler
  itself, not the outer middleware stack. Only registered when `settings.workers_available`
  is true (same condition that mounts the Streaq UI router).
- Docs updated in `background-tasks.md`, `llms.txt`, and `llms-full.txt`.

Closes #1863

## Test plan

- [x] `just lint-py` passes
- [x] `just type-check` passes
- [x] New unit tests cover hang/timeout, fast pass-through, cheap-path bypass, and lifespan
      pass-through (`tests/unit/test_streaq_debug_timeout_middleware.py`, 6 tests, all green)
- [x] Full unit suite still green (829 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)