### PR TITLE
fix(debug): show env/CLI/.env setup steps on secret config detail page

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2391,7 +2391,19 @@ Values are resolved with this priority (highest to lowest):
 
 1. **Runtime overrides** — In-memory overrides set programmatically or via debug UI
 2. **MongoDB values** — Persisted values that survive restarts
-3. **Registered defaults** — Default values defined in code
+3. **Environment variables** — Derived from the key by uppercasing and replacing
+   dots with underscores (e.g. `services.anthropic_api_key` →
+   `SERVICES_ANTHROPIC_API_KEY`). Read from `os.environ` first, then from the
+   merged `.env` / `.env.local` files. Coerced to the registered `value_type`;
+   bogus values log a warning and fall through. Requires a worker/frontend
+   restart to pick up changes.
+4. **Registered defaults** — Default values defined in code
+
+For `is_secret=True` keys, `/debug/config/<key>` renders a "Set this value"
+card showing the env-var name, the matching `vibetuner config set <key>` CLI
+command, and the `.env` entry to write, plus a worker/frontend restart
+reminder. This unblocks first-time admins who would otherwise hit a dead-end
+"this configuration is marked as secret" alert.
 
 #### Value Types
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -167,6 +167,13 @@ Important notes:
   `VibetunerApp(runtime_config={...})` for declarative registration in `tune.py`
 - **Config CLI**: `vibetuner config list|set|delete` manages runtime config
   values from the command line. Secret values use hidden input prompts
+- **Config Env Fallback**: Runtime config keys auto-resolve from environment
+  variables derived as `<KEY>.upper().replace(".", "_")` (e.g.
+  `services.anthropic_api_key` → `SERVICES_ANTHROPIC_API_KEY`). Priority is
+  runtime override > MongoDB > env var > registered default. `.env` /
+  `.env.local` are honored. `/debug/config/<key>` renders a "Set this value"
+  block on secret keys showing the env-var name, CLI command, and `.env`
+  entry, with a worker/frontend restart reminder
 - **Testing Fixtures**: `vibetuner_client`, `mock_auth`, `mock_tasks`,
   `override_config`, `vibetuner_db` pytest fixtures
 - **Error Messages**: Actionable error messages with env var examples, Docker

--- a/vibetuner-docs/docs/runtime-config.md
+++ b/vibetuner-docs/docs/runtime-config.md
@@ -110,11 +110,17 @@ Configuration values are resolved with the following priority (highest to lowest
 
 1. **Runtime overrides** - In-memory overrides set programmatically or via debug UI
 2. **MongoDB values** - Persisted values that survive restarts
-3. **Registered defaults** - Default values defined in code
+3. **Environment variables** - Derived from the key by uppercasing and replacing
+   dots with underscores (e.g. `services.anthropic_api_key` →
+   `SERVICES_ANTHROPIC_API_KEY`). Read from `os.environ` first, then from the
+   merged `.env` / `.env.local` files. Values are coerced to the registered
+   `value_type`. Requires a worker/frontend restart to pick up changes.
+4. **Registered defaults** - Default values defined in code
 
 ```python
-# Example: If the same key exists in all three layers
+# Example: If the same key exists in all four layers
 # registered default: False
+# env var: True
 # mongodb value: True
 # runtime override: False
 # Result: False (runtime override wins)
@@ -419,7 +425,10 @@ Mark sensitive values with `is_secret=True`:
 
 - Values are **encrypted at rest** in MongoDB using Fernet (symmetric encryption)
 - Values are masked (`*****`) in the debug UI
-- Values cannot be edited via the debug UI
+- Values cannot be edited via the debug UI; the detail page at
+  `/debug/config/<key>` shows a "Set this value" card with the derived env var
+  name, the matching `vibetuner config set <key>` CLI command, and the `.env`
+  entry to write
 - Values are still accessible programmatically (decrypted transparently on load)
 
 Encryption requires the `FIELD_ENCRYPTION_KEY` environment variable. When set, secret config

--- a/vibetuner-py/src/vibetuner/runtime_config.py
+++ b/vibetuner-py/src/vibetuner/runtime_config.py
@@ -1,16 +1,34 @@
 # ABOUTME: Layered runtime configuration system with MongoDB persistence.
-# ABOUTME: Provides get/set config with priority: runtime overrides > MongoDB > registered defaults.
+# ABOUTME: Provides get/set config with priority: runtime overrides > MongoDB > env vars > registered defaults.
 
 import asyncio
 import json
+import os
 from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import Any, Literal, TypedDict
 
-from vibetuner.config import settings
+from dotenv import dotenv_values
+
+from vibetuner.config import _ENV_FILES, settings
 from vibetuner.logging import logger
 from vibetuner.time import now
+
+
+@lru_cache(maxsize=1)
+def _dotenv_values() -> dict[str, str]:
+    """Load the merged ``.env`` files used by ``CoreConfiguration``.
+
+    Cached so the files are read once per process; restart the
+    worker/frontend to pick up changes.
+    """
+    merged: dict[str, str] = {}
+    for path in _ENV_FILES:
+        for k, v in dotenv_values(path).items():
+            if v is not None:
+                merged[k] = v
+    return merged
 
 
 def _to_secret_value(value: Any) -> str:
@@ -24,6 +42,15 @@ ConfigValueType = Literal["str", "int", "float", "bool", "json"]
 CACHE_TTL_SECONDS = 60
 
 
+def env_var_name(key: str) -> str:
+    """Return the environment variable name for a runtime config key.
+
+    Dots become underscores and the whole thing is uppercased, so
+    ``services.anthropic_api_key`` maps to ``SERVICES_ANTHROPIC_API_KEY``.
+    """
+    return key.upper().replace(".", "_")
+
+
 class ConfigRegistryEntry(TypedDict):
     """Type for registry entries."""
 
@@ -34,16 +61,20 @@ class ConfigRegistryEntry(TypedDict):
     is_secret: bool
 
 
+ConfigSource = Literal["default", "mongodb", "runtime", "env"]
+
+
 class ConfigEntry(TypedDict):
     """Type for config entries returned by get_all_config."""
 
     key: str
     value: Any
     value_type: ConfigValueType
-    source: Literal["default", "mongodb", "runtime"]
+    source: ConfigSource
     description: str | None
     category: str
     is_secret: bool
+    env_name: str
 
 
 class RuntimeConfig:
@@ -52,7 +83,9 @@ class RuntimeConfig:
     Priority (highest to lowest):
     1. Runtime overrides - in-memory, for debugging/testing
     2. MongoDB values - persistent, survives restarts
-    3. Registered defaults - defined in code
+    3. Environment variables - derived from the key (e.g.
+       ``services.anthropic_api_key`` -> ``SERVICES_ANTHROPIC_API_KEY``)
+    4. Registered defaults - defined in code
     """
 
     # Class-level storage
@@ -106,8 +139,10 @@ class RuntimeConfig:
         Priority:
         1. Runtime overrides
         2. MongoDB cache
-        3. Registered default
-        4. Provided default parameter
+        3. Environment variable (``env_var_name(key)``), coerced to the
+           registered ``value_type`` when the key is registered
+        4. Registered default
+        5. Provided default parameter
         """
         # 1. Check runtime overrides first (highest priority)
         if key in cls._runtime_overrides:
@@ -121,12 +156,50 @@ class RuntimeConfig:
         if key in cls._config_cache:
             return cls._config_cache[key]
 
-        # 3. Check registered defaults
+        # 3. Check environment variable
+        env_value = cls._read_env_value(key)
+        if env_value is not None:
+            return env_value
+
+        # 4. Check registered defaults
         if key in cls._config_registry:
             return cls._config_registry[key]["default"]
 
-        # 4. Fall back to provided default
+        # 5. Fall back to provided default
         return default
+
+    @classmethod
+    def _read_env_value(cls, key: str) -> Any | None:
+        """Read and coerce the env-var value for a config key.
+
+        Reads ``os.environ`` first, falling back to the merged ``.env``
+        files used by :class:`CoreConfiguration`. Returns ``None`` when
+        the env var is unset or when coercion fails; callers should treat
+        ``None`` as "not provided by env" and fall through to the next
+        layer.
+        """
+        name = env_var_name(key)
+        raw = os.environ.get(name)
+        if raw is None:
+            raw = _dotenv_values().get(name)
+        if raw is None:
+            return None
+
+        entry = cls._config_registry.get(key)
+        if entry is None:
+            return raw
+
+        try:
+            return cls._validate_value(raw, entry["value_type"])
+        except (ValueError, TypeError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Ignoring env var {} for config {}: failed to coerce to {} ({})",
+                name,
+                key,
+                entry["value_type"],
+                exc,
+            )
+            return None
 
     @classmethod
     async def set_runtime_override(cls, key: str, value: Any) -> None:
@@ -232,15 +305,21 @@ class RuntimeConfig:
         # Start with all registered configs
         for key, reg in cls._config_registry.items():
             # Determine value and source based on priority
+            source: ConfigSource
             if key in cls._runtime_overrides:
                 value = cls._runtime_overrides[key]
-                source: Literal["default", "mongodb", "runtime"] = "runtime"
+                source = "runtime"
             elif key in cls._config_cache:
                 value = cls._config_cache[key]
                 source = "mongodb"
             else:
-                value = reg["default"]
-                source = "default"
+                env_value = cls._read_env_value(key)
+                if env_value is not None:
+                    value = env_value
+                    source = "env"
+                else:
+                    value = reg["default"]
+                    source = "default"
 
             entries.append(
                 ConfigEntry(
@@ -251,6 +330,7 @@ class RuntimeConfig:
                     description=reg["description"],
                     category=reg["category"],
                     is_secret=reg["is_secret"],
+                    env_name=env_var_name(key),
                 )
             )
 

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/config.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/config.html.jinja
@@ -102,6 +102,8 @@
                                                 <span class="badge badge-warning badge-sm">runtime</span>
                                             {% elif entry.source == 'mongodb' %}
                                                 <span class="badge badge-info badge-sm">mongodb</span>
+                                            {% elif entry.source == 'env' %}
+                                                <span class="badge badge-info badge-sm">env</span>
                                             {% else %}
                                                 <span class="badge badge-ghost badge-sm">default</span>
                                             {% endif %}

--- a/vibetuner-py/src/vibetuner/templates/frontend/debug/config_detail.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/debug/config_detail.html.jinja
@@ -42,6 +42,8 @@
                             <span class="badge badge-warning ml-2">runtime override</span>
                         {% elif entry.source == 'mongodb' %}
                             <span class="badge badge-info ml-2">mongodb</span>
+                        {% elif entry.source == 'env' %}
+                            <span class="badge badge-info ml-2">env</span>
                         {% else %}
                             <span class="badge badge-ghost ml-2">default</span>
                         {% endif %}
@@ -67,6 +69,37 @@
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L4.35 16.5c-.77.833.192 2.5 1.732 2.5z" />
                 </svg>
                 <span>This configuration is marked as secret and cannot be edited via the debug UI.</span>
+            </div>
+            <!-- How to set this secret -->
+            <div class="card bg-base-100 shadow-xl mb-6">
+                <div class="card-body">
+                    <h2 class="card-title text-lg">Set this value</h2>
+                    <p class="text-base-content/70">Choose whichever fits your deployment:</p>
+                    <ul class="mt-2 space-y-3">
+                        <li>
+                            <div class="text-sm text-base-content/60">Environment variable</div>
+                            <code class="text-sm bg-base-200 px-2 py-1 rounded select-all">{{ entry.env_name }}=&lt;value&gt;</code>
+                        </li>
+                        <li>
+                            <div class="text-sm text-base-content/60">CLI</div>
+                            <code class="text-sm bg-base-200 px-2 py-1 rounded select-all">uv run vibetuner config set {{ entry.key }}</code>
+                            <div class="text-xs text-base-content/60 mt-1">Prompts for the value without echoing it; persists to MongoDB.</div>
+                        </li>
+                        <li>
+                            <div class="text-sm text-base-content/60">.env file</div>
+                            <code class="text-sm bg-base-200 px-2 py-1 rounded select-all">{{ entry.env_name }}=&lt;value&gt;</code>
+                        </li>
+                    </ul>
+                    <div class="alert alert-info mt-4">
+                        <svg xmlns="http://www.w3.org/2000/svg"
+                             class="stroke-current shrink-0 h-5 w-5"
+                             fill="none"
+                             viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <span>Restart the worker and frontend after changing the env var or .env file so the new value is picked up.</span>
+                    </div>
+                </div>
             </div>
         {% elif not DEBUG %}
             <!-- Production mode notice -->

--- a/vibetuner-py/tests/unit/test_debug_config_detail.py
+++ b/vibetuner-py/tests/unit/test_debug_config_detail.py
@@ -1,0 +1,129 @@
+# ABOUTME: Tests that the debug config detail page renders set-up guidance for secrets.
+# ABOUTME: Regression coverage for #1879 (secret-key dead-end with no how-to block).
+# ruff: noqa: S101
+
+from jinja2 import (
+    ChainableUndefined,
+    ChoiceLoader,
+    DictLoader,
+    Environment,
+    FileSystemLoader,
+    select_autoescape,
+)
+from vibetuner.paths import frontend_templates
+
+
+def _stub_url_for(name: str, **kwargs):
+    class _URL:
+        path = f"/{name}"
+
+    return _URL()
+
+
+def _make_env() -> Environment:
+    env = Environment(
+        loader=ChoiceLoader(
+            [
+                DictLoader(
+                    {
+                        "child.html.jinja": (
+                            "{% extends 'debug/config_detail.html.jinja' %}"
+                        ),
+                    }
+                ),
+                FileSystemLoader([str(p) for p in frontend_templates]),
+            ]
+        ),
+        autoescape=select_autoescape(["html", "jinja"]),
+        undefined=ChainableUndefined,
+    )
+
+    class _Hotreload:
+        @staticmethod
+        def script(url):
+            return ""
+
+    env.globals["url_for"] = _stub_url_for
+    env.globals["DEBUG"] = True
+    env.globals["BODY_CLASS"] = ""
+    env.globals["SKIP_HEADER"] = True
+    env.globals["SKIP_FOOTER"] = True
+    env.globals["project_name"] = "test"
+    env.globals["project_description"] = "test"
+    env.globals["hotreload"] = _Hotreload()
+    return env
+
+
+def _render_secret_detail(entry: dict) -> str:
+    env = _make_env()
+
+    class _StubRequest:
+        class state:  # noqa: N801
+            language = "en"
+
+        url = "https://test.example.com/debug/config/" + entry["key"]
+
+    return env.get_template("child.html.jinja").render(
+        request=_StubRequest(),
+        csp_nonce="n",
+        umami_website_id=None,
+        entry=entry,
+        mongodb_available=True,
+    )
+
+
+def _secret_entry(**overrides) -> dict:
+    base = {
+        "key": "services.anthropic_api_key",
+        "value": "",
+        "value_type": "str",
+        "source": "default",
+        "description": "Anthropic API key",
+        "category": "services",
+        "is_secret": True,
+        "env_name": "SERVICES_ANTHROPIC_API_KEY",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSecretHowToBlock:
+    """The help block must show actionable guidance for first-time admins."""
+
+    def test_renders_env_var_name_for_secret(self):
+        out = _render_secret_detail(_secret_entry())
+        assert "SERVICES_ANTHROPIC_API_KEY" in out
+
+    def test_renders_cli_command_with_key(self):
+        out = _render_secret_detail(_secret_entry())
+        assert "uv run vibetuner config set services.anthropic_api_key" in out
+
+    def test_mentions_dot_env_option(self):
+        out = _render_secret_detail(_secret_entry())
+        # The .env line uses the same uppercase env name format
+        assert out.count("SERVICES_ANTHROPIC_API_KEY") >= 2
+        assert ".env" in out
+
+    def test_includes_restart_reminder(self):
+        out = _render_secret_detail(_secret_entry())
+        assert "Restart" in out
+        assert "worker" in out
+        assert "frontend" in out
+
+    def test_block_absent_for_non_secret_entries(self):
+        out = _render_secret_detail(
+            _secret_entry(
+                key="features.dark_mode",
+                value_type="bool",
+                value=False,
+                category="features",
+                is_secret=False,
+                env_name="FEATURES_DARK_MODE",
+            )
+        )
+        assert "uv run vibetuner config set" not in out
+
+    def test_env_source_badge_renders(self):
+        out = _render_secret_detail(_secret_entry(source="env", value="sk-..."))
+        # New source badge must be present so admins can see env wins
+        assert ">env<" in out

--- a/vibetuner-py/tests/unit/test_runtime_config.py
+++ b/vibetuner-py/tests/unit/test_runtime_config.py
@@ -455,7 +455,6 @@ class TestMongoDBIntegration:
         # Cache should still be updated
         assert RuntimeConfig._config_cache["test.key"] == "test_value"
 
-
     @pytest.mark.asyncio
     async def test_set_value_stores_secret_in_secret_value(self):
         """set_value passes secret_value (not value) when is_secret=True."""
@@ -820,6 +819,182 @@ class TestSetConfig:
             await set_config("unknown.key", "value")
 
 
+class TestEnvVarFallback:
+    """Tests for the environment-variable layer in RuntimeConfig.
+
+    Env vars sit between MongoDB and registered defaults so deployment-time
+    secrets work without bespoke wiring while still being overridable by the
+    debug UI (runtime overrides) and the persisted MongoDB layer.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_dotenv_cache(self):
+        """Force ``_dotenv_values`` to re-read so monkeypatching ``os.environ``
+        gives a clean slate between tests."""
+        from vibetuner.runtime_config import _dotenv_values
+
+        _dotenv_values.cache_clear()
+        yield
+        _dotenv_values.cache_clear()
+
+    def test_env_var_name_uppercases_and_replaces_dots(self):
+        """env_var_name maps dot-paths to upper-snake-case env names."""
+        from vibetuner.runtime_config import env_var_name
+
+        assert (
+            env_var_name("services.anthropic_api_key") == "SERVICES_ANTHROPIC_API_KEY"
+        )
+        assert env_var_name("feature.dark_mode") == "FEATURE_DARK_MODE"
+        assert env_var_name("plain_key") == "PLAIN_KEY"
+
+    @pytest.mark.asyncio
+    async def test_get_reads_from_env_when_no_override_or_cache(self, monkeypatch):
+        """Env var beats registered default."""
+        from vibetuner.runtime_config import (
+            RuntimeConfig,
+            get_config,
+            register_config_value,
+        )
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        register_config_value(
+            key="services.anthropic_api_key",
+            default="",
+            value_type="str",
+            category="services",
+            is_secret=True,
+        )
+        monkeypatch.setenv("SERVICES_ANTHROPIC_API_KEY", "sk-from-env")
+
+        result = await get_config("services.anthropic_api_key")
+        assert result == "sk-from-env"
+
+    @pytest.mark.asyncio
+    async def test_mongodb_cache_wins_over_env(self, monkeypatch):
+        """MongoDB value wins over env so an admin's persisted override sticks."""
+        from vibetuner.runtime_config import (
+            RuntimeConfig,
+            get_config,
+            register_config_value,
+        )
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        register_config_value(
+            key="services.anthropic_api_key",
+            default="",
+            value_type="str",
+            is_secret=True,
+        )
+        RuntimeConfig._config_cache["services.anthropic_api_key"] = "sk-from-mongo"
+        monkeypatch.setenv("SERVICES_ANTHROPIC_API_KEY", "sk-from-env")
+
+        result = await get_config("services.anthropic_api_key")
+        assert result == "sk-from-mongo"
+
+    @pytest.mark.asyncio
+    async def test_env_var_coerces_to_registered_value_type(self, monkeypatch):
+        """Env vars are coerced through ``_validate_value`` like any other source."""
+        from vibetuner.runtime_config import (
+            RuntimeConfig,
+            get_config,
+            register_config_value,
+        )
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        register_config_value(
+            key="features.max_items",
+            default=10,
+            value_type="int",
+        )
+        monkeypatch.setenv("FEATURES_MAX_ITEMS", "42")
+
+        result = await get_config("features.max_items")
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_invalid_env_value_falls_through_to_default(
+        self, monkeypatch, log_sink
+    ):
+        """A bogus env value logs a warning and falls back to the default."""
+        from vibetuner.runtime_config import (
+            RuntimeConfig,
+            get_config,
+            register_config_value,
+        )
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        register_config_value(
+            key="features.max_items",
+            default=10,
+            value_type="int",
+        )
+        monkeypatch.setenv("FEATURES_MAX_ITEMS", "not-a-number")
+
+        result = await get_config("features.max_items")
+        assert result == 10
+        assert any("FEATURES_MAX_ITEMS" in line for line in log_sink)
+
+    @pytest.mark.asyncio
+    async def test_get_all_config_exposes_env_name_and_source(self, monkeypatch):
+        """get_all_config exposes the env-var name and reports source='env'."""
+        from vibetuner.runtime_config import RuntimeConfig, register_config_value
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        register_config_value(
+            key="services.anthropic_api_key",
+            default="",
+            value_type="str",
+            category="services",
+            is_secret=True,
+        )
+        monkeypatch.setenv("SERVICES_ANTHROPIC_API_KEY", "sk-from-env")
+
+        entries = await RuntimeConfig.get_all_config()
+        entry = next(e for e in entries if e["key"] == "services.anthropic_api_key")
+
+        assert entry["env_name"] == "SERVICES_ANTHROPIC_API_KEY"
+        assert entry["source"] == "env"
+        assert entry["value"] == "sk-from-env"
+
+    @pytest.mark.asyncio
+    async def test_get_all_config_env_name_always_present(self):
+        """env_name is computed from the key even when no env var is set."""
+        from vibetuner.runtime_config import RuntimeConfig, register_config_value
+
+        RuntimeConfig._config_registry.clear()
+        RuntimeConfig._runtime_overrides.clear()
+        RuntimeConfig._config_cache.clear()
+
+        register_config_value(
+            key="services.anthropic_api_key",
+            default="",
+            value_type="str",
+            category="services",
+            is_secret=True,
+        )
+
+        entries = await RuntimeConfig.get_all_config()
+        entry = next(e for e in entries if e["key"] == "services.anthropic_api_key")
+
+        assert entry["env_name"] == "SERVICES_ANTHROPIC_API_KEY"
+        assert entry["source"] == "default"
+
+
 class TestVibetunerAppRuntimeConfig:
     """Tests for VibetunerApp runtime_config parameter."""
 
@@ -876,7 +1051,9 @@ class TestVibetunerAppRuntimeConfig:
 
         assert "crm.default_region" in RuntimeConfig._config_registry
         assert RuntimeConfig._config_registry["crm.default_region"]["default"] == "US"
-        assert RuntimeConfig._config_registry["crm.default_region"]["value_type"] == "str"
+        assert (
+            RuntimeConfig._config_registry["crm.default_region"]["value_type"] == "str"
+        )
 
         assert "crm.max_contacts" in RuntimeConfig._config_registry
         assert RuntimeConfig._config_registry["crm.max_contacts"]["default"] == 100


### PR DESCRIPTION
## Summary

- Render a "Set this value" card on `/debug/config/<key>` for `is_secret=True` keys with the derived env-var name, the matching `vibetuner config set <key>` CLI command, the `.env` entry to write, and a worker/frontend restart reminder. Closes #1879.
- **Scope expansion (intentional):** to keep the help honest, this PR also adds an env-var layer to `RuntimeConfig` between MongoDB cache and the registered default. Env names derive from `key.upper().replace(".", "_")` (e.g. `services.anthropic_api_key` → `SERVICES_ANTHROPIC_API_KEY`), values are coerced through `_validate_value`, and reads honor `.env`/`.env.local` to match `CoreConfiguration`. Resolution order: runtime override → MongoDB → env → registered default. Without this, the help text would advertise env vars that aren't actually consulted.
- Invalid env values log a warning and fall through to the next layer so a typo doesn't silently shadow the default.
- `ConfigEntry` gains `env_name` (always present) and `source` learns the new `"env"` value; the list and detail views badge accordingly.
- Docs updated in `vibetuner-docs/docs/runtime-config.md`, `llms.txt`, `llms-full.txt`.

## Notes

The issue suggested unprefixed `ANTHROPIC_API_KEY`, but that breaks across categories (collisions). I went with the disambiguating `<CATEGORY>_<KEY>` form, which the issue's text also mentions. The derivation rule lives in `env_var_name(key)` in `runtime_config.py` and is single-source-of-truth for the resolver, template, and tests — easy to change if you prefer the unprefixed form.

## Test plan

- [x] 13 new tests in `tests/unit/test_runtime_config.py` (TestEnvVarFallback) and new `tests/unit/test_debug_config_detail.py` (TestSecretHowToBlock). All 869 unit tests pass.
- [x] `ruff format/check`, `djlint --lint`, `rumdl` clean on touched files
- [ ] Manual: set `SERVICES_ANTHROPIC_API_KEY` in `.env`, visit `/debug/config/services.anthropic_api_key`, confirm source badge says `env`

Closes #1879