### PR TITLE
docs(scaffold): fix non-existent extra_head block in frontend AGENTS.md

### DIFF
--- a/vibetuner-py/tests/unit/test_docs_skeleton_block_references.py
+++ b/vibetuner-py/tests/unit/test_docs_skeleton_block_references.py
@@ -1,0 +1,54 @@
+# ABOUTME: Ensures jinja {% block %} names referenced in the scaffolded
+# ABOUTME: frontend AGENTS.md docs actually exist in skeleton.html.jinja.
+# ruff: noqa: S101
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKELETON = (
+    REPO_ROOT
+    / "vibetuner-py"
+    / "src"
+    / "vibetuner"
+    / "templates"
+    / "frontend"
+    / "base"
+    / "skeleton.html.jinja"
+)
+AGENTS_MD = REPO_ROOT / "vibetuner-template" / "templates" / "frontend" / "AGENTS.md"
+
+_BLOCK_RE = re.compile(r"{%-?\s*block\s+([A-Za-z_][A-Za-z0-9_]*)")
+_JINJA_FENCE_RE = re.compile(r"```jinja\b[^\n]*\n(.*?)```", re.DOTALL)
+_EXTENDS_RE = re.compile(r"{%-?\s*extends\s+['\"]([^'\"]+)['\"]")
+
+
+def _skeleton_block_names() -> set[str]:
+    return set(_BLOCK_RE.findall(SKELETON.read_text()))
+
+
+def _agents_md_skeleton_block_refs() -> set[str]:
+    """Block names used inside jinja fences that extend the skeleton."""
+    text = AGENTS_MD.read_text()
+    refs: set[str] = set()
+    for fence in _JINJA_FENCE_RE.findall(text):
+        extends = _EXTENDS_RE.search(fence)
+        if extends is None or extends.group(1) != "base/skeleton.html.jinja":
+            continue
+        refs.update(_BLOCK_RE.findall(fence))
+    return refs
+
+
+def test_agents_md_only_references_real_skeleton_blocks():
+    """Jinja silently drops `{% block X %}` content when the parent template has
+    no matching block. Doc examples extending the skeleton must use real block
+    names so copy-pasting them doesn't fail silently in the browser."""
+    skeleton = _skeleton_block_names()
+    refs = _agents_md_skeleton_block_refs()
+    assert refs, "expected at least one skeleton-extending jinja example in AGENTS.md"
+    unknown = refs - skeleton
+    assert not unknown, (
+        f"AGENTS.md references blocks {sorted(unknown)} that do not exist in "
+        f"skeleton.html.jinja. Available blocks: {sorted(skeleton)}."
+    )

--- a/vibetuner-template/templates/frontend/AGENTS.md
+++ b/vibetuner-template/templates/frontend/AGENTS.md
@@ -138,11 +138,23 @@ Extend them in your templates:
 ```jinja
 {% extends "base/skeleton.html.jinja" %}
 
-{% block extra_head %}
-  {# Add page-specific CSS/JS #}
-{% endblock extra_head %}
+{% block extra_head_links %}
+  {# Page-specific <link> tags — RSS feeds, alternates, custom meta #}
+{% endblock extra_head_links %}
+
+{% block extra_scripts %}
+  {# Page-specific <script> tags — loaded after bundle.js in <head> #}
+{% endblock extra_scripts %}
 
 {% block body %}
   {# Your page content #}
 {% endblock body %}
 ```
+
+The slots `<head>` exposes are `extra_head_links` (before `bundle.css`),
+`extra_scripts` (after `bundle.js`), and `head` (catch-all at the end of
+`<head>`). Use `before_main` / `after_main` to wrap the body. Jinja
+silently drops `{% block %}` content when the parent has no matching
+block — if a `<script>` or `<style>` you added never reaches the
+browser, double-check the block name. Full list:
+<https://vibetuner.alltuner.com/development-guide/#skeleton-extension-points>.


### PR DESCRIPTION
## Summary

- Scaffolded `templates/frontend/AGENTS.md` (and the symlinked `CLAUDE.md`) documented `{% block extra_head %}` as the slot for page-specific CSS/JS, but `base/skeleton.html.jinja` never declared that block. Jinja silently drops content from child blocks the parent doesn't declare, so anything wrapped in it never reached the browser (real-world bite from issue #1889: a Google Picker `<script>` that silently never loaded).
- Replace the example with real `extra_head_links` / `extra_scripts` blocks, enumerate the available `<head>` slots, and call out the silent-drop pitfall.
- Add a regression test that walks the jinja code fences in `AGENTS.md` and asserts every `{% block %}` name referenced exists in `skeleton.html.jinja`, so this class of doc/skeleton drift fails loudly next time.

Closes #1889.

## Test plan

- [x] `uv run python -m pytest tests/unit/` — 884 passed
- [x] `uv run python -m pytest tests/unit/test_docs_skeleton_block_references.py tests/unit/test_skeleton_extension_points.py -v` — 22 passed
- [x] Verified the regression test correctly flags the pre-fix `extra_head` block name as unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)