### PR TITLE
fix: gate prek auto-update with 3-day cooldown and roll back rumdl-pre-commit

### DIFF
--- a/.justfiles/deps.justfile
+++ b/.justfiles/deps.justfile
@@ -47,10 +47,18 @@ update-and-commit: update-all update-precommit
         vibetuner-template/package.json \
         || echo "No changes to commit"
 
-# Update pre-commit hooks and commit changes
+# Update pre-commit hooks and commit changes.
+#
+# `--cooldown-days 3` makes prek skip any hook tag younger than 3 days.
+# Some hooks (e.g. rvben/rumdl-pre-commit) strict-pin their runtime
+# tool to the matching version and tag both within seconds, so bumping
+# the hook immediately leaves the strict-pinned PyPI package unresolv-
+# able for anyone whose resolver doesn't see it yet (uv `exclude-newer`,
+# mirror lag, offline caches). 3 days outlasts the typical
+# `exclude-newer = "2 days"` window.
 [group('Dependencies')]
 update-precommit:
-    @uv run --frozen prek auto-update
+    @uv run --frozen prek auto-update --cooldown-days 3
     @git add vibetuner-template/.pre-commit-config.yaml
     @git commit -m "chore: update pre-commit hooks" \
         vibetuner-template/.pre-commit-config.yaml \

--- a/vibetuner-template/.pre-commit-config.yaml
+++ b/vibetuner-template/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       # Run the linter (check only, no auto-fix).
       - id: ruff-check
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.2.2
+    rev: v0.2.0
     hooks:
       - id: rumdl
         name: rumdl check


### PR DESCRIPTION
## Summary

Fixes #1930 — scaffolded projects pinning `rvben/rumdl-pre-commit v0.2.2` fail
to install the hook because that release strict-pins `rumdl==0.2.2`, and
`rumdl 0.2.2` was published less than 2 days before the v10.17.0 bump shipped
(so any user with `exclude-newer = "2 days"` in their uv config gets a hard
resolve failure).

**Root cause** is upstream: `rvben/rumdl-pre-commit` declares
`dependencies = ["rumdl==<same-version>"]` and tags both releases within
seconds of each other (rumdl v0.2.2 at 19:29:28Z, rumdl-pre-commit v0.2.2
at 19:29:44Z — 16 seconds later). vibetuner's `just update-precommit`
recipe runs `prek auto-update` blindly and grabbed the bleeding-edge tag the
same day, baking the timing trap into v10.17.0.

Two changes:

- **Prevent recurrence**: `update-precommit` now passes
  `--cooldown-days 3` to `prek auto-update`. Any hook tag younger than
  3 days is skipped, which outlasts a typical `exclude-newer = "2 days"`
  window and gives PyPI mirrors time to catch up before a hook with a
  strict transitive pin propagates into the template.
- **Unblock today**: roll the template pin back from `v0.2.2` to `v0.2.0`
  (published 2026-05-22, ~5 days old at time of writing) so projects
  scaffolded from main resolve cleanly right now.

## Test plan

- [x] `uv run --frozen prek auto-update --cooldown-days 3 --dry-run` is
      silent (no eligible newer rev) after rollback to v0.2.0
- [x] Before the rollback, the same command reported:
      `keeping current rev v0.2.2; 3-day cooldown would select older rev v0.2.0`
      confirming the cooldown gate would have blocked the original bump
- [ ] Manual verify: scaffold a project from this branch, run
      `prek run --all-files` with the default `exclude-newer = "2 days"`
      and confirm the rumdl hook installs cleanly

## Follow-ups (not in this PR)

- File upstream issue at `rvben/rumdl-pre-commit` to loosen the
  `rumdl==<same-version>` pin to something like `rumdl>=X,<Y` so the
  hook isn't unusable in any environment with even mild dep recency
  caution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)