### PR TITLE
fix: triage ty diagnostics and wire ty into the lint flow

### DIFF
--- a/.justfiles/linting.justfile
+++ b/.justfiles/linting.justfile
@@ -4,3 +4,12 @@ lint-gh:
     @echo "🔍 Linting GitHub Actions workflows..."
     @actionlint .github/workflows/*.yml
     @echo "✅ GitHub Actions workflows linted successfully"
+
+# Type check Python files in vibetuner-py with ty
+[group('Code quality: linting')]
+type-check-py:
+    @cd vibetuner-py && uv run --frozen ty check .
+
+# Run all linting checks (overrides template's recipe to add type-check-py)
+[group('Code quality: linting')]
+lint: lint-md lint-py lint-toml lint-jinja lint-yaml lint-po type-check type-check-py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,8 @@ just lint-jinja              # Lint Jinja with djlint
 just lint-md                 # Lint markdown files
 just lint-toml               # Lint TOML with taplo
 just lint-yaml               # Lint YAML with dprint
-just type-check              # Type check Python with ty
+just type-check              # Type check at the repo root (template + tooling)
+just type-check-py           # Type check the vibetuner-py framework code with ty
 ```
 
 ### Testing (vibetuner-py)

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -107,7 +107,8 @@ just lint-jinja              # Lint Jinja templates with djlint
 just lint-md                 # Lint markdown files
 just lint-toml               # Lint TOML files with taplo
 just lint-yaml               # Lint YAML files with dprint
-just type-check              # Type check Python with ty
+just type-check              # Type check at the repo root (template + tooling)
+just type-check-py           # Type check the vibetuner-py framework code with ty
 ```
 
 ### Localization (i18n)

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -134,7 +134,8 @@ just lint-jinja              # Lint Jinja templates with djlint
 just lint-md                 # Lint markdown files
 just lint-toml               # Lint TOML files with taplo
 just lint-yaml               # Lint YAML files with dprint
-just type-check              # Type check Python with ty
+just type-check              # Type check at the repo root (template + tooling)
+just type-check-py           # Type check the vibetuner-py framework code with ty
 ```
 
 **Localization:**

--- a/vibetuner-py/src/vibetuner/app_config.py
+++ b/vibetuner-py/src/vibetuner/app_config.py
@@ -2,6 +2,7 @@
 # ABOUTME: Users create tune.py with an `app = VibetunerApp(...)` to configure their app.
 from typing import Any, Callable
 
+from beanie import Document, UnionDoc, View
 from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict
 from starlette.middleware import Middleware
@@ -32,7 +33,7 @@ class VibetunerApp(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     # Models (Beanie documents and views)
-    models: list[type] = []
+    models: list[type[Document] | type[UnionDoc] | type[View]] = []
 
     # SQL Models (SQLModel table models)
     sql_models: list[type] = []

--- a/vibetuner-py/src/vibetuner/cli/run.py
+++ b/vibetuner-py/src/vibetuner/cli/run.py
@@ -95,6 +95,7 @@ def _run_frontend(
     """Start the frontend server."""
     from granian import Granian
     from granian.constants import Interfaces
+    from granian.log import LogLevels
 
     is_dev = mode == "dev"
 
@@ -121,7 +122,7 @@ def _run_frontend(
         workers_kill_timeout=5,
         reload=is_dev,
         reload_paths=paths.reload_paths if is_dev else [],
-        log_level="info",
+        log_level=LogLevels.info,
         log_access=True,
     )
 

--- a/vibetuner-py/src/vibetuner/cli/scaffold.py
+++ b/vibetuner-py/src/vibetuner/cli/scaffold.py
@@ -28,7 +28,7 @@ def _get_git_config(key: str, cwd: Path) -> str | None:
         repo = git.Repo(cwd, search_parent_directories=True)
         reader = repo.config_reader()
         section, option = key.split(".", 1)
-        return reader.get_value(section, option)
+        return str(reader.get_value(section, option))
     except (git.InvalidGitRepositoryError, git.GitError, KeyError, ValueError):
         return None
 

--- a/vibetuner-py/src/vibetuner/crud.py
+++ b/vibetuner-py/src/vibetuner/crud.py
@@ -2,7 +2,7 @@
 # ABOUTME: Generates list/create/read/update/delete routes with pagination, filtering, and sorting.
 import re
 from collections.abc import Callable
-from enum import StrEnum
+from enum import Enum, StrEnum
 from typing import Any
 
 from beanie import Document, PydanticObjectId
@@ -149,7 +149,7 @@ def _register_create_route(
     post_create: PostHook | None,
 ) -> None:
     @router.post("", name=f"{collection_name}_create", status_code=201)
-    async def create_item(request: Request, data: schema):  # type: ignore[valid-type]
+    async def create_item(request: Request, data: schema):  # type: ignore[valid-type]  # ty: ignore[invalid-type-form]
         if pre_create:
             try:
                 data = await pre_create(data, request) or data
@@ -209,7 +209,7 @@ def _register_update_route(
     async def update_item(
         request: Request,
         item_id: PydanticObjectId,
-        data: schema,  # type: ignore[valid-type]
+        data: schema,  # type: ignore[valid-type]  # ty: ignore[invalid-type-form]
     ):
         doc = await model.get(item_id)
         if doc is None:
@@ -293,7 +293,7 @@ def create_crud_routes(
     model: type[Document],
     *,
     prefix: str | None = None,
-    tags: list[str] | None = None,
+    tags: list[str | Enum] | None = None,
     operations: set[Operation] | None = None,
     page_size: int = 25,
     max_page_size: int = 100,

--- a/vibetuner-py/src/vibetuner/frontend/application.py
+++ b/vibetuner-py/src/vibetuner/frontend/application.py
@@ -49,7 +49,7 @@ if settings.rate_limit.enabled:
     from vibetuner.ratelimit import limiter
 
     app.state.limiter = limiter
-    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # ty: ignore[invalid-argument-type]
 
 # Static files
 app.mount(f"/static/v{ctx.v_hash}/css", StaticFiles(directory=paths.css), name="css")

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -1,6 +1,7 @@
 import asyncio
 import re
 import secrets
+from typing import Any, MutableMapping
 
 from fastapi.middleware import Middleware
 from fastapi.requests import HTTPConnection
@@ -445,7 +446,7 @@ class StreaqDebugTimeoutMiddleware:
 
         response_started = False
 
-        async def send_tracking(message: dict) -> None:
+        async def send_tracking(message: MutableMapping[str, Any]) -> None:
             nonlocal response_started
             if message["type"] == "http.response.start":
                 response_started = True

--- a/vibetuner-py/src/vibetuner/frontend/routes/debug.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/debug.py
@@ -10,6 +10,7 @@ from fastapi.responses import (
     HTMLResponse,
     RedirectResponse,
 )
+from starlette.datastructures import FormData
 
 from vibetuner.config import settings
 from vibetuner.context import ctx
@@ -20,6 +21,12 @@ from vibetuner.paths import package_templates
 
 from ..deps import MAGIC_COOKIE_NAME
 from ..templates import render_template
+
+
+def _form_str(form: FormData, key: str, default: str = "") -> str:
+    """Return a string field from form data; treats uploaded files as missing."""
+    value = form.get(key)
+    return value if isinstance(value, str) else default
 
 
 def check_debug_access(request: Request):
@@ -764,11 +771,11 @@ async def debug_oauth_app_store(request: Request):
     from vibetuner.models.oauth_app import OAuthProviderAppModel
 
     form = await request.form()
-    scopes_raw = form.get("scopes", "").strip()
+    scopes_raw = _form_str(form, "scopes").strip()
     scopes = (
         [s.strip() for s in scopes_raw.split(",") if s.strip()] if scopes_raw else []
     )
-    capabilities_raw = form.get("capabilities", "").strip()
+    capabilities_raw = _form_str(form, "capabilities").strip()
     capabilities = (
         [c.strip() for c in capabilities_raw.split(",") if c.strip()]
         if capabilities_raw
@@ -776,14 +783,14 @@ async def debug_oauth_app_store(request: Request):
     )
 
     app = OAuthProviderAppModel(
-        provider=form.get("provider", ""),
-        name=form.get("name", ""),
-        client_id=form.get("client_id", ""),
-        client_secret=form.get("client_secret", ""),
-        external_app_id=form.get("external_app_id", "").strip() or None,
+        provider=_form_str(form, "provider"),
+        name=_form_str(form, "name"),
+        client_id=_form_str(form, "client_id"),
+        client_secret=_form_str(form, "client_secret"),
+        external_app_id=_form_str(form, "external_app_id").strip() or None,
         scopes=scopes,
         capabilities=capabilities,
-        is_active=form.get("is_active") == "on",
+        is_active=_form_str(form, "is_active") == "on",
     )
     await app.insert()
 
@@ -803,28 +810,28 @@ async def debug_oauth_app_update(request: Request, app_id: str):
         raise HTTPException(status_code=404, detail="OAuth app not found")
 
     form = await request.form()
-    scopes_raw = form.get("scopes", "").strip()
+    scopes_raw = _form_str(form, "scopes").strip()
     scopes = (
         [s.strip() for s in scopes_raw.split(",") if s.strip()] if scopes_raw else []
     )
-    capabilities_raw = form.get("capabilities", "").strip()
+    capabilities_raw = _form_str(form, "capabilities").strip()
     capabilities = (
         [c.strip() for c in capabilities_raw.split(",") if c.strip()]
         if capabilities_raw
         else []
     )
 
-    app.provider = form.get("provider", app.provider)
-    app.name = form.get("name", app.name)
-    app.client_id = form.get("client_id", app.client_id)
+    app.provider = _form_str(form, "provider", app.provider)
+    app.name = _form_str(form, "name", app.name)
+    app.client_id = _form_str(form, "client_id", app.client_id)
     # Only update secret if a new value was provided
-    new_secret = form.get("client_secret", "").strip()
+    new_secret = _form_str(form, "client_secret").strip()
     if new_secret:
         app.client_secret = new_secret
-    app.external_app_id = form.get("external_app_id", "").strip() or None
+    app.external_app_id = _form_str(form, "external_app_id").strip() or None
     app.scopes = scopes
     app.capabilities = capabilities
-    app.is_active = form.get("is_active") == "on"
+    app.is_active = _form_str(form, "is_active") == "on"
 
     await app.save()
 

--- a/vibetuner-py/src/vibetuner/frontend/routing.py
+++ b/vibetuner-py/src/vibetuner/frontend/routing.py
@@ -96,7 +96,7 @@ def localized(func: Callable[..., Any]) -> Callable[..., Any]:
         async def privacy(request: Request):
             return render_template("privacy.html.jinja", request)
     """
-    func._localized = True
+    func._localized = True  # ty: ignore[unresolved-attribute]
 
     @wraps(func)
     async def wrapper(*args, **kwargs):
@@ -115,5 +115,5 @@ def localized(func: Callable[..., Any]) -> Callable[..., Any]:
         return await func(*args, **kwargs)
 
     # Preserve the _localized attribute on wrapper
-    wrapper._localized = True
+    wrapper._localized = True  # ty: ignore[unresolved-attribute]
     return wrapper

--- a/vibetuner-py/src/vibetuner/models/config_entry.py
+++ b/vibetuner-py/src/vibetuner/models/config_entry.py
@@ -23,7 +23,7 @@ class ConfigEntryModel(Document, TimeStampMixin, EncryptedFieldsMixin):
     for secret entries so plaintext never reaches the database.
     """
 
-    key: Indexed(str, unique=True) = Field(  # type: ignore[valid-type]
+    key: Indexed(str, unique=True) = Field(  # type: ignore[valid-type]  # ty: ignore[invalid-type-form]
         description="Unique configuration key using dot-notation (e.g., 'features.dark_mode')",
     )
     value: Any = Field(

--- a/vibetuner-py/src/vibetuner/mongo.py
+++ b/vibetuner-py/src/vibetuner/mongo.py
@@ -2,7 +2,7 @@
 # ABOUTME: Manages connection lifecycle and model registration.
 from typing import Optional
 
-from beanie import init_beanie
+from beanie import Document, UnionDoc, View, init_beanie
 from deprecated import deprecated
 from pymongo import AsyncMongoClient
 from pymongo.errors import ConnectionFailure
@@ -11,6 +11,20 @@ from vibetuner.config import settings
 from vibetuner.loader import load_app_config
 from vibetuner.logging import logger
 from vibetuner.models import __all__ as core_models
+
+
+BeanieDocumentType = type[Document] | type[UnionDoc] | type[View]
+
+
+def _mongo_endpoint(url: object) -> str:
+    """Return a ``host:port`` string for log messages, or ``"unknown"``."""
+    if url is None:
+        return "unknown"
+    host = getattr(url, "host", None)
+    port = getattr(url, "port", None)
+    if host is None:
+        return "unknown"
+    return f"{host}:{port}" if port is not None else str(host)
 
 
 # Global singleton, created lazily
@@ -35,7 +49,7 @@ def _ensure_client() -> None:
         logger.debug("MongoDB client created.")
 
 
-def get_all_models() -> list[type]:
+def get_all_models() -> list[BeanieDocumentType]:
     """Get all models: core vibetuner models + user models from tune.py."""
     app_config = load_app_config()
     return list(core_models) + list(app_config.models)
@@ -76,10 +90,9 @@ async def init_mongodb() -> None:
             document_models=all_models,
         )
     except ConnectionFailure as exc:
-        url = settings.mongodb_url
         logger.error(
             "Failed to connect to MongoDB at {}: {}",
-            f"{url.host}:{url.port}" if url else "unknown",
+            _mongo_endpoint(settings.mongodb_url),
             exc,
         )
         raise

--- a/vibetuner-py/src/vibetuner/paths.py
+++ b/vibetuner-py/src/vibetuner/paths.py
@@ -149,31 +149,31 @@ class PathSettings(BaseSettings):
 
     @computed_field
     @property
-    def css(self) -> Path | None:
+    def css(self) -> Path:
         """Project CSS directory."""
         return self._get_statics_type_path("css")
 
     @computed_field
     @property
-    def js(self) -> Path | None:
+    def js(self) -> Path:
         """Project JavaScript directory."""
         return self._get_statics_type_path("js")
 
     @computed_field
     @property
-    def favicons(self) -> Path | None:
+    def favicons(self) -> Path:
         """Project favicons directory."""
         return self._get_statics_type_path("favicons")
 
     @computed_field
     @property
-    def img(self) -> Path | None:
+    def img(self) -> Path:
         """Project images directory."""
         return self._get_statics_type_path("img")
 
     @computed_field
     @property
-    def fonts(self) -> Path | None:
+    def fonts(self) -> Path:
         """Project fonts directory."""
         return self._get_statics_type_path("fonts")
 

--- a/vibetuner-py/src/vibetuner/provider.py
+++ b/vibetuner-py/src/vibetuner/provider.py
@@ -21,7 +21,7 @@ class ScopeCapabilityDetector(CapabilityDetector):
     async def detect(self, token: dict[str, Any]) -> list[str]:
         scope = token.get("scope", "")
         if isinstance(scope, list):
-            return list(scope)
+            return [str(s) for s in scope]
         if isinstance(scope, str):
             return [s for s in scope.split() if s]
         return []

--- a/vibetuner-py/src/vibetuner/rendering.py
+++ b/vibetuner-py/src/vibetuner/rendering.py
@@ -38,7 +38,7 @@ __all__ = [
 # App-level template context: static globals and dynamic providers
 _context_lock = threading.RLock()
 _template_globals: dict[str, Any] = {}
-_context_providers: list[Callable[[], dict[str, Any]]] = []
+_context_providers: list[Callable[..., dict[str, Any]]] = []
 _provider_accepts_request: dict[Callable, bool] = {}
 
 
@@ -130,6 +130,8 @@ def render(template: str) -> Callable:
     """
 
     def decorator(func: Callable) -> Callable:
+        func_name = getattr(func, "__name__", repr(func))
+
         @functools.wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> Response:
             # Extract request from kwargs or positional args
@@ -142,7 +144,7 @@ def render(template: str) -> Callable:
 
             if request is None:
                 raise TypeError(
-                    f"@render('{template}'): route '{func.__name__}' must accept "
+                    f"@render('{template}'): route '{func_name}' must accept "
                     "a 'request' parameter"
                 )
 
@@ -157,7 +159,7 @@ def render(template: str) -> Callable:
 
             if not isinstance(result, dict):
                 raise TypeError(
-                    f"@render('{template}'): route '{func.__name__}' must return "
+                    f"@render('{template}'): route '{func_name}' must return "
                     f"a dict or Response, got {type(result).__name__}"
                 )
 
@@ -178,6 +180,7 @@ def _collect_provider_context(request: Request | None = None) -> dict[str, Any]:
         providers = list(_context_providers)
     result: dict[str, Any] = {}
     for provider in providers:
+        provider_name = getattr(provider, "__name__", repr(provider))
         try:
             accepts_request = _provider_accepts_request.get(provider, False)
             if accepts_request and request is not None:
@@ -188,11 +191,11 @@ def _collect_provider_context(request: Request | None = None) -> dict[str, Any]:
                 result.update(ctx)
             else:
                 logger.error(
-                    f"Context provider '{provider.__name__}' returned "
+                    f"Context provider '{provider_name}' returned "
                     f"{type(ctx).__name__} instead of dict, skipping"
                 )
         except Exception as e:
-            logger.error(f"Context provider '{provider.__name__}' failed: {e}")
+            logger.error(f"Context provider '{provider_name}' failed: {e}")
     return result
 
 
@@ -792,19 +795,19 @@ def _project_context() -> dict[str, Any]:
 
 register_context_provider(_project_context)
 
-# Global Vars
-jinja_env.globals.update({"DEBUG": data_ctx.DEBUG})
-
-# Language URL helpers for SEO
-jinja_env.globals.update({"lang_url_for": lang_url_for})
-jinja_env.globals.update({"url_for_language": url_for_language})
-jinja_env.globals.update({"hreflang_tags": hreflang_tags})
-
 # Language picker (lazy import to avoid circular dependency on vibetuner.i18n)
 from vibetuner.i18n import language_picker as _language_picker  # noqa: E402
 
 
-jinja_env.globals.update({"language_picker": _language_picker})
+_extra_globals: dict[str, Any] = {
+    "DEBUG": data_ctx.DEBUG,
+    # Language URL helpers for SEO
+    "lang_url_for": lang_url_for,
+    "url_for_language": url_for_language,
+    "hreflang_tags": hreflang_tags,
+    "language_picker": _language_picker,
+}
+jinja_env.globals.update(_extra_globals)
 
 # Date Filters
 jinja_env.filters["timeago"] = timeago
@@ -834,7 +837,8 @@ def _ensure_custom_filters() -> None:
     # Hotreload is imported lazily to avoid pulling in vibetuner.frontend
     from vibetuner.frontend.hotreload import hotreload
 
-    jinja_env.globals.update({"hotreload": hotreload})
+    _hotreload_global: dict[str, Any] = {"hotreload": hotreload}
+    jinja_env.globals.update(_hotreload_global)
 
     app_config = load_app_config()
     builtin_filters = set(jinja_env.filters.keys())

--- a/vibetuner-py/src/vibetuner/runtime_config.py
+++ b/vibetuner-py/src/vibetuner/runtime_config.py
@@ -2,6 +2,7 @@
 # ABOUTME: Provides get/set config with priority: runtime overrides > MongoDB > env vars > registered defaults.
 
 import asyncio
+import inspect
 import json
 import os
 from collections.abc import Callable, Coroutine
@@ -457,10 +458,12 @@ def config_value(
     """
 
     def decorator(func: Callable[[], Any]) -> Callable[[], Coroutine[Any, Any, Any]]:
-        if func.__code__.co_argcount > 0:
+        param_count = len(inspect.signature(func).parameters)
+        if param_count > 0:
+            name = getattr(func, "__name__", repr(func))
             raise ValueError(
-                f"@config_value() decorated function '{func.__name__}' must take no parameters, "
-                f"but it has {func.__code__.co_argcount}"
+                f"@config_value() decorated function '{name}' must take no parameters, "
+                f"but it has {param_count}"
             )
         default = func()
         register_config_value(
@@ -476,7 +479,7 @@ def config_value(
         async def wrapper() -> Any:
             return await RuntimeConfig.get(key, default)
 
-        wrapper.key = key  # type: ignore[attr-defined]
+        wrapper.key = key  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return wrapper
 
     return decorator
@@ -545,4 +548,6 @@ class ConfigField:
     def __get__(
         self, obj: Any, objtype: type | None = None
     ) -> Coroutine[Any, Any, Any]:
-        return RuntimeConfig.get(self.key, self.default)  # type: ignore[arg-type]
+        if self.key is None:
+            raise RuntimeError("ConfigField must be bound to a ConfigGroup")
+        return RuntimeConfig.get(self.key, self.default)

--- a/vibetuner-py/src/vibetuner/services/email/resend.py
+++ b/vibetuner-py/src/vibetuner/services/email/resend.py
@@ -1,11 +1,15 @@
 # ABOUTME: Resend email provider implementation.
 # ABOUTME: Sends transactional emails via the Resend API.
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from asyncer import asyncify
 
 from vibetuner.services.email.base import EmailAddress, format_email_str
+
+
+if TYPE_CHECKING:
+    from resend.emails._emails import Emails as _ResendEmails
 
 
 class ResendEmailProvider:
@@ -35,5 +39,6 @@ class ResendEmailProvider:
         }
         if tags:
             params["tags"] = [{"name": k, "value": v} for k, v in tags.items()]
-        result = await asyncify(self._resend.Emails.send)(params)
-        return result
+        send_params = cast("_ResendEmails.SendParams", params)
+        result = await asyncify(self._resend.Emails.send)(send_params)
+        return dict(result)

--- a/vibetuner-py/src/vibetuner/tasks/robust.py
+++ b/vibetuner-py/src/vibetuner/tasks/robust.py
@@ -182,7 +182,7 @@ def robust_task(
     _ensure_middleware(worker)
 
     def decorator(fn: Callable) -> Any:
-        task_name = task_name_arg or fn.__name__
+        task_name = task_name_arg or getattr(fn, "__name__", repr(fn))
         _configs[task_name] = _RobustConfig(
             max_retries=max_retries,
             backoff_base=backoff_base,
@@ -245,7 +245,7 @@ def robust_cron(
     _ensure_middleware(worker)
 
     def decorator(fn: Callable) -> Any:
-        task_name = task_name_arg or fn.__name__
+        task_name = task_name_arg or getattr(fn, "__name__", repr(fn))
         _configs[task_name] = _RobustConfig(
             max_retries=max_retries,
             backoff_base=backoff_base,

--- a/vibetuner-py/src/vibetuner/testing.py
+++ b/vibetuner-py/src/vibetuner/testing.py
@@ -2,7 +2,7 @@
 # ABOUTME: Provides test client, mock auth, mock DB, mock tasks, and config overrides.
 import os
 import uuid
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Iterator
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -95,7 +95,7 @@ async def _vibetuner_db_session() -> AsyncGenerator[str, None]:
     # Make every consumer of ``settings.mongo_dbname`` (framework code,
     # user code) target the session test database for the whole run.
     original = type(settings).mongo_dbname
-    type(settings).mongo_dbname = property(lambda self: test_db_name)  # type: ignore[assignment]
+    type(settings).mongo_dbname = property(lambda self: test_db_name)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     settings.__dict__.pop("mongo_dbname", None)
 
     session_client: AsyncMongoClient = AsyncMongoClient(
@@ -212,7 +212,7 @@ class MockAuth:
 
 
 @pytest.fixture
-def mock_auth() -> MockAuth:
+def mock_auth() -> Iterator[MockAuth]:
     """Fixture for mocking authentication in tests.
 
     Patches the Starlette ``AuthBackend`` used by vibetuner so that

--- a/vibetuner-py/ty.toml
+++ b/vibetuner-py/ty.toml
@@ -1,0 +1,27 @@
+# ABOUTME: Type-check config for the vibetuner Python framework package
+# ABOUTME: Strict on src/; relaxes pydantic-narrowing noise rules under tests/
+
+[src]
+include = ["src", "tests"]
+exclude = ["**/__pycache__", "**/.venv", ".venv"]
+respect-ignore-files = true
+
+[terminal]
+output-format = "concise"
+
+# Test code exercises pydantic constructors with parametrized kwargs
+# (~125 errors from CoreConfiguration(**{field: 8080}) in test_utils.py
+# alone, where ty can't narrow which model field the parametrized key
+# targets) and monkey-patches framework internals in ways ty's narrower
+# can't follow. These rules fire on real bugs in src/, so we only relax
+# them under tests/.
+[[overrides]]
+include = ["tests/**/*.py"]
+
+[overrides.rules]
+invalid-argument-type = "ignore"
+unknown-argument = "ignore"
+invalid-assignment = "ignore"
+unresolved-attribute = "ignore"
+not-subscriptable = "ignore"
+invalid-return-type = "ignore"


### PR DESCRIPTION
## Summary

- Brings `uv run ty check .` in `vibetuner-py/` from **309 diagnostics to 0**, fixing the real soundness gaps the issue called out and adding targeted `# ty: ignore[...]` only where framework interop genuinely defeats ty.
- Adds a `vibetuner-py/ty.toml` with a `[[overrides]]` section that relaxes the pydantic-narrowing rules only under `tests/**` (the `CoreConfiguration(**{field: 8080})` parametrized-kwargs pattern accounts for ~125 errors in `test_utils.py` alone — pure ty limitation, no bug). `src/` stays strict.
- Wires ty into the lint checkpoint: new `type-check-py` recipe at the repo-root `.justfiles/linting.justfile` and a `just lint` override that depends on it. The template's existing `type-check` runs from the repo-root cwd where `ty.toml` excludes `vibetuner-py/`, so it was a silent no-op for the framework code.

Closes #1927.

### Real bugs fixed in `src/`

- `cli/scaffold.py:31` — coerce `git config_reader().get_value(...)` to `str` (it can also return `int | float | bool`).
- `paths.py` — `_get_statics_type_path()` always returns a `Path`, so `favicons` / `css` / `js` / `img` / `fonts` shouldn't be typed `Path | None`. Fixes the `paths.favicons / "favicon.ico"` chain in `frontend/routes/meta.py`.
- `provider.py:21` — coerce items to `str` in `ScopeCapabilityDetector.detect` so `list[str]` is honored.
- `frontend/routes/debug.py` — add a `_form_str` helper and route all `form.get(...)` calls through it. Starlette's `FormData.get` returns `UploadFile | str`, so the old `.strip()` and direct-assignment paths would have crashed on a multipart upload.
- `mongo.py` — tighten `get_all_models` to `list[type[Document] | type[UnionDoc] | type[View]]`, tighten `VibetunerApp.models` likewise, and replace direct `MongoDsn.host` / `.port` access with a `_mongo_endpoint()` helper.
- `runtime_config.py` — switch `func.__code__.co_argcount` to `inspect.signature(func)` and raise `RuntimeError` instead of asserting on an unbound `ConfigField.key`.
- `rendering.py` / `tasks/robust.py` — use `getattr(fn, "__name__", repr(fn))` for `Callable` name access (ty doesn't promise `__name__` on `Callable`).
- `testing.py` — type `mock_auth` as `Iterator[MockAuth]` since it yields.

### Framework-interop quirks (targeted ignores)

- slowapi `add_exception_handler` argument typing
- ASGI `send_tracking` widened to `MutableMapping[str, Any]`
- Beanie `Indexed(str, unique=True)` field annotation
- Pydantic `schema: type[BaseModel]` used as a FastAPI route parameter type
- `_localized` and `key` attribute attachments on wrapped callables
- Resend `SendParams` TypedDict via `cast("_ResendEmails.SendParams", ...)` and `dict(result)` for `SendResponse`

### Wiring

- `.justfiles/linting.justfile` — adds `type-check-py` recipe and overrides `lint` to depend on it.
- `AGENTS.md`, `vibetuner-docs/docs/development-guide.md`, `vibetuner-docs/docs/llms-full.txt` — document the new recipe alongside the existing `type-check`.

## Test plan

- [x] `uv run --frozen ty check .` in `vibetuner-py/` reports `All checks passed!` (was 309 diagnostics)
- [x] `uv run --frozen ty check src/` in `vibetuner-py/` reports `All checks passed!`
- [x] `uv run --frozen ty check tests/` in `vibetuner-py/` reports `All checks passed!`
- [x] `uv run --frozen ruff check .` in `vibetuner-py/` reports `All checks passed!`
- [x] `uv run --frozen python -m pytest tests/unit/` — **884 passed**
- [x] `just type-check-py` from the repo root reports `All checks passed!`
- [x] Reviewed each `# ty: ignore[...]` to confirm it sits at a framework boundary, not a real bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)