### PR TITLE
fix: add Redis socket resilience to the streaq worker connection

### DIFF
--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -581,6 +581,25 @@ vibetuner run prod worker --workers 4
 | Concurrency | `WORKER_CONCURRENCY` | `16` | Max concurrent tasks per worker |
 | Queue name | — | Project slug | Derived from `REDIS_KEY_PREFIX` |
 | Monitoring port | `--port` flag | `11111` | Port for the worker web UI |
+| Socket timeout | `REDIS_SOCKET_TIMEOUT` | `30` | Seconds before a hung Redis read raises (0 disables) |
+| Connect timeout | `REDIS_SOCKET_CONNECT_TIMEOUT` | `10` | Seconds before a Redis connect attempt gives up (0 disables) |
+| Keepalive | `REDIS_SOCKET_KEEPALIVE` | `true` | Enable TCP keepalive on the Redis connection |
+| Health check | `REDIS_HEALTH_CHECK_INTERVAL` | `30` | Seconds between PINGs on idle connections (0 disables) |
+
+### Connection resilience
+
+The worker holds a long-lived Redis connection. Without a socket timeout, a
+silently-dropped TCP connection (a VPN or network blip) leaves a blocking read
+that never returns, wedging the worker's event loop indefinitely: the container
+stays up but stops processing tasks and crons, with no automatic recovery.
+
+The `REDIS_SOCKET_TIMEOUT`, `REDIS_SOCKET_CONNECT_TIMEOUT`,
+`REDIS_SOCKET_KEEPALIVE`, and `REDIS_HEALTH_CHECK_INTERVAL` settings guard
+against this: a dead connection raises an error instead of hanging, so the
+worker reconnects or exits and is restarted by its `restart` policy. The
+defaults are safe for the worker, whose blocking reads are bounded to well
+under a second. Raise `REDIS_SOCKET_TIMEOUT` if your network has high latency,
+or set it to `0` to disable it entirely.
 
 ## Testing Tasks
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2326,6 +2326,14 @@ vibetuner run prod worker --workers 4
 Configuration: `REDIS_URL` (required), `WORKER_CONCURRENCY` (default 16),
 `--port` flag (default 11111 for monitoring UI).
 
+Connection resilience: the worker holds a long-lived Redis connection. Without
+a socket timeout, a silently-dropped TCP connection (a VPN/network blip) leaves
+a blocking read that never returns, wedging the worker's event loop
+indefinitely. `REDIS_SOCKET_TIMEOUT` (default 30s, 0 disables),
+`REDIS_SOCKET_CONNECT_TIMEOUT` (default 10s), `REDIS_SOCKET_KEEPALIVE` (default
+true), and `REDIS_HEALTH_CHECK_INTERVAL` (default 30s) make a dead connection
+raise instead of hang, so the worker reconnects or exits and is restarted.
+
 #### Testing Tasks
 
 Use the `mock_tasks` fixture:

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 from datetime import datetime
 from functools import cached_property
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 import yaml
 from pydantic import (
@@ -330,6 +330,16 @@ class CoreConfiguration(BaseSettings):
 
     worker_concurrency: int = 16
 
+    # Redis connection resilience for long-lived clients (e.g. the streaq worker).
+    # Without a socket timeout, a silently-dropped TCP connection leaves a blocking
+    # read that never returns, wedging the worker's event loop indefinitely. A
+    # non-zero socket_timeout turns that hang into a raised error so the worker
+    # reconnects or exits and is restarted. Set the timeouts to 0 to disable.
+    redis_socket_timeout: float = 30.0
+    redis_socket_connect_timeout: float = 10.0
+    redis_socket_keepalive: bool = True
+    redis_health_check_interval: float = 30.0
+
     # Port configuration (read from DEV_PORT / WORKER_PORT env or .env.local)
     dev_port: UnprivilegedPort | None = None
     worker_port: UnprivilegedPort | None = None
@@ -411,6 +421,24 @@ class CoreConfiguration(BaseSettings):
     @property
     def workers_available(self) -> bool:
         return self.redis_url is not None
+
+    @property
+    def redis_socket_kwargs(self) -> dict[str, Any]:
+        """Connection-resilience kwargs for long-lived Redis clients.
+
+        Passed through to the underlying redis-py client so a dead connection
+        raises instead of hanging the event loop. A timeout of 0 is omitted,
+        which redis-py treats as no timeout.
+        """
+        kwargs: dict[str, Any] = {
+            "socket_keepalive": self.redis_socket_keepalive,
+            "health_check_interval": self.redis_health_check_interval,
+        }
+        if self.redis_socket_timeout > 0:
+            kwargs["socket_timeout"] = self.redis_socket_timeout
+        if self.redis_socket_connect_timeout > 0:
+            kwargs["socket_connect_timeout"] = self.redis_socket_connect_timeout
+        return kwargs
 
     @cached_property
     def mongo_dbname(self) -> str:

--- a/vibetuner-py/src/vibetuner/tasks/worker.py
+++ b/vibetuner-py/src/vibetuner/tasks/worker.py
@@ -9,6 +9,7 @@ from vibetuner.tasks.lifespan import lifespan
 worker: Worker | None = (
     Worker(
         redis_url=str(settings.redis_url),
+        redis_kwargs=settings.redis_socket_kwargs,
         queue_name=settings.redis_key_prefix.rstrip(":"),
         lifespan=lifespan,
         concurrency=settings.worker_concurrency,

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -173,6 +173,52 @@ class TestLoadProjectConfig:
             assert result.project_slug == "default_project"
 
 
+class TestRedisSocketKwargs:
+    """Test redis_socket_kwargs resilience options for long-lived clients."""
+
+    def test_defaults_enable_resilience(self):
+        """By default, socket timeouts, keepalive and health checks are on."""
+        config = CoreConfiguration(project=ProjectConfiguration())
+        kwargs = config.redis_socket_kwargs
+        assert kwargs["socket_timeout"] == 30.0
+        assert kwargs["socket_connect_timeout"] == 10.0
+        assert kwargs["socket_keepalive"] is True
+        assert kwargs["health_check_interval"] == 30.0
+
+    def test_socket_timeout_disabled_when_zero(self):
+        """A zero socket_timeout is omitted so redis-py treats it as no timeout."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(), redis_socket_timeout=0
+        )
+        assert "socket_timeout" not in config.redis_socket_kwargs
+
+    def test_connect_timeout_disabled_when_zero(self):
+        """A zero socket_connect_timeout is omitted."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(), redis_socket_connect_timeout=0
+        )
+        assert "socket_connect_timeout" not in config.redis_socket_kwargs
+
+    def test_overrides_from_env_vars(self):
+        """REDIS_SOCKET_* and REDIS_HEALTH_CHECK_INTERVAL env vars are honored."""
+        with patch.dict(
+            "os.environ",
+            {
+                "REDIS_SOCKET_TIMEOUT": "5",
+                "REDIS_SOCKET_CONNECT_TIMEOUT": "2",
+                "REDIS_SOCKET_KEEPALIVE": "false",
+                "REDIS_HEALTH_CHECK_INTERVAL": "15",
+            },
+            clear=False,
+        ):
+            config = CoreConfiguration(project=ProjectConfiguration())
+            kwargs = config.redis_socket_kwargs
+            assert kwargs["socket_timeout"] == 5.0
+            assert kwargs["socket_connect_timeout"] == 2.0
+            assert kwargs["socket_keepalive"] is False
+            assert kwargs["health_check_interval"] == 15.0
+
+
 class TestCoreConfigurationLocaleDetection:
     """Test locale_detection field in CoreConfiguration."""
 

--- a/vibetuner-py/tests/unit/test_worker.py
+++ b/vibetuner-py/tests/unit/test_worker.py
@@ -1,0 +1,53 @@
+# ABOUTME: Tests for the streaq worker construction.
+# ABOUTME: Verifies Redis connection-resilience kwargs are passed to the worker.
+"""Tests for the streaq worker module."""
+
+# ruff: noqa: S101
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+
+class TestWorkerConstruction:
+    """Verify how the module-level worker is built from settings."""
+
+    def test_passes_redis_socket_kwargs(self):
+        """The worker is constructed with the configured resilience kwargs."""
+        resilience = {"socket_timeout": 30.0, "socket_keepalive": True}
+        fake_settings = MagicMock()
+        fake_settings.workers_available = True
+        fake_settings.redis_url = "redis://localhost:6379/0"
+        fake_settings.redis_socket_kwargs = resilience
+        fake_settings.redis_key_prefix = "myproject:"
+        fake_settings.worker_concurrency = 16
+
+        with (
+            patch("vibetuner.config.settings", fake_settings),
+            patch("streaq.Worker") as mock_worker,
+        ):
+            import vibetuner.tasks.worker as worker_mod
+
+            importlib.reload(worker_mod)
+
+        assert mock_worker.call_args.kwargs["redis_kwargs"] is resilience
+
+        # Restore the module to its real state for other tests.
+        importlib.reload(worker_mod)
+
+    def test_no_worker_when_redis_not_configured(self):
+        """No worker is built when Redis is unavailable."""
+        fake_settings = MagicMock()
+        fake_settings.workers_available = False
+
+        with (
+            patch("vibetuner.config.settings", fake_settings),
+            patch("streaq.Worker") as mock_worker,
+        ):
+            import vibetuner.tasks.worker as worker_mod
+
+            importlib.reload(worker_mod)
+            assert worker_mod.worker is None
+            mock_worker.assert_not_called()
+
+        # Restore the module to its real state for other tests.
+        importlib.reload(worker_mod)


### PR DESCRIPTION
## Summary

Fixes #1935 — a production worker silently stopped processing for ~11 hours after a dropped Redis TCP connection (a Tailscale blip). The container stayed `Up` with 0 restarts, but the asyncio event loop was wedged on a blocking Redis read that never returned, so the `restart: unless-stopped` policy never triggered.

This implements suggested fix **(1) Redis resilience on the worker connection** — the piece the issue scopes to the framework.

## What changed

- **`config.py`** — new tunable settings with safe defaults:
  - `REDIS_SOCKET_TIMEOUT` (30s) — turns a hung read into a raised error
  - `REDIS_SOCKET_CONNECT_TIMEOUT` (10s)
  - `REDIS_SOCKET_KEEPALIVE` (true)
  - `REDIS_HEALTH_CHECK_INTERVAL` (30s)
  - A `redis_socket_kwargs` property assembles these into redis-py kwargs (a `0` timeout is omitted = disabled).
- **`tasks/worker.py`** — passes `redis_kwargs=settings.redis_socket_kwargs` to the streaq `Worker`. streaq forwards these straight to `Redis.from_url`.
- **Docs** — `background-tasks.md` config table + a "Connection resilience" section, and `llms-full.txt`.

## Why the defaults are safe

streaq's blocking `xreadgroup` is bounded to ~500ms loops, so a 30s `socket_timeout` sits well above any legitimate blocking read while still breaking a dead socket. When a Redis op raises, streaq's run loop lets it propagate → the process exits → Docker restarts it. Net effect: ~30s of downtime on a network blip instead of indefinite wedge.

## Scope note

The shared async clients in `redis.py` (cache, SSE pub/sub) have the same latent hang, but `socket_timeout` would break SSE's indefinite `pubsub.listen()`, so that needs a separately-tested fix. This PR is scoped to the worker connection as the issue requests. Suggested fixes (2) liveness watchdog and (3) scaffolded worker healthcheck were already worked around by the reporter and are out of scope here.

## Testing

- New `TestRedisSocketKwargs` cases in `test_config.py` (defaults, env overrides, disable-via-zero).
- New `test_worker.py` verifying the worker is constructed with `redis_kwargs` and that no worker is built when Redis is unconfigured.
- Full unit suite: 890 passed. ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)