### PR TITLE
feat(scaffold): enforce 2-day cooldown on Renovate updates

### DIFF
--- a/vibetuner-template/renovate.json
+++ b/vibetuner-template/renovate.json
@@ -3,6 +3,8 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "2 days",
+  "internalChecksFilter": "strict",
   "bun": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary

- Add `minimumReleaseAge: "2 days"` and `internalChecksFilter: "strict"` to `vibetuner-template/renovate.json`, mirroring the root config.
- Renovate doesn't read uv's or bun's cooldown settings; without this, scaffolded projects open PRs for fresh releases regardless of the package manager's own cooldown.
- `internalChecksFilter: "strict"` ensures Renovate won't open the PR until the cooldown elapses (vs. opening it in a pending state).

## Test plan

- [ ] Visual review of `vibetuner-template/renovate.json` diff
- [ ] Confirm the rest of the config (lockFileMaintenance, packageRules) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)