### PR TITLE
fix(ci): always publish JS and Jinja packages when their versions bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,12 +264,12 @@ jobs:
             JS_NEEDED="true"
             echo "✅ Building JavaScript (major/minor version)"
           elif [ -n "$PREV_TAG" ]; then
-            JS_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -E "^vibetuner-js/" | grep -vcE "package\.json" || true)
+            JS_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -cE "^vibetuner-js/" || true)
             if [ "$JS_CHANGED" -gt 0 ]; then
               JS_NEEDED="true"
               echo "✅ JavaScript has changes"
             else
-              echo "❌ JavaScript unchanged (only version files)"
+              echo "❌ JavaScript unchanged"
             fi
           else
             JS_NEEDED="true"
@@ -287,12 +287,12 @@ jobs:
             # Trigger on changes to either the package itself or the upstream
             # templates it mirrors, so a Python-side template edit causes the
             # mirror to be republished.
-            JINJA_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -E "^vibetuner-jinja/|^vibetuner-py/src/vibetuner/templates/frontend/" | grep -vcE "package\.json" || true)
+            JINJA_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -cE "^vibetuner-jinja/|^vibetuner-py/src/vibetuner/templates/frontend/" || true)
             if [ "$JINJA_CHANGED" -gt 0 ]; then
               JINJA_NEEDED="true"
               echo "✅ Jinja has changes"
             else
-              echo "❌ Jinja unchanged (only version files)"
+              echo "❌ Jinja unchanged"
             fi
           else
             JINJA_NEEDED="true"


### PR DESCRIPTION
## Summary

Release-please bumps every package's `package.json` in lockstep on every release, but the
`plan-release` job was excluding `package.json` from the per-package change detection. So a
patch release where only `vibetuner-py/` changed would skip publishing JS and Jinja — while
the on-disk version (and the exact-pin in `vibetuner-js/package.json`) still advanced. The
result: `@alltuner/vibetuner-jinja` pinned to a version that doesn't exist on npm.

### npm vs main drift (as of this PR)

| Package | npm | main (`package.json`) |
|---------|-----|-----------------------|
| `@alltuner/vibetuner` | 10.16.0 | 10.16.6 |
| `@alltuner/vibetuner-jinja` | 10.16.2 | 10.16.6 |

`bun install` in `vibetuner-js` (and in any scaffolded project that depends on it) fails with:

```
error: No version matching "10.16.6" found for specifier "@alltuner/vibetuner-jinja"
```

This has silently affected releases 10.16.1 → 10.16.6 (six releases in a row).

### Root cause

In the `Plan release` step, the per-package detection for JS and Jinja used
`grep -vcE "package\.json"` to exclude version-only files from the diff count:

```bash
# Before — excludes package.json, so a version-bump-only diff counts as zero
JS_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -E "^vibetuner-js/" | grep -vcE "package\.json" || true)
```

When only `vibetuner-py/` had real changes, `JS_CHANGED=0` → `JS_NEEDED=false` → `build-js`
and `publish-js` skipped. But the version in `vibetuner-js/package.json` (and its exact-pin
on `@alltuner/vibetuner-jinja`) was already bumped by release-please.

## What changes

Two lines in `.github/workflows/release.yml` (JS and Jinja per-package detection blocks):

```bash
# After — any change in the package directory, including package.json, counts
JS_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -cE "^vibetuner-js/" || true)
JINJA_CHANGED=$(git diff --name-only "$PREV_TAG..HEAD" | grep -cE "^vibetuner-jinja/|^vibetuner-py/src/vibetuner/templates/frontend/" || true)
```

The `TOTAL_CHANGED` global gate (lines 194-200) is intentionally left untouched — it is a
legitimate "did anything meaningful change at all?" guard that exits early when literally no
files changed, and it is not part of the bug.

## Why it's safe

- **Only-py patch release**: `JS_CHANGED` is now non-zero (release-please bumped
  `vibetuner-js/package.json`), so JS and Jinja publish. This is the bug scenario — now fixed.
- **Only-docs patch release**: Same as above — package.json was bumped, so JS and Jinja
  publish too, keeping the pin chain intact.
- **Nothing changed at all**: `TOTAL_CHANGED=0` at the global gate causes an early `exit 0`
  before the per-package blocks run. Unaffected.
- **Major/minor version**: `BUILD_ALL=true` forces all packages. Unaffected.
- **First release (`PREV_TAG` empty)**: the `else` branch sets `JS_NEEDED=true`
  unconditionally. Unaffected.
- **JS↔Jinja coupling block**: still intact at lines 307-310 — any release that publishes JS
  also forces Jinja to publish.

## About the npm gap

The missing versions (10.16.1–10.16.5 for `@alltuner/vibetuner`, 10.16.3–10.16.5 for
`@alltuner/vibetuner-jinja`) will not be backfilled. Downstream consumers caret-range on
`@alltuner/vibetuner`, so once the next release publishes correctly the gap is harmless. The
pin chain will be consistent from that release forward.

## Related

- Closes the version-drift bug first surfaced in #1817 (adjacent CI race, distinct root cause)
- Related to the `bun install` failure pattern noted around PR #1926

Filed by Claude Code (Claude Sonnet 4.6)