### PR TITLE
feat(deps): bump htmx.org to 4.0.0-beta4 and rename hx-nonce to hx-csp

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -785,22 +785,30 @@ turn the response into an error page or a 0-byte download. App code
 should still set `media_type=` explicitly when it matters, but the
 guard prevents the worst-case UX when something slips through.
 
-### htmx Nonce Protection (opt-in)
+### htmx CSP Protection (opt-in)
 
-!!! note "Requires `@alltuner/vibetuner` ≥ 10.11.0"
-    The `hx-nonce` extension file ships with `htmx.org@4.0.0-beta3`, which
-    is pulled transitively by `@alltuner/vibetuner@10.11.0` and later. On
-    older versions the bundler will fail with
-    `Could not resolve "./node_modules/htmx.org/dist/ext/hx-nonce.js"`.
+!!! note "Requires `htmx.org@4.0.0-beta4`"
+    The `hx-csp` extension file ships with `htmx.org@4.0.0-beta4`, pulled
+    transitively by the matching `@alltuner/vibetuner` release. On older
+    versions the bundler will fail with
+    `Could not resolve "./node_modules/htmx.org/dist/ext/hx-csp.js"`
+    (releases shipping htmx beta3 carry the extension as `hx-nonce.js`).
     Bump `@alltuner/vibetuner` in `package.json` and re-run `bun install`
     before enabling.
 
-htmx 4.0.0-beta3 ships an `hx-nonce` extension that gates htmx attribute
-processing behind the page CSP nonce. Elements without a matching
-`hx-nonce` attribute are stripped at init time, providing a
-defence-in-depth layer against HTML injection attacks: even if an
-attacker manages to inject HTML, the browser will not honour any
-`hx-get`/`hx-post`/etc. attributes on injected elements.
+htmx 4.0.0-beta4 ships an `hx-csp` extension (renamed from `hx-nonce`
+in beta3) that gates htmx attribute processing behind the page CSP
+nonce. Elements without a matching `hx-nonce` attribute are stripped
+at init time, providing a defence-in-depth layer against HTML
+injection attacks: even if an attacker manages to inject HTML, the
+browser will not honour any `hx-get`/`hx-post`/etc. attributes on
+injected elements. The HTML attribute is still named `hx-nonce`; only
+the extension itself was renamed.
+
+If you previously enabled the extension on a beta3-shipping vibetuner
+release, see
+[Beta3 to Beta4 Changes](htmx-migration.md#beta3-to-beta4-changes) in
+the migration guide for the import-path update.
 
 The framework's templates already stamp `hx-nonce="{{ csp_nonce }}"` on
 their htmx-bearing elements, so the extension is safe to enable from a
@@ -812,7 +820,7 @@ fresh project as soon as you mirror the pattern in your own templates.
 
     ```javascript
     // Add your custom imports below:
-    import "./node_modules/htmx.org/dist/ext/hx-nonce.js";
+    import "./node_modules/htmx.org/dist/ext/hx-csp.js";
     ```
 
 2. Add `hx-nonce="{{ csp_nonce }}"` to every element in your templates
@@ -862,7 +870,7 @@ and every `<style>` tag must carry `nonce="{{ csp_nonce }}"`.
 
 The framework's own templates already follow this pattern (the inline
 styles in `skeleton.html.jinja` and `theme.html.jinja` are nonced; the
-htmx 4.0.0-beta3 indicator stylesheet uses a constructable
+htmx 4.0.0-beta4 indicator stylesheet uses a constructable
 `CSSStyleSheet` which does not need `'unsafe-inline'`). Before flipping
 this flag in your project:
 

--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -2,8 +2,8 @@
 
 This guide covers the breaking changes when upgrading from htmx v2 to v4
 in Vibetuner projects. It also documents what changed between htmx 4
-pre-release versions (alpha → beta1 → beta3), so users on any
-pre-release can migrate.
+pre-release versions (alpha → beta1 → beta3 → beta4), so users on
+any pre-release can migrate.
 
 ## Quick Start
 
@@ -490,7 +490,7 @@ htmx 4 ships with these core extensions. All auto-register when imported.
 | `ptag` | Per-element polling tags to skip unchanged content |
 | `alpine-compat` | Alpine.js compatibility |
 | `htmx-2-compat` | Backward compatibility layer for htmx 2.x code |
-| `nonce` | CSP nonce-based protection for inline scripts and `eval`-style code paths (beta3) |
+| `csp` | CSP nonce-based protection for inline scripts and `eval`-style code paths (beta3, renamed from `nonce` in beta4) |
 | `live` | DOM-reactivity via `hx-live` and richer `hx-on` helpers: `q()`, `toggle()`, `debounce()` (beta3) |
 
 htmx also provides an `htmax` bundle (`htmax.min.js`) that includes htmx
@@ -551,6 +551,8 @@ the changes specific to beta3 (which is the 4.0 release candidate).
   Vibetuner enforces nonce-based CSP by default, so this extension is a
   natural fit. See the
   [vibetuner CSP docs](development-guide.md#security-headers-and-csp-nonce).
+  **Renamed to `hx-csp` in beta4** — see the
+  [Beta3 to Beta4 Changes](#beta3-to-beta4-changes) section below.
 - **`hx-live`**: DOM-reactivity via `hx-live="..."` (a JS expression
   re-evaluated whenever any DOM input/change/mutation event fires) plus
   a richer JavaScript surface inside `hx-on`: `q(selector)` jQuery-like
@@ -612,6 +614,86 @@ were calling them directly, import the `hx-live` extension or migrate
 to native equivalents. Vibetuner loads `hx-live` by default, so
 `htmx.live.take(...)` is available without extra setup.
 
+## Beta3 to Beta4 Changes
+
+Beta4 is a small follow-up to the 4.0 release candidate. The only
+vibetuner-relevant change is the rename of the CSP extension.
+
+### Upgrade Recipe
+
+For most projects this is a three-step bump:
+
+1. Bump `@alltuner/vibetuner` in `package.json` to a release that
+   ships `htmx.org@4.0.0-beta4` (or run
+   `just deps-scaffolding-pr` / `just deps-scaffolding`).
+2. Run `bun install` to refresh `node_modules` and `bun.lock`.
+3. If your `config.js` imports the CSP extension, update the path
+   from `hx-nonce.js` to `hx-csp.js` (see below).
+
+Run `just lint` and `just dev` to confirm the build still passes; no
+template changes are required.
+
+### `hx-nonce` Extension Renamed to `hx-csp`
+
+The extension file that beta3 shipped as
+`./node_modules/htmx.org/dist/ext/hx-nonce.js` is now
+`./node_modules/htmx.org/dist/ext/hx-csp.js` in beta4. The HTML
+attribute the extension reads is **still named `hx-nonce`** — only
+the extension itself was renamed (its scope grew beyond pure nonce
+gating, so the name was generalised to "CSP").
+
+**If you imported the extension in `config.js`:**
+
+```javascript
+// Before (beta3):
+import "./node_modules/htmx.org/dist/ext/hx-nonce.js";
+
+// After (beta4):
+import "./node_modules/htmx.org/dist/ext/hx-csp.js";
+```
+
+**If you registered the extension via `hx-ext`** (uncommon — most
+projects let vibetuner register it via the import above):
+
+```html
+<!-- Before (beta3): -->
+<meta name="htmx-config" content='extensions:"hx-nonce"'>
+
+<!-- After (beta4): -->
+<meta name="htmx-config" content='extensions:"hx-csp"'>
+```
+
+Template `hx-nonce="{{ csp_nonce }}"` attributes need no change.
+
+### Other Beta4 Changes (no action required)
+
+Beta4 also ships several bug fixes and minor additions that do not
+require any template or code changes in vibetuner projects:
+
+- New `hx-on` / `hx-trigger` modifiers (`prevent`, `stop`, `halt`,
+  `capture`, `passive`, `from:self`, `from:outside`) with a unified
+  arrow grammar: `hx-on="event mods -> code"`. Vibetuner templates use
+  plain `hx-on:event="..."` syntax which keeps working — adopt the
+  arrow form opportunistically when a modifier set would otherwise
+  duplicate code.
+- `rootMargin` modifier on the `intersect` trigger.
+- Fixes for `hx-get` / `hx-delete` over non-form inputs (these
+  variants no longer gather unrelated form fields when triggered on
+  bare inputs).
+- `outerSync` now re-processes the correct body on history restore.
+- `hx-ws` with `hx-trigger="load"` waits for the socket to open
+  instead of erroring.
+
+If you had been relying on the **undocumented dot-modifier shorthand**
+(`hx-on:click.prevent="..."`), it has been removed — use the new
+arrow grammar (`hx-on="click prevent -> ..."`) instead. Vibetuner
+templates do not use this shorthand, so a clean codebase needs no
+migration here.
+
+The `hx-trigger="..." queue:..."` modifier (a no-op since 4.0) was
+also hard-removed in beta4; use `hx-sync="this:queue all"` instead.
+Vibetuner templates do not use the `queue:` modifier either.
+
 ## Live Reactivity with `hx-live`
 
 `@alltuner/vibetuner` 10.15.0 imports `hx-live` by default from
@@ -628,8 +710,9 @@ no `'unsafe-inline'`, which blocks inline `onclick="..."` /
 `onchange="..."` attributes at the spec level. htmx attributes
 (`hx-on:`, `hx-live`) evaluate through htmx's nonced TrustedTypes
 pipeline, so they work where raw handler attributes do not. If you
-also enable `hx-nonce`, every `hx-live` expression gets the same
-defence-in-depth as `hx-get` / `hx-post`.
+also enable `hx-csp` (formerly `hx-nonce`, see
+[Beta3 to Beta4 Changes](#beta3-to-beta4-changes)), every `hx-live`
+expression gets the same defence-in-depth as `hx-get` / `hx-post`.
 
 ### Idiomatic patterns
 
@@ -833,3 +916,27 @@ htmx.config.defaultTimeout = 0; // no timeout, like v2
 - [ ] Test error handling (4xx/5xx now swap by default)
 - [ ] Test long-running requests against the 60-second timeout
 - [ ] Update `hx-swap` scroll modifiers to new syntax if used
+
+## Beta3 to Beta4 Checklist
+
+If you are already on htmx 4.0.0-beta3 (the common case for projects
+scaffolded since `@alltuner/vibetuner` 10.11.0), this is the only work
+that beta4 requires:
+
+- [ ] Bump `@alltuner/vibetuner` in `package.json` to a release that
+  ships `htmx.org@4.0.0-beta4`
+- [ ] Run `bun install`
+- [ ] If `config.js` imports the CSP extension, change
+  `import "./node_modules/htmx.org/dist/ext/hx-nonce.js";` to
+  `import "./node_modules/htmx.org/dist/ext/hx-csp.js";`
+- [ ] If any `<meta name="htmx-config" content='extensions:"hx-nonce"'>`
+  tags exist, change `hx-nonce` to `hx-csp` (uncommon — most projects
+  register the extension via the import above)
+- [ ] If you ever used the undocumented dot-modifier shorthand
+  (`hx-on:click.prevent="..."`), migrate to the new arrow grammar
+  (`hx-on="click prevent -> ..."`) — these shortcuts were removed in
+  beta4
+- [ ] If you used the `queue:` modifier on `hx-trigger` (a no-op since
+  4.0), migrate to `hx-sync="this:queue all"` — removed in beta4
+- [ ] No template changes required — `hx-nonce="{{ csp_nonce }}"`
+  attributes keep working

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2029,25 +2029,25 @@ a 0-byte download and Chrome show a generic error page.
 and use the request nonce instead. Inline `style="..."` attributes will
 be blocked by the browser and every `<style>` tag must carry
 `nonce="{{ csp_nonce }}"`. Framework templates already follow this
-pattern; htmx 4.0.0-beta3's indicator stylesheet uses a constructable
+pattern; htmx 4.0.0-beta4's indicator stylesheet uses a constructable
 `CSSStyleSheet` so no inline style is needed there either. Audit user
 templates for inline `style="..."` before flipping. On older releases
 the env var is silently ignored, so bump `vibetuner` in `pyproject.toml`
 and re-run `uv sync` first.
 
-**htmx Nonce Protection (opt-in, requires `@alltuner/vibetuner` ≥ 10.11.0):**
-htmx 4.0.0-beta3 ships an `hx-nonce` extension that strips htmx
-attributes from elements without a matching `hx-nonce`. Stamp
-`hx-nonce="{{ csp_nonce }}"` on every htmx-bearing element and add
-`import "htmx.org/dist/ext/hx-nonce.js";` to `config.js` custom imports.
-Framework templates already include the attribute. Useful defence-in-depth
-even though vibetuner already enforces strict script-src. The extension
-file only ships with `htmx.org@4.0.0-beta3`, pulled transitively by
-`@alltuner/vibetuner` 10.11.0+; on older versions the bundler errors
-with `Could not resolve "./node_modules/htmx.org/dist/ext/hx-nonce.js"`.
+**htmx CSP Protection (opt-in, requires `htmx.org@4.0.0-beta4`):**
+htmx 4.0.0-beta4 ships an `hx-csp` extension (renamed from `hx-nonce`
+in beta3) that strips htmx attributes from elements without a matching
+`hx-nonce`. Stamp `hx-nonce="{{ csp_nonce }}"` on every htmx-bearing
+element and add `import "htmx.org/dist/ext/hx-csp.js";` to `config.js`
+custom imports. Framework templates already include the attribute.
+Useful defence-in-depth even though vibetuner already enforces strict
+script-src. The HTML attribute is still named `hx-nonce`; only the
+extension itself was renamed. On older releases that ship
+`htmx.org@4.0.0-beta3` the file is named `hx-nonce.js`.
 
 **htmx Live Reactivity (default-on, requires `@alltuner/vibetuner` ≥ 10.15.0):**
-htmx 4.0.0-beta3's `hx-live` extension is loaded by default from the
+htmx 4's `hx-live` extension is loaded by default from the
 framework-managed block of `config.js`, alongside `hx-preload`. This is
 vibetuner's recommended path for client-side reactivity — chip lists,
 derived form fields, live filters, paired controls, inline validation.
@@ -2058,7 +2058,7 @@ event-listener boilerplate.
 CSP blocks inline `onclick="..."` / `onchange="..."` attributes at the spec
 level. `hx-on:` and `hx-live` evaluate through htmx's nonced TrustedTypes
 pipeline, so they work where raw handler attributes do not. Pair with the
-opt-in `hx-nonce` extension for defence-in-depth.
+opt-in `hx-csp` extension for defence-in-depth.
 
 **Primitives** (full reference at <https://four.htmx.org/extensions/hx-live/>):
 
@@ -2579,11 +2579,13 @@ manager linker mode (Bun hoisted or isolated, pnpm-style stores, npm v9+ isolate
 htmx 4.0.0-beta3 (the 4.0 release candidate) ships several additions
 relevant to vibetuner projects:
 
-- **`hx-nonce` extension** — gates htmx attribute processing behind the
-  page CSP nonce. Stamp `hx-nonce="{{ csp_nonce }}"` on every htmx-bearing
-  element and import `htmx.org/dist/ext/hx-nonce.js` in `config.js` to
-  enable. Framework templates already follow the pattern. Elements
-  without a matching nonce are stripped (fail-closed)
+- **`hx-csp` extension** (introduced in beta3 as `hx-nonce`, renamed in
+  beta4) — gates htmx attribute processing behind the page CSP nonce.
+  Stamp `hx-nonce="{{ csp_nonce }}"` on every htmx-bearing element and
+  import `htmx.org/dist/ext/hx-csp.js` in `config.js` to enable. Framework
+  templates already follow the pattern. Elements without a matching nonce
+  are stripped (fail-closed). The HTML attribute is still named
+  `hx-nonce`; only the extension itself was renamed
 - **`hx-live` extension** — DOM-reactivity via `hx-live="..."` plus a
   richer `hx-on` JS surface (`q()`, `toggle()`, `debounce()`). **Default-on
   in vibetuner** since `@alltuner/vibetuner` 10.15.0; see the Live

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -134,14 +134,16 @@ Important notes:
   no `Content-Type` (e.g. a bare `Response(status_code=404)`), so bare responses do
   not get turned into 0-byte browser downloads (Safari/Firefox) or generic error
   pages (Chrome)
-- **htmx Nonce Protection (opt-in)**: htmx 4.0.0-beta3 ships an `hx-nonce` extension
-  that gates htmx attribute processing behind the page CSP nonce. Framework templates
-  stamp `hx-nonce="{{ csp_nonce }}"` on htmx-bearing elements; mirror that pattern in
-  user templates and add `import "htmx.org/dist/ext/hx-nonce.js";` to `config.js` to
-  enable. Elements without a matching `hx-nonce` are stripped (fail-closed). Requires
-  `@alltuner/vibetuner` ≥ 10.11.0 (older releases pull `htmx.org@4.0.0-beta2` which
-  does not ship the extension file)
-- **htmx Live Reactivity (default-on)**: htmx 4.0.0-beta3's `hx-live` extension is
+- **htmx CSP Protection (opt-in)**: htmx 4.0.0-beta4 ships an `hx-csp` extension
+  (renamed from `hx-nonce` in beta3) that gates htmx attribute processing behind the
+  page CSP nonce. Framework templates stamp `hx-nonce="{{ csp_nonce }}"` on
+  htmx-bearing elements; mirror that pattern in user templates and add
+  `import "htmx.org/dist/ext/hx-csp.js";` to `config.js` to enable. Elements without
+  a matching `hx-nonce` are stripped (fail-closed). The HTML attribute is still
+  named `hx-nonce`; only the extension itself was renamed. Requires
+  `@alltuner/vibetuner` shipping `htmx.org@4.0.0-beta4` (older releases shipped the
+  extension as `hx-nonce.js`)
+- **htmx Live Reactivity (default-on)**: htmx 4's `hx-live` extension is
   loaded by default from `config.js` since `@alltuner/vibetuner` 10.15.0. Use
   `hx-live="<expr>"` for derived state that recomputes on any DOM mutation,
   `hx-on:event="..."` with the `q()` proxy / sigil-`toggle()` / per-element

--- a/vibetuner-js/bun.lock
+++ b/vibetuner-js/bun.lock
@@ -9,7 +9,7 @@
         "@tailwindcss/cli": "^4.3.0",
         "@tailwindcss/typography": "^0.5.19",
         "daisyui": "^5.5.19",
-        "htmx.org": "4.0.0-beta3",
+        "htmx.org": "4.0.0-beta4",
         "tailwindcss": "^4.3.0",
       },
     },
@@ -101,7 +101,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "htmx.org": ["htmx.org@4.0.0-beta3", "", { "bin": { "upgrade-check": "dist/scripts/upgrade-check.js" } }, "sha512-FCs8/Umq4hy2TTdrzdOn7uQDCn6JaM+0AE4lyYuk4djBzA3Ug2y67LxaifpQElKAcvX7MgUsYv9zkX4UqIRhcw=="],
+    "htmx.org": ["htmx.org@4.0.0-beta4", "", { "bin": { "upgrade-check": "dist/scripts/upgrade-check.js" } }, "sha512-gnz4FUkbWSGc+OK0MUq7KCyWDElaIJoQegwkdfL9Os8xwKugHvAvFJY5AL8n1vhTVDks3mugfOK5BWfZWKDqAw=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 

--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@alltuner/vibetuner-jinja": "10.16.6",
     "daisyui": "^5.5.19",
-    "htmx.org": "4.0.0-beta3",
+    "htmx.org": "4.0.0-beta4",
     "tailwindcss": "^4.3.0",
     "@tailwindcss/cli": "^4.3.0",
     "@tailwindcss/typography": "^0.5.19"

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -103,16 +103,17 @@ directly to elements or use `hx-on` attributes.
 See the [HTMX migration guide](https://vibetuner.alltuner.com/htmx-migration/)
 for full details.
 
-## htmx Nonce Protection (opt-in)
+## htmx CSP Protection (opt-in)
 
-The `hx-nonce` extension (htmx 4.0.0-beta3+) gates htmx attribute
-processing behind the page CSP nonce. Framework templates already
-stamp `hx-nonce="{{ csp_nonce }}"` on htmx-bearing elements; mirror
-that pattern in your own templates if you enable the extension.
-Add `import "./node_modules/htmx.org/dist/ext/hx-nonce.js";` to your
-`config.js` custom imports section. Elements without a matching
-`hx-nonce` will be stripped (fail-closed). See the
-[CSP/htmx docs](https://vibetuner.alltuner.com/development-guide/#htmx-nonce-protection-opt-in).
+The `hx-csp` extension (htmx 4.0.0-beta4+, renamed from `hx-nonce`)
+gates htmx attribute processing behind the page CSP nonce. Framework
+templates already stamp `hx-nonce="{{ csp_nonce }}"` on htmx-bearing
+elements; mirror that pattern in your own templates if you enable the
+extension. Add `import "./node_modules/htmx.org/dist/ext/hx-csp.js";`
+to your `config.js` custom imports section. Elements without a
+matching `hx-nonce` will be stripped (fail-closed). The HTML attribute
+is still named `hx-nonce`; only the extension itself was renamed. See
+the [CSP/htmx docs](https://vibetuner.alltuner.com/development-guide/#htmx-csp-protection-opt-in).
 
 ## htmx Live Reactivity (default-on)
 


### PR DESCRIPTION
## Summary

- Bumps `htmx.org` from `4.0.0-beta3` to `4.0.0-beta4` in `vibetuner-js`.
- Renames the CSP extension throughout docs and template rules from `hx-nonce` → `hx-csp` (the extension script was renamed in htmx beta4; the HTML attribute `hx-nonce="{{ csp_nonce }}"` is unchanged).
- Adds a "Beta3 to Beta4 Changes" section + focused upgrade checklist to `htmx-migration.md` so scaffolded projects can migrate cleanly.

Supersedes dependabot #1911 and renovate #1907 (both pure version bumps with no doc work).

## What changed in beta4

| Area | Beta3 | Beta4 |
|---|---|---|
| Extension script | `hx-nonce.js` | `hx-csp.js` |
| `hx-ext` value | `"hx-nonce"` | `"hx-csp"` |
| HTML attribute | `hx-nonce="..."` | `hx-nonce="..."` (unchanged) |
| `hx-on:event.prevent` shorthand | undocumented but worked | **removed**, use `hx-on="event prevent -> code"` |
| `hx-trigger="... queue:..."` | no-op since 4.0 | **removed**, use `hx-sync="this:queue all"` |

Vibetuner templates and code use none of the removed shortcuts, so no in-tree migration was required — the changelog calls them out for downstream projects.

## Files touched

- `vibetuner-js/package.json`, `vibetuner-js/bun.lock` — dep bump
- `vibetuner-docs/docs/development-guide.md` — rename "htmx Nonce Protection" → "htmx CSP Protection"; update import path; cross-link to migration guide
- `vibetuner-docs/docs/htmx-migration.md` — new "Beta3 to Beta4 Changes" section with upgrade recipe; new tail checklist; rename references throughout
- `vibetuner-docs/docs/llms.txt`, `llms-full.txt` — update Features entries
- `vibetuner-template/.claude/rules/frontend.md` — update rule for scaffolded projects

## Test plan

- [x] `bun.lock` updated with correct `htmx.org@4.0.0-beta4` integrity hash from npm
- [x] `just docs-build` succeeds; new anchors render in built HTML
- [x] `rumdl` clean on every edited file (pre-existing README issues unchanged)
- [x] `pytest tests/unit/` → 884 passed (no regressions from the docs/lock changes)
- [ ] Visual check of the migration guide preview once the PR builds