### PR TITLE
chore(deps): prek autoupdate pre-commit hooks

### DIFF
--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: no-commit-to-branch
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.14
+    rev: 0.11.15
     hooks:
       # Update the uv lockfile
       - id: uv-lock
@@ -18,7 +18,7 @@ repos:
       # Run the linter (check only, no auto-fix).
       - id: ruff-check
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.93
+    rev: v0.1.95
     hooks:
       - id: rumdl
         name: rumdl check


### PR DESCRIPTION
## Summary

- Ran \`prek autoupdate\` on \`.pre-commit-config.yaml\`
- Bumps \`astral-sh/uv-pre-commit\` 0.11.14 → 0.11.15
- Bumps \`rvben/rumdl-pre-commit\` v0.1.93 → v0.1.95

## Test plan

- [ ] pre-commit hooks run cleanly on a touched file