### PR TITLE
fix(auth): keep admin session when impersonating a nameless user

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -481,8 +481,14 @@ class AuthBackend(AuthenticationBackend):
                     AuthCredentials(["authenticated"]),
                     WebUser.model_validate(user),
                 )
-            except Exception:
-                # Clear corrupted session data and continue unauthenticated
+            except Exception as exc:
+                logger.warning(
+                    "Clearing invalid session user data: {exc}",
+                    exc=exc,
+                    session_user_keys=sorted(user.keys())
+                    if isinstance(user, dict)
+                    else None,
+                )
                 conn.session.pop("user", None)
                 return None
 

--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -41,7 +41,7 @@ def register_oauth_provider(name: str, provider: OauthProviderModel) -> None:
 
 class WebUser(BaseUser, BaseModel):
     id: str
-    name: str
+    name: Optional[str] = None
     email: str
     picture: Optional[str] = Field(
         default=DEFAULT_AVATAR_IMAGE,
@@ -58,7 +58,7 @@ class WebUser(BaseUser, BaseModel):
 
     @property
     def display_name(self) -> str:
-        return self.name
+        return self.name or self.email.split("@", 1)[0]
 
 
 class Config:

--- a/vibetuner-py/tests/unit/test_webuser_session.py
+++ b/vibetuner-py/tests/unit/test_webuser_session.py
@@ -1,0 +1,74 @@
+# ABOUTME: Regression tests for WebUser session validation and AuthBackend logging.
+# ABOUTME: Guards against silent logout when a session user lacks an optional `name` (#1873).
+# ruff: noqa: S101
+
+import pytest
+from starlette.requests import HTTPConnection
+from vibetuner.frontend.middleware import AuthBackend
+from vibetuner.frontend.oauth import WebUser
+
+
+def test_webuser_accepts_session_without_name():
+    """A user impersonated/loaded from session_dict that omits `name` is still valid."""
+    user = WebUser.model_validate(
+        {"id": "u1", "email": "ada@example.com", "settings": {}}
+    )
+    assert user.name is None
+    assert user.is_authenticated is True
+
+
+def test_webuser_display_name_falls_back_to_email_prefix():
+    """display_name falls back to the email local-part when name is missing."""
+    user = WebUser(id="u1", email="ada@example.com")
+    assert user.display_name == "ada"
+
+
+def test_webuser_display_name_prefers_name_when_present():
+    user = WebUser(id="u1", name="Ada Lovelace", email="ada@example.com")
+    assert user.display_name == "Ada Lovelace"
+
+
+def _make_conn_with_session_user(user_data: object) -> HTTPConnection:
+    scope: dict = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "session": {"user": user_data},
+    }
+    return HTTPConnection(scope)
+
+
+@pytest.mark.asyncio
+async def test_auth_backend_authenticates_nameless_session_user():
+    """A session dict without `name` no longer triggers a silent logout."""
+    conn = _make_conn_with_session_user(
+        {"id": "u1", "email": "ada@example.com", "settings": {}}
+    )
+
+    result = await AuthBackend().authenticate(conn)
+
+    assert result is not None
+    credentials, user = result
+    assert "authenticated" in credentials.scopes
+    assert isinstance(user, WebUser)
+    assert user.id == "u1"
+    assert conn.session.get("user") == {
+        "id": "u1",
+        "email": "ada@example.com",
+        "settings": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_auth_backend_logs_warning_when_session_invalid(log_sink):
+    """When session data really is malformed, we log a warning instead of failing silently."""
+    conn = _make_conn_with_session_user({"id": "u1"})  # missing required `email`
+
+    result = await AuthBackend().authenticate(conn)
+
+    assert result is None
+    assert "user" not in conn.session
+    assert any(
+        "Clearing invalid session user data" in message for message in log_sink
+    ), log_sink


### PR DESCRIPTION
## Summary

- `WebUser.name` is now `Optional[str]`, matching `UserModel.name`; `display_name` falls back to the email local-part when name is missing
- `AuthBackend.authenticate` now logs a warning before clearing invalid session data, so future silent-corruption regressions leave a breadcrumb
- Adds regression tests for both the model accepting a nameless session dict and the new warning-on-clear behaviour

Closes #1873.

The bug: clicking "Impersonate" on a user whose `UserModel.name` was `None` (which the standard test fixtures ship) wrote a `session_dict` without `name` into the session, then on the next request `WebUser.model_validate` raised `ValidationError`, and the previous code silently popped the session — logging the admin out instead of swapping them into the target user.

## Test plan

- [x] `uv run python -m pytest tests/unit/` — 851 passing in `vibetuner-py`
- [x] `just lint-py` clean
- [x] `just type-check` clean
- [ ] Manually verify in a scaffolded debug app: log in as admin, visit `/debug/users`, impersonate a user with `name=None`, confirm you're now that user instead of logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)