### PR TITLE
fix(debug): restore admin session on stop-impersonation

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/routes/debug.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/debug.py
@@ -564,7 +564,13 @@ async def debug_impersonate_user(request: Request, user_id: str):
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    # Set full user session data (using the proper session_dict method)
+    # Stash the caller's session so /stop-impersonation can restore it.
+    # Only stash on the first hop so chained impersonations all unwind to
+    # the original admin instead of the previous impersonation target.
+    current_user = request.session.get("user")
+    if current_user is not None and "original_user" not in request.session:
+        request.session["original_user"] = current_user
+
     request.session["user"] = user.session_dict
 
     return RedirectResponse(url="/", status_code=302)
@@ -572,11 +578,15 @@ async def debug_impersonate_user(request: Request, user_id: str):
 
 @router.post("/stop-impersonation")
 async def debug_stop_impersonation(request: Request):
-    """Stop impersonating and clear user session."""
+    """Stop impersonating and restore the original session, if any."""
     if not ctx.DEBUG:
         raise HTTPException(status_code=404, detail="Not found")
 
-    request.session.pop("user", None)
+    original_user = request.session.pop("original_user", None)
+    if original_user is not None:
+        request.session["user"] = original_user
+    else:
+        request.session.pop("user", None)
     return RedirectResponse(url="/debug/users", status_code=302)
 
 

--- a/vibetuner-py/tests/unit/test_debug_impersonation.py
+++ b/vibetuner-py/tests/unit/test_debug_impersonation.py
@@ -1,0 +1,115 @@
+# ABOUTME: Tests debug impersonation routes preserve the admin's session.
+# ABOUTME: Regression coverage for #1875 (stop-impersonation must restore, not clear).
+# ruff: noqa: S101
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+from vibetuner.frontend.routes import debug as debug_routes
+
+
+@pytest.fixture(autouse=True)
+def _force_debug_mode(monkeypatch):
+    """Impersonation routes are 404 unless ctx.DEBUG is true."""
+    monkeypatch.setattr(debug_routes.ctx, "DEBUG", True)
+
+
+def _make_request(session: dict | None = None) -> Request:
+    scope: dict = {
+        "type": "http",
+        "method": "POST",
+        "path": "/debug/impersonate",
+        "headers": [],
+        "session": session if session is not None else {},
+    }
+    return Request(scope)
+
+
+def _make_user(user_id: str, session_dict: dict) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    user.session_dict = session_dict
+    return user
+
+
+@pytest.mark.asyncio
+async def test_impersonate_stashes_original_user():
+    admin = {"id": "admin1", "email": "admin@example.com", "settings": {}}
+    target_dict = {"id": "u2", "email": "u2@example.com", "settings": {}}
+    request = _make_request(session={"user": dict(admin)})
+
+    target = _make_user("u2", target_dict)
+    with patch.object(
+        debug_routes.UserModel, "get", new=AsyncMock(return_value=target)
+    ):
+        await debug_routes.debug_impersonate_user(request, "u2")
+
+    assert request.session["user"] == target_dict
+    assert request.session["original_user"] == admin
+
+
+@pytest.mark.asyncio
+async def test_stop_impersonation_restores_original_user():
+    admin = {"id": "admin1", "email": "admin@example.com", "settings": {}}
+    target = {"id": "u2", "email": "u2@example.com", "settings": {}}
+    request = _make_request(session={"user": target, "original_user": admin})
+
+    await debug_routes.debug_stop_impersonation(request)
+
+    assert request.session["user"] == admin
+    assert "original_user" not in request.session
+
+
+@pytest.mark.asyncio
+async def test_stop_impersonation_clears_session_when_no_original():
+    """Without an original_user (admin somehow lacked a session), keep old behaviour."""
+    request = _make_request(session={"user": {"id": "u2", "email": "u2@example.com"}})
+
+    await debug_routes.debug_stop_impersonation(request)
+
+    assert "user" not in request.session
+    assert "original_user" not in request.session
+
+
+@pytest.mark.asyncio
+async def test_chained_impersonations_preserve_root_admin():
+    """Hopping admin -> u2 -> u3 -> stop must return to the root admin, not u2."""
+    admin = {"id": "admin1", "email": "admin@example.com", "settings": {}}
+    u2_dict = {"id": "u2", "email": "u2@example.com", "settings": {}}
+    u3_dict = {"id": "u3", "email": "u3@example.com", "settings": {}}
+    request = _make_request(session={"user": dict(admin)})
+
+    with patch.object(
+        debug_routes.UserModel,
+        "get",
+        new=AsyncMock(
+            side_effect=[_make_user("u2", u2_dict), _make_user("u3", u3_dict)]
+        ),
+    ):
+        await debug_routes.debug_impersonate_user(request, "u2")
+        await debug_routes.debug_impersonate_user(request, "u3")
+
+    assert request.session["user"] == u3_dict
+    assert request.session["original_user"] == admin
+
+    await debug_routes.debug_stop_impersonation(request)
+
+    assert request.session["user"] == admin
+    assert "original_user" not in request.session
+
+
+@pytest.mark.asyncio
+async def test_impersonate_without_existing_session_does_not_stash():
+    """Calling impersonate while logged out shouldn't synthesise an original_user."""
+    target_dict = {"id": "u2", "email": "u2@example.com", "settings": {}}
+    request = _make_request(session={})
+
+    target = _make_user("u2", target_dict)
+    with patch.object(
+        debug_routes.UserModel, "get", new=AsyncMock(return_value=target)
+    ):
+        await debug_routes.debug_impersonate_user(request, "u2")
+
+    assert request.session["user"] == target_dict
+    assert "original_user" not in request.session


### PR DESCRIPTION
## Summary

- `debug_impersonate_user` now stashes the caller's `session["user"]` under `session["original_user"]` on the first hop only, so chained impersonations unwind to the root admin
- `debug_stop_impersonation` pops `original_user` and restores it; with no stash it falls back to the previous "clear user" behaviour
- Adds regression tests for restore, chained impersonations, and the no-stash fallback

Closes #1875.

The bug: `debug_impersonate_user` overwrote `session.user` with the target's `session_dict` and never stashed the caller anywhere, so `debug_stop_impersonation` could only ever clear the session — kicking the admin out instead of returning them to their normal account.

## Test plan

- [x] `uv run python -m pytest tests/unit/` — 856 passing in `vibetuner-py` (5 new)
- [x] `just lint-py` clean
- [x] `just type-check` clean
- [ ] Manually: log in as admin → `/debug/users` → impersonate user → back at admin home as that user → click "Stop impersonating" → returned to admin home as admin (not logged out)
- [ ] Manually: chained impersonate admin → u1 → u2 → stop → back as admin (not u1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)