### PR TITLE
fix(debug): use path-relative URLs and surface tasks/users tiles

### DIFF
--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/components/debug_nav.html.jinja
@@ -1,8 +1,7 @@
 <!-- Debug Navigation Component -->
 <nav class="mt-8 pt-6 border-t border-base-200">
     <div class="flex flex-wrap gap-4">
-        <a href="{{ url_for('debug_index') }}"
-           class="btn btn-outline btn-primary gap-2">
+        <a href="/debug/" class="btn btn-outline btn-primary gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z">
                 </path>
@@ -11,59 +10,56 @@
             </svg>
             Debug Home
         </a>
-        <a href="{{ url_for('debug_info') }}"
-           class="btn btn-outline btn-primary gap-2">
+        <a href="/debug/info" class="btn btn-outline btn-primary gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z">
                 </path>
             </svg>
             System Info
         </a>
-        <a href="{{ url_for('debug_collections') }}"
-           class="btn btn-outline btn-primary gap-2">
+        <a href="/debug/collections" class="btn btn-outline btn-primary gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4">
                 </path>
             </svg>
             Collections
         </a>
-        <a href="{{ url_for('debug_users') }}"
-           class="btn btn-outline btn-warning gap-2">
+        <a href="/debug/users" class="btn btn-outline btn-warning gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z">
                 </path>
             </svg>
             User Impersonation
         </a>
-        <a href="{{ url_for('debug_blocks') }}"
-           class="btn btn-outline btn-accent gap-2">
+        <a href="/debug/blocks" class="btn btn-outline btn-accent gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z">
                 </path>
             </svg>
             Template Blocks
         </a>
-        <a href="{{ url_for('debug_version') }}"
-           class="btn btn-outline btn-primary gap-2">
+        <a href="/debug/tasks/" class="btn btn-outline btn-primary gap-2">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z">
+                </path>
+            </svg>
+            Background Tasks
+        </a>
+        <a href="/debug/version" class="btn btn-outline btn-primary gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z">
                 </path>
             </svg>
             Version
         </a>
-        <a href="{{ url_for('debug_oauth_apps') }}"
-           class="btn btn-outline btn-secondary gap-2">
+        <a href="/debug/oauth-apps" class="btn btn-outline btn-secondary gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z">
                 </path>
             </svg>
             OAuth Apps
         </a>
-        <a href="{{ url_for('debug_config') }}"
-           class="btn btn-outline btn-secondary gap-2">
+        <a href="/debug/config" class="btn btn-outline btn-secondary gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z">
                 </path>
@@ -71,8 +67,7 @@
             </svg>
             Config
         </a>
-        <a href="{{ url_for('health_ping') }}"
-           class="btn btn-outline btn-success gap-2">
+        <a href="/health/ping" class="btn btn-outline btn-success gap-2">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z">
                 </path>

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/config.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/config.html.jinja
@@ -24,7 +24,7 @@
         <!-- Actions Bar -->
         <div class="flex justify-between items-center mb-6">
             <div class="flex gap-2">
-                <form method="post" action="{{ url_for('debug_config_refresh') }}">
+                <form method="post" action="/debug/config/refresh">
                     <button type="submit" class="btn btn-outline btn-sm gap-2">
                         <svg xmlns="http://www.w3.org/2000/svg"
                              class="h-4 w-4"
@@ -109,8 +109,7 @@
                                         {% if DEBUG %}
                                             <td class="text-center">
                                                 {% if not entry.is_secret %}
-                                                    <a href="{{ url_for('debug_config_detail', key=entry.key) }}"
-                                                       class="btn btn-outline btn-xs">Edit</a>
+                                                    <a href="/debug/config/{{ entry.key }}" class="btn btn-outline btn-xs">Edit</a>
                                                 {% else %}
                                                     <span class="text-base-content/40 text-xs">Protected</span>
                                                 {% endif %}

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/config_detail.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/config_detail.html.jinja
@@ -8,7 +8,7 @@
         <!-- Header -->
         <header class="mb-8">
             <div class="flex items-center gap-2 mb-2">
-                <a href="{{ url_for('debug_config') }}" class="btn btn-ghost btn-sm">
+                <a href="/debug/config" class="btn btn-ghost btn-sm">
                     <svg xmlns="http://www.w3.org/2000/svg"
                          class="h-4 w-4"
                          fill="none"
@@ -84,8 +84,7 @@
             <div class="card bg-base-100 shadow-xl mb-6">
                 <div class="card-body">
                     <h2 class="card-title text-lg">Edit Value</h2>
-                    <form method="post"
-                          action="{{ url_for('debug_config_update', key=entry.key) }}">
+                    <form method="post" action="/debug/config/{{ entry.key }}">
                         <div class="form-control w-full">
                             <label class="label">
                                 <span class="label-text">Current Value</span>
@@ -131,7 +130,7 @@
                             </label>
                         </div>
                         <div class="card-actions justify-end mt-6">
-                            <a href="{{ url_for('debug_config') }}" class="btn btn-ghost">Cancel</a>
+                            <a href="/debug/config" class="btn btn-ghost">Cancel</a>
                             <button type="submit" class="btn btn-primary">Save Changes</button>
                         </div>
                     </form>
@@ -146,8 +145,7 @@
                             This value has a runtime override. Remove it to fall back to the MongoDB or default value.
                         </p>
                         <div class="card-actions justify-end mt-4">
-                            <form method="post"
-                                  action="{{ url_for('debug_config_clear_override', key=entry.key) }}">
+                            <form method="post" action="/debug/config/{{ entry.key }}/clear-override">
                                 <button type="submit" class="btn btn-warning btn-outline">Remove Runtime Override</button>
                             </form>
                         </div>

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/index.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/index.html.jinja
@@ -24,7 +24,7 @@
                     </h2>
                     <p class="text-base-content/70 mb-4">View application configuration, cookies, and runtime information</p>
                     <div class="card-actions justify-end">
-                        <a href="{{ url_for('debug_info') }}" class="btn btn-primary btn-sm">View Details</a>
+                        <a href="/debug/info" class="btn btn-primary btn-sm">View Details</a>
                     </div>
                 </div>
             </div>
@@ -40,8 +40,7 @@
                     </h2>
                     <p class="text-base-content/70 mb-4">Explore MongoDB collections and their field schemas</p>
                     <div class="card-actions justify-end">
-                        <a href="{{ url_for('debug_collections') }}"
-                           class="btn btn-primary btn-sm">View Schemas</a>
+                        <a href="/debug/collections" class="btn btn-primary btn-sm">View Schemas</a>
                     </div>
                 </div>
             </div>
@@ -57,7 +56,7 @@
                     </h2>
                     <p class="text-base-content/70 mb-4">Check application version and build information</p>
                     <div class="card-actions justify-end">
-                        <a href="{{ url_for('debug_version') }}" class="btn btn-primary btn-sm">View Version</a>
+                        <a href="/debug/version" class="btn btn-primary btn-sm">View Version</a>
                     </div>
                 </div>
             </div>
@@ -73,7 +72,7 @@
                     </h2>
                     <p class="text-base-content/70 mb-4">Verify application health and API endpoint status</p>
                     <div class="card-actions justify-end">
-                        <a href="{{ url_for('health_ping') }}" class="btn btn-success btn-sm">Check Health</a>
+                        <a href="/health/ping" class="btn btn-success btn-sm">Check Health</a>
                     </div>
                 </div>
             </div>
@@ -82,20 +81,14 @@
                 <div class="card-body">
                     <h2 class="card-title text-secondary flex items-center gap-2">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                  d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z">
                             </path>
                         </svg>
                         OAuth Provider Apps
                     </h2>
-                    <p class="text-base-content/70 mb-4">
-                        Manage OAuth app credentials per provider
-                    </p>
+                    <p class="text-base-content/70 mb-4">Manage OAuth app credentials per provider</p>
                     <div class="card-actions justify-end">
-                        <a href="{{ url_for('debug_oauth_apps') }}"
-                           class="btn btn-secondary btn-sm">Manage Apps</a>
+                        <a href="/debug/oauth-apps" class="btn btn-secondary btn-sm">Manage Apps</a>
                     </div>
                 </div>
             </div>
@@ -112,7 +105,7 @@
                     </h2>
                     <p class="text-base-content/70 mb-4">View and manage runtime configuration values</p>
                     <div class="card-actions justify-end">
-                        <a href="{{ url_for('debug_config') }}" class="btn btn-secondary btn-sm">View Config</a>
+                        <a href="/debug/config" class="btn btn-secondary btn-sm">View Config</a>
                     </div>
                 </div>
             </div>
@@ -128,7 +121,39 @@
                     </h2>
                     <p class="text-base-content/70 mb-4">Discover available skeleton blocks for template inheritance</p>
                     <div class="card-actions justify-end">
-                        <a href="{{ url_for('debug_blocks') }}" class="btn btn-accent btn-sm">View Blocks</a>
+                        <a href="/debug/blocks" class="btn btn-accent btn-sm">View Blocks</a>
+                    </div>
+                </div>
+            </div>
+            <!-- Background Tasks -->
+            <div class="card bg-base-100 shadow-xl border border-base-200 hover:shadow-2xl transition-shadow">
+                <div class="card-body">
+                    <h2 class="card-title text-primary flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z">
+                            </path>
+                        </svg>
+                        Background Tasks
+                    </h2>
+                    <p class="text-base-content/70 mb-4">Inspect the Streaq queue, workers, scheduled crons, and task history</p>
+                    <div class="card-actions justify-end">
+                        <a href="/debug/tasks/" class="btn btn-primary btn-sm">View Queue</a>
+                    </div>
+                </div>
+            </div>
+            <!-- Users -->
+            <div class="card bg-base-100 shadow-xl border border-base-200 hover:shadow-2xl transition-shadow">
+                <div class="card-body">
+                    <h2 class="card-title text-warning flex items-center gap-2">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z">
+                            </path>
+                        </svg>
+                        Users
+                    </h2>
+                    <p class="text-base-content/70 mb-4">Browse all users and impersonate any account for testing</p>
+                    <div class="card-actions justify-end">
+                        <a href="/debug/users" class="btn btn-warning btn-sm">Browse Users</a>
                     </div>
                 </div>
             </div>

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_app_form.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_app_form.html.jinja
@@ -8,7 +8,7 @@
         <!-- Header -->
         <header class="mb-8">
             <div class="flex items-center gap-2 mb-2">
-                <a href="{{ url_for('debug_oauth_apps') }}" class="btn btn-ghost btn-sm">
+                <a href="/debug/oauth-apps" class="btn btn-ghost btn-sm">
                     <svg xmlns="http://www.w3.org/2000/svg"
                          class="h-4 w-4"
                          fill="none"
@@ -36,7 +36,7 @@
                 <div class="card-body">
                     <form method="post"
                           autocomplete="off"
-                          action="{{ url_for('debug_oauth_app_update', app_id=app.id) if app else url_for('debug_oauth_app_store') }}">
+                          action="{{ '/debug/oauth-apps/' ~ app.id if app else '/debug/oauth-apps/create' }}">
                         <!-- Provider -->
                         <div class="form-control w-full mb-4">
                             <label class="label">
@@ -203,7 +203,7 @@
                         </div>
                         <!-- Submit -->
                         <div class="card-actions justify-end">
-                            <a href="{{ url_for('debug_oauth_apps') }}" class="btn btn-ghost">Cancel</a>
+                            <a href="/debug/oauth-apps" class="btn btn-ghost">Cancel</a>
                             <button type="submit" class="btn btn-primary">{{ 'Save Changes' if app else 'Create App' }}</button>
                         </div>
                     </form>

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_apps.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/oauth_apps.html.jinja
@@ -8,25 +8,19 @@
         <!-- Header -->
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-base-content mb-2">OAuth Provider Apps</h1>
-            <p class="text-base-content/70">
-                Manage OAuth app credentials per provider
-            </p>
+            <p class="text-base-content/70">Manage OAuth app credentials per provider</p>
         </header>
         <!-- Actions Bar -->
         <div class="flex justify-between items-center mb-6">
             <div class="flex gap-2">
                 {% if DEBUG %}
-                    <a href="{{ url_for('debug_oauth_app_create') }}"
-                       class="btn btn-primary btn-sm gap-2">
+                    <a href="/debug/oauth-apps/create" class="btn btn-primary btn-sm gap-2">
                         <svg xmlns="http://www.w3.org/2000/svg"
                              class="h-4 w-4"
                              fill="none"
                              viewBox="0 0 24 24"
                              stroke="currentColor">
-                            <path stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                  d="M12 4v16m8-8H4" />
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
                         </svg>
                         Add App
                     </a>
@@ -48,10 +42,7 @@
                                  fill="none"
                                  viewBox="0 0 24 24"
                                  stroke="currentColor">
-                                <path stroke-linecap="round"
-                                      stroke-linejoin="round"
-                                      stroke-width="2"
-                                      d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
                             </svg>
                             {{ provider }}
                         </h2>
@@ -72,9 +63,7 @@
                                             <td>
                                                 <span class="font-medium">{{ app.name }}</span>
                                                 {% if app.external_app_id %}
-                                                    <div class="text-xs text-base-content/60 mt-1">
-                                                        ext: {{ app.external_app_id }}
-                                                    </div>
+                                                    <div class="text-xs text-base-content/60 mt-1">ext: {{ app.external_app_id }}</div>
                                                 {% endif %}
                                             </td>
                                             <td>
@@ -84,9 +73,7 @@
                                             </td>
                                             <td>
                                                 {% if app.scopes %}
-                                                    {% for scope in app.scopes %}
-                                                        <span class="badge badge-outline badge-sm">{{ scope }}</span>
-                                                    {% endfor %}
+                                                    {% for scope in app.scopes %}<span class="badge badge-outline badge-sm">{{ scope }}</span>{% endfor %}
                                                 {% else %}
                                                     <span class="text-base-content/40 text-xs">provider defaults</span>
                                                 {% endif %}
@@ -101,15 +88,11 @@
                                             {% if DEBUG %}
                                                 <td class="text-center">
                                                     <div class="flex gap-1 justify-center">
-                                                        <a href="{{ url_for('debug_oauth_app_edit', app_id=app.id) }}"
-                                                           class="btn btn-outline btn-xs">Edit</a>
+                                                        <a href="/debug/oauth-apps/{{ app.id }}" class="btn btn-outline btn-xs">Edit</a>
                                                         <form method="post"
-                                                              action="{{ url_for('debug_oauth_app_delete', app_id=app.id) }}"
+                                                              action="/debug/oauth-apps/{{ app.id }}/delete"
                                                               onsubmit="return confirm('Delete this OAuth app?')">
-                                                            <button type="submit"
-                                                                    class="btn btn-outline btn-error btn-xs">
-                                                                Delete
-                                                            </button>
+                                                            <button type="submit" class="btn btn-outline btn-error btn-xs">Delete</button>
                                                         </form>
                                                     </div>
                                                 </td>
@@ -128,15 +111,12 @@
                      class="stroke-current shrink-0 h-6 w-6"
                      fill="none"
                      viewBox="0 0 24 24">
-                    <path stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <span>
                     No OAuth apps configured.
                     {% if providers %}
-                        Registered providers: {{ providers | join(', ') }}.
+                        Registered providers: {{ providers | join(", ") }}.
                     {% else %}
                         No providers registered yet (configure in tune.py).
                     {% endif %}

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/users.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/users.html.jinja
@@ -37,7 +37,7 @@
                         User ID: <code>{{ current_user_id }}</code>
                     </p>
                     <div class="card-actions justify-end">
-                        <form method="post" action="{{ url_for('debug_stop_impersonation') }}">
+                        <form method="post" action="/debug/stop-impersonation">
                             <button type="submit" class="btn btn-secondary btn-sm">Stop Impersonation</button>
                         </form>
                     </div>
@@ -106,7 +106,7 @@
                                         <td class="text-center">
                                             {% if current_user_id != user.id|string %}
                                                 <form method="post"
-                                                      action="{{ url_for('debug_impersonate_user', user_id=user.id) }}"
+                                                      action="/debug/impersonate/{{ user.id }}"
                                                       class="inline">
                                                     <button type="submit" class="btn btn-outline btn-sm">Impersonate</button>
                                                 </form>

--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -34,6 +34,10 @@ repos:
     hooks:
       - id: djlint-jinja
         files: \.(html\.jinja)$
+        # Mirror ignore list from djlint.toml: the djlint-jinja hook
+        # passes --profile=jinja, which causes djlint to skip the
+        # config file, so the ignore rules must be repeated here.
+        args: ["--ignore=H006,J018"]
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:


### PR DESCRIPTION
## Summary

- Replace every `url_for(...)` in `templates/frontend/debug/` (index, nav, oauth apps, oauth app form, users, config, config detail) with the literal route path. Starlette's `url_for` returns absolute URLs derived from the request's host/scheme, which breaks debug navigation behind dev tunnels (Tailscale Funnel, ngrok, Cloudflare) or when the dev server is fronted from another LAN device.
- Add **Background Tasks** (`/debug/tasks/`) and **Users** (`/debug/users`) cards to the debug index, plus a matching Background Tasks entry in `debug_nav`, so the Streaq queue UI and users browser are discoverable without grepping `frontend/routes/debug.py`.
- Align the `djlint-jinja` pre-commit hook with `djlint.toml`: the hook passes `--profile=jinja`, which causes djlint to skip the config file, so `H006`/`J018` must be repeated on the hook command line. Without this, the literal `/debug/...` hrefs would trip J018 in pre-commit even though the project intentionally ignores it via `djlint.toml`. The edit lands on the template-shared symlink, so scaffolded projects inherit the fix.
- `lang/select.html.jinja` already uses `url_for(...).path`, so it's tunnel-safe and unchanged.

## Test plan

- [x] `just lint-jinja`, `just format-jinja`, debug-related pytest suites all green
- [ ] Manual: load `/debug/` behind a Tailscale Funnel and confirm every tile resolves through the tunnel
- [ ] Manual: confirm the new Background Tasks / Users tiles render and click through

Closes #1877