### PR TITLE
fix(worker): scope dev reloader to paths.reload_paths

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -44,6 +44,9 @@ def _run_worker(mode: Literal["dev", "prod"], port: int, workers: int) -> None:
     _console().print(f"[green]Starting worker in {mode} mode on port {port}[/green]")
     if is_dev:
         _console().print("[dim]Hot reload enabled[/dim]")
+        _console().print("Registered reload paths:")
+        for path in paths.reload_paths:
+            _console().print(f"  - {path}")
     else:
         _console().print(f"[dim]Workers: {workers}[/dim]")
 
@@ -60,14 +63,26 @@ def _run_worker(mode: Literal["dev", "prod"], port: int, workers: int) -> None:
 
     for _ in range(workers - 1):
         p = Process(
-            target=run_worker, args=(worker_path, False, is_dev, verbose), daemon=True
+            target=run_worker, args=(worker_path, False, False, verbose), daemon=True
         )
         p.start()
         processes.append(p)
 
     # Run main worker in the current process (blocks)
     try:
-        run_worker(worker_path, False, is_dev, verbose)
+        if is_dev:
+            from watchfiles import run_process
+
+            run_process(
+                *paths.reload_paths,
+                target=run_worker,
+                args=(worker_path, False, False, verbose),
+                callback=lambda _: _console().print(
+                    "[dim]changes detected, reloading...[/dim]"
+                ),
+            )
+        else:
+            run_worker(worker_path, False, False, verbose)
     finally:
         for p in processes:
             p.terminate()

--- a/vibetuner-py/tests/unit/test_run.py
+++ b/vibetuner-py/tests/unit/test_run.py
@@ -1,6 +1,7 @@
 # ABOUTME: Tests for the run CLI module
 # ABOUTME: Verifies worker process configuration and lifecycle behavior
 # ruff: noqa: S101
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,7 +9,7 @@ import pytest
 
 @pytest.fixture
 def mock_streaq():
-    """Provide mock streaq functions that return immediately."""
+    """Provide mock streaq + watchfiles functions that return immediately."""
     mock_settings = MagicMock()
     mock_settings.workers_available = True
     mock_settings.debug = False
@@ -17,11 +18,13 @@ def mock_streaq():
         patch("vibetuner.config.settings", mock_settings),
         patch("streaq.cli.run_worker") as mock_run_worker,
         patch("streaq.ui.run_web") as mock_run_web,
+        patch("watchfiles.run_process") as mock_run_process,
     ):
         yield {
             "settings": mock_settings,
             "run_worker": mock_run_worker,
             "run_web": mock_run_web,
+            "run_process": mock_run_process,
         }
 
 
@@ -85,3 +88,47 @@ class TestWorkerProcessDaemonFlag:
         assert len(created_processes) == 3
         for proc in created_processes:
             assert proc.daemon is True
+
+
+class TestWorkerDevReloadPaths:
+    """Dev worker must watch only the project's reload paths, not the entire cwd."""
+
+    def test_dev_worker_uses_explicit_reload_paths(self, mock_streaq):
+        """In dev mode, watchfiles.run_process must be called with paths.reload_paths."""
+        fake_paths = [Path("/proj/src"), Path("/proj/templates/frontend")]
+
+        with (
+            patch("multiprocessing.Process") as mock_process,
+            patch("vibetuner.cli.run.paths") as mock_paths,
+        ):
+            mock_paths.reload_paths = fake_paths
+            mock_process.return_value = MagicMock()
+
+            from vibetuner.cli.run import _run_worker
+
+            _run_worker("dev", 9100, 1)
+
+        mock_streaq["run_process"].assert_called_once()
+        call_args = mock_streaq["run_process"].call_args
+        assert list(call_args.args) == fake_paths
+        # The target must be streaq's run_worker invoked with watch=False so we
+        # don't double-wrap the worker in a second (cwd-wide) watchfiles process.
+        assert call_args.kwargs["target"] is mock_streaq["run_worker"]
+        target_args = call_args.kwargs["args"]
+        assert target_args[2] is False, (
+            "Inner streaq.run_worker must be called with watch=False"
+        )
+
+    def test_prod_worker_does_not_use_watchfiles(self, mock_streaq):
+        """In prod mode, watchfiles.run_process must not be invoked."""
+        with patch("multiprocessing.Process") as mock_process:
+            mock_process.return_value = MagicMock()
+
+            from vibetuner.cli.run import _run_worker
+
+            _run_worker("prod", 9100, 1)
+
+        mock_streaq["run_process"].assert_not_called()
+        mock_streaq["run_worker"].assert_called_once()
+        # streaq's watch flag must stay False in prod.
+        assert mock_streaq["run_worker"].call_args.args[2] is False


### PR DESCRIPTION
## Summary

- Drive `watchfiles.run_process` ourselves with `paths.reload_paths` so the dev worker reloads only on edits under `src/` and template trees, matching what `_run_frontend` already does with Granian.
- Pass `watch=False` into streaq's `run_worker` so it no longer falls back to its all-of-cwd watcher.
- Print the registered reload paths in dev mode (symmetric with the frontend output) and add unit coverage for both the dev and prod paths.

Closes #1886.

## Test plan

- [x] `uv run python -m pytest tests/unit/` (883 passed)
- [x] `just lint-py`
- [x] `just type-check`
- [ ] Manual smoke: in a scaffolded project with a noisy `.claude/worktrees/<branch>/` sibling, run `just worker-dev` and confirm edits inside that sibling no longer trigger `changes detected, reloading...`, while edits under `src/` and `templates/` still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)