### PR TITLE
feat: add worker liveness watchdog and healthcheck

### DIFF
--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -585,6 +585,8 @@ vibetuner run prod worker --workers 4
 | Connect timeout | `REDIS_SOCKET_CONNECT_TIMEOUT` | `10` | Seconds before a Redis connect attempt gives up (0 disables) |
 | Keepalive | `REDIS_SOCKET_KEEPALIVE` | `true` | Enable TCP keepalive on the Redis connection |
 | Health check | `REDIS_HEALTH_CHECK_INTERVAL` | `30` | Seconds between PINGs on idle connections (0 disables) |
+| Watchdog timeout | `WORKER_WATCHDOG_TIMEOUT` | `60` | Seconds of event-loop stall before the process force-exits (0 disables) |
+| Watchdog interval | `WORKER_WATCHDOG_INTERVAL` | `5` | Seconds between watchdog heartbeats/checks |
 
 ### Connection resilience
 
@@ -600,6 +602,32 @@ worker reconnects or exits and is restarted by its `restart` policy. The
 defaults are safe for the worker, whose blocking reads are bounded to well
 under a second. Raise `REDIS_SOCKET_TIMEOUT` if your network has high latency,
 or set it to `0` to disable it entirely.
+
+### Liveness watchdog
+
+As a backstop for any event-loop stall (not just Redis), the worker runs a
+watchdog: a daemon thread refreshes a heartbeat from inside the loop, and if
+the loop stops ticking for longer than `WORKER_WATCHDOG_TIMEOUT` seconds the
+process force-exits so its `restart` policy starts a fresh worker. This catches
+wedges a socket timeout can't, such as a blocking call in a task. Set
+`WORKER_WATCHDOG_TIMEOUT=0` to disable it. The threshold must exceed your
+longest legitimate loop-blocking work; CPU-bound tasks should use streaq's sync
+task support so they run off the event loop.
+
+### Worker healthcheck
+
+The scaffolded `compose.prod.yml` gives the `worker` service a healthcheck that
+runs `vibetuner worker-health`. The command exits non-zero when no live worker
+is found — it checks for a fresh streaq health key in Redis, which the worker
+renews from inside its event loop, so a wedged or stopped worker reads as
+unhealthy. Plain Docker Compose does not restart on healthcheck status (the
+watchdog handles recovery), but the healthcheck surfaces a "live but hung"
+worker to `docker ps`, orchestrators (Kubernetes, Swarm), and autoheal
+sidecars. Run it manually with:
+
+```bash
+vibetuner worker-health && echo healthy || echo unhealthy
+```
 
 ## Testing Tasks
 

--- a/vibetuner-docs/docs/cli-reference.md
+++ b/vibetuner-docs/docs/cli-reference.md
@@ -114,6 +114,17 @@ vibetuner run prod [frontend|worker] [--port PORT] [--host HOST] [--workers COUN
 - Disables hot reload and honors `--workers` for both frontend and worker services.
 - Useful for containerless deployments or reproducing production settings locally.
 
+## `vibetuner worker-health`
+
+```bash
+vibetuner worker-health
+```
+
+- Exits `0` if a live worker is found, non-zero otherwise.
+- Checks for a fresh streaq health key in Redis, which the worker renews from
+  inside its event loop, so a wedged or stopped worker reads as unhealthy.
+- Used as the `worker` service healthcheck in the scaffolded `compose.prod.yml`.
+
 ## `vibetuner db`
 
 Database management commands for SQL databases (SQLModel/SQLAlchemy).

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2334,6 +2334,18 @@ indefinitely. `REDIS_SOCKET_TIMEOUT` (default 30s, 0 disables),
 true), and `REDIS_HEALTH_CHECK_INTERVAL` (default 30s) make a dead connection
 raise instead of hang, so the worker reconnects or exits and is restarted.
 
+Liveness watchdog: as a backstop for any event-loop stall (not just Redis), the
+worker runs a daemon thread that force-exits the process if the loop stops
+ticking for `WORKER_WATCHDOG_TIMEOUT` seconds (default 60, 0 disables;
+`WORKER_WATCHDOG_INTERVAL` default 5), so its `restart` policy starts a fresh
+worker.
+
+Worker healthcheck: `vibetuner worker-health` exits non-zero when no live
+worker is found (it checks for a fresh streaq health key in Redis, renewed from
+inside the worker's event loop). The scaffolded `compose.prod.yml` wires it as
+the worker service healthcheck for orchestrators / autoheal; recovery on plain
+Compose comes from the watchdog.
+
 #### Testing Tasks
 
 Use the `mock_tasks` fixture:

--- a/vibetuner-py/src/vibetuner/cli/__init__.py
+++ b/vibetuner-py/src/vibetuner/cli/__init__.py
@@ -132,6 +132,42 @@ def version(
     console.print(table)
 
 
+@app.command(name="worker-health")
+async def worker_health() -> None:
+    """Exit 0 if a worker is alive, else exit 1 (for container healthchecks).
+
+    The streaq worker renews a health key in Redis from inside its event loop,
+    so a wedged loop lets the key expire. This checks for a fresh key.
+    """
+    from vibetuner.config import settings
+
+    if not settings.workers_available:
+        logger.error("worker-health: REDIS_URL not configured")
+        raise typer.Exit(code=1)
+
+    import redis.asyncio as aioredis
+
+    queue_name = settings.redis_key_prefix.rstrip(":")
+    pattern = f"streaq:{queue_name}:health:*"
+    client = aioredis.from_url(
+        str(settings.redis_url), socket_timeout=3, socket_connect_timeout=3
+    )
+    found = False
+    try:
+        async for _key in client.scan_iter(match=pattern, count=100):
+            found = True
+            break
+    except Exception as exc:
+        logger.error("worker-health: Redis check failed: {}", exc)
+        raise typer.Exit(code=1) from exc
+    finally:
+        await client.aclose()
+
+    if not found:
+        logger.error("worker-health: no live worker found for queue {}", queue_name)
+        raise typer.Exit(code=1)
+
+
 app.add_typer(config_app, name="config")
 app.add_typer(crypto_app, name="crypto")
 app.add_typer(db_app, name="db")

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -340,6 +340,13 @@ class CoreConfiguration(BaseSettings):
     redis_socket_keepalive: bool = True
     redis_health_check_interval: float = 30.0
 
+    # Liveness watchdog: a thread force-exits the worker if the event loop
+    # stops ticking for longer than the timeout, so a stalled (but not crashed)
+    # process is restarted by its `restart` policy. Set the timeout to 0 to
+    # disable. The interval is how often the loop beats and the thread checks.
+    worker_watchdog_timeout: float = 60.0
+    worker_watchdog_interval: float = 5.0
+
     # Port configuration (read from DEV_PORT / WORKER_PORT env or .env.local)
     dev_port: UnprivilegedPort | None = None
     worker_port: UnprivilegedPort | None = None

--- a/vibetuner-py/src/vibetuner/tasks/lifespan.py
+++ b/vibetuner-py/src/vibetuner/tasks/lifespan.py
@@ -10,6 +10,7 @@ from vibetuner.logging import logger
 from vibetuner.mongo import init_mongodb, teardown_mongodb
 from vibetuner.runtime_config import RuntimeConfig
 from vibetuner.sqlmodel import init_sqlmodel, teardown_sqlmodel
+from vibetuner.tasks.watchdog import LoopWatchdog
 
 
 @asynccontextmanager
@@ -24,7 +25,18 @@ async def base_lifespan() -> AsyncGenerator[Context, None]:
         await RuntimeConfig.refresh_cache()
         logger.debug("Runtime config cache initialized")
 
+    watchdog: LoopWatchdog | None = None
+    if settings.worker_watchdog_timeout > 0:
+        watchdog = LoopWatchdog(
+            timeout=settings.worker_watchdog_timeout,
+            interval=settings.worker_watchdog_interval,
+        )
+        watchdog.start()
+
     yield ctx
+
+    if watchdog is not None:
+        await watchdog.stop()
 
     await teardown_sqlmodel()
     await teardown_mongodb()

--- a/vibetuner-py/src/vibetuner/tasks/watchdog.py
+++ b/vibetuner-py/src/vibetuner/tasks/watchdog.py
@@ -1,0 +1,68 @@
+# ABOUTME: Liveness watchdog that force-exits a worker whose event loop stalls.
+# ABOUTME: A daemon thread restarts the process when the loop stops ticking.
+import asyncio
+import os
+import threading
+import time
+
+from vibetuner.logging import logger
+
+
+class LoopWatchdog:
+    """Force-exit the process if the asyncio event loop stops ticking.
+
+    A daemon thread, independent of the loop, watches a heartbeat that an
+    asyncio task refreshes every ``interval`` seconds. If the loop wedges (for
+    example on a blocking call that never returns), the heartbeat goes stale
+    and the thread force-exits so a ``restart`` policy can recover the worker.
+    """
+
+    def __init__(self, timeout: float, interval: float) -> None:
+        self._timeout = timeout
+        self._interval = interval
+        self._last_beat = time.monotonic()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._task: asyncio.Task[None] | None = None
+
+    async def _heartbeat(self) -> None:
+        while True:
+            self._last_beat = time.monotonic()
+            await asyncio.sleep(self._interval)
+
+    def _monitor(self) -> None:
+        while not self._stop.wait(self._interval):
+            stalled = time.monotonic() - self._last_beat
+            if stalled > self._timeout:
+                logger.critical(
+                    "Worker event loop stalled for {:.0f}s (>{:.0f}s); "
+                    "force-exiting so the process is restarted",
+                    stalled,
+                    self._timeout,
+                )
+                os._exit(1)
+
+    def start(self) -> None:
+        """Start the heartbeat task and the monitoring thread."""
+        self._last_beat = time.monotonic()
+        self._task = asyncio.create_task(self._heartbeat())
+        self._thread = threading.Thread(
+            target=self._monitor, name="loop-watchdog", daemon=True
+        )
+        self._thread.start()
+        logger.debug(
+            "Loop watchdog started (timeout={}s, interval={}s)",
+            self._timeout,
+            self._interval,
+        )
+
+    async def stop(self) -> None:
+        """Stop the monitoring thread and cancel the heartbeat task."""
+        self._stop.set()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None

--- a/vibetuner-py/tests/unit/test_watchdog.py
+++ b/vibetuner-py/tests/unit/test_watchdog.py
@@ -1,0 +1,64 @@
+# ABOUTME: Tests for the worker liveness watchdog.
+# ABOUTME: Verifies heartbeat refresh and force-exit on a stalled event loop.
+"""Tests for the LoopWatchdog."""
+
+# ruff: noqa: S101
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+from vibetuner.tasks.watchdog import LoopWatchdog
+
+
+class TestHeartbeat:
+    @pytest.mark.asyncio
+    async def test_heartbeat_refreshes_last_beat(self):
+        """The heartbeat task advances the recorded beat over time."""
+        wd = LoopWatchdog(timeout=10.0, interval=0.01)
+        wd._last_beat = time.monotonic() - 100
+        wd.start()
+        await asyncio.sleep(0.05)
+        assert time.monotonic() - wd._last_beat < 1.0
+        await wd.stop()
+
+
+class TestMonitor:
+    def test_force_exits_when_loop_stalls(self):
+        """A stale heartbeat triggers os._exit(1)."""
+        wd = LoopWatchdog(timeout=10.0, interval=0.001)
+        wd._last_beat = time.monotonic() - 30  # 30s stale > 10s timeout
+
+        with patch("os._exit", side_effect=lambda _code: wd._stop.set()) as mock_exit:
+            wd._monitor()
+
+        mock_exit.assert_called_once_with(1)
+
+    def test_does_not_exit_when_healthy(self):
+        """A fresh heartbeat never triggers os._exit."""
+        wd = LoopWatchdog(timeout=10.0, interval=0.001)
+        wd._last_beat = time.monotonic()
+        # Stop after the first wait so the loop runs exactly one iteration.
+        wd._stop.set()
+
+        with patch("os._exit") as mock_exit:
+            wd._monitor()
+
+        mock_exit.assert_not_called()
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_stop_cancels_heartbeat_task(self):
+        """stop() cancels the heartbeat task and stops the thread."""
+        wd = LoopWatchdog(timeout=10.0, interval=0.01)
+        wd.start()
+        thread = wd._thread
+        await wd.stop()
+
+        assert wd._task is None
+        assert wd._stop.is_set()
+        if thread is not None:
+            thread.join(timeout=1.0)
+            assert not thread.is_alive()

--- a/vibetuner-py/tests/unit/test_worker_health.py
+++ b/vibetuner-py/tests/unit/test_worker_health.py
@@ -1,0 +1,79 @@
+# ABOUTME: Tests for the `vibetuner worker-health` CLI command.
+# ABOUTME: Verifies exit codes based on the presence of a fresh streaq health key.
+# ruff: noqa: S101
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+from vibetuner.cli import app
+
+
+runner = CliRunner()
+
+
+class FakeRedis:
+    """Minimal async Redis stand-in for the health check."""
+
+    def __init__(self, keys: list[str], scan_error: Exception | None = None) -> None:
+        self._keys = keys
+        self._scan_error = scan_error
+        self.closed = False
+
+    def scan_iter(self, match=None, count=None):
+        keys = self._keys
+        error = self._scan_error
+
+        async def gen():
+            if error is not None:
+                raise error
+            for key in keys:
+                yield key
+
+        return gen()
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _settings(workers_available: bool = True) -> MagicMock:
+    s = MagicMock()
+    s.workers_available = workers_available
+    s.redis_url = "redis://localhost:6379/0"
+    s.redis_key_prefix = "myproject:"
+    return s
+
+
+class TestWorkerHealth:
+    def test_healthy_when_health_key_exists(self):
+        fake = FakeRedis(keys=["streaq:myproject:health:abc123"])
+        with (
+            patch("vibetuner.config.settings", _settings()),
+            patch("redis.asyncio.from_url", return_value=fake),
+        ):
+            result = runner.invoke(app, ["worker-health"])
+        assert result.exit_code == 0
+        assert fake.closed is True
+
+    def test_unhealthy_when_no_health_key(self):
+        fake = FakeRedis(keys=[])
+        with (
+            patch("vibetuner.config.settings", _settings()),
+            patch("redis.asyncio.from_url", return_value=fake),
+        ):
+            result = runner.invoke(app, ["worker-health"])
+        assert result.exit_code == 1
+        assert fake.closed is True
+
+    def test_unhealthy_when_redis_not_configured(self):
+        with patch("vibetuner.config.settings", _settings(workers_available=False)):
+            result = runner.invoke(app, ["worker-health"])
+        assert result.exit_code == 1
+
+    def test_unhealthy_when_redis_errors(self):
+        fake = FakeRedis(keys=[], scan_error=ConnectionError("boom"))
+        with (
+            patch("vibetuner.config.settings", _settings()),
+            patch("redis.asyncio.from_url", return_value=fake),
+        ):
+            result = runner.invoke(app, ["worker-health"])
+        assert result.exit_code == 1
+        assert fake.closed is True

--- a/vibetuner-py/tests/unit/test_worker_lifespan.py
+++ b/vibetuner-py/tests/unit/test_worker_lifespan.py
@@ -14,12 +14,8 @@ class TestWorkerBaseLifespan:
     async def test_base_lifespan_initializes_runtime_config_cache(self):
         """base_lifespan calls RuntimeConfig.refresh_cache() after MongoDB init."""
         with (
-            patch(
-                "vibetuner.tasks.lifespan.init_mongodb", new_callable=AsyncMock
-            ),
-            patch(
-                "vibetuner.tasks.lifespan.init_sqlmodel", new_callable=AsyncMock
-            ),
+            patch("vibetuner.tasks.lifespan.init_mongodb", new_callable=AsyncMock),
+            patch("vibetuner.tasks.lifespan.init_sqlmodel", new_callable=AsyncMock),
             patch(
                 "vibetuner.tasks.lifespan.teardown_mongodb",
                 new_callable=AsyncMock,
@@ -29,11 +25,10 @@ class TestWorkerBaseLifespan:
                 new_callable=AsyncMock,
             ),
             patch("vibetuner.tasks.lifespan.settings") as mock_settings,
-            patch(
-                "vibetuner.tasks.lifespan.RuntimeConfig"
-            ) as mock_runtime_config,
+            patch("vibetuner.tasks.lifespan.RuntimeConfig") as mock_runtime_config,
         ):
             mock_settings.mongodb_url = "mongodb://localhost:27017"
+            mock_settings.worker_watchdog_timeout = 0
             mock_runtime_config.refresh_cache = AsyncMock()
 
             from vibetuner.tasks.lifespan import base_lifespan
@@ -47,12 +42,8 @@ class TestWorkerBaseLifespan:
     async def test_base_lifespan_skips_runtime_config_without_mongodb(self):
         """base_lifespan skips RuntimeConfig.refresh_cache() when no MongoDB URL."""
         with (
-            patch(
-                "vibetuner.tasks.lifespan.init_mongodb", new_callable=AsyncMock
-            ),
-            patch(
-                "vibetuner.tasks.lifespan.init_sqlmodel", new_callable=AsyncMock
-            ),
+            patch("vibetuner.tasks.lifespan.init_mongodb", new_callable=AsyncMock),
+            patch("vibetuner.tasks.lifespan.init_sqlmodel", new_callable=AsyncMock),
             patch(
                 "vibetuner.tasks.lifespan.teardown_mongodb",
                 new_callable=AsyncMock,
@@ -62,11 +53,10 @@ class TestWorkerBaseLifespan:
                 new_callable=AsyncMock,
             ),
             patch("vibetuner.tasks.lifespan.settings") as mock_settings,
-            patch(
-                "vibetuner.tasks.lifespan.RuntimeConfig"
-            ) as mock_runtime_config,
+            patch("vibetuner.tasks.lifespan.RuntimeConfig") as mock_runtime_config,
         ):
             mock_settings.mongodb_url = None
+            mock_settings.worker_watchdog_timeout = 0
             mock_runtime_config.refresh_cache = AsyncMock()
 
             from vibetuner.tasks.lifespan import base_lifespan
@@ -75,3 +65,28 @@ class TestWorkerBaseLifespan:
                 pass
 
             mock_runtime_config.refresh_cache.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_base_lifespan_starts_and_stops_watchdog(self):
+        """The liveness watchdog is started and stopped when enabled."""
+        with (
+            patch("vibetuner.tasks.lifespan.init_mongodb", new_callable=AsyncMock),
+            patch("vibetuner.tasks.lifespan.init_sqlmodel", new_callable=AsyncMock),
+            patch("vibetuner.tasks.lifespan.teardown_mongodb", new_callable=AsyncMock),
+            patch("vibetuner.tasks.lifespan.teardown_sqlmodel", new_callable=AsyncMock),
+            patch("vibetuner.tasks.lifespan.settings") as mock_settings,
+            patch("vibetuner.tasks.lifespan.LoopWatchdog") as mock_watchdog_cls,
+        ):
+            mock_settings.mongodb_url = None
+            mock_settings.worker_watchdog_timeout = 60.0
+            mock_settings.worker_watchdog_interval = 5.0
+            instance = mock_watchdog_cls.return_value
+            instance.stop = AsyncMock()
+
+            from vibetuner.tasks.lifespan import base_lifespan
+
+            async with base_lifespan():
+                instance.start.assert_called_once()
+                instance.stop.assert_not_awaited()
+
+            instance.stop.assert_awaited_once()

--- a/vibetuner-template/compose.prod.yml
+++ b/vibetuner-template/compose.prod.yml
@@ -6,6 +6,12 @@ services:
       - path: .env
         required: false
     command: ["prod", "worker"]
+    healthcheck:
+      test: ["CMD", "vibetuner", "worker-health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
     labels:
       com.centurylinklabs.watchtower.enable: "${ENABLE_WATCHTOWER:-false}"
   frontend:


### PR DESCRIPTION
## Summary

Follow-up to #1936, implementing the remaining framework asks from #1935:

- **(2) Liveness watchdog** — a daemon OS thread refreshes a heartbeat from inside the worker's event loop and force-exits the process if the loop stops ticking for `WORKER_WATCHDOG_TIMEOUT` seconds (default 60, `0` disables; interval via `WORKER_WATCHDOG_INTERVAL`, default 5). This catches *any* loop stall a socket timeout can't (e.g. a blocking call in a task), so a "live but hung" worker is recovered by its `restart: unless-stopped` policy. Lives in `tasks/watchdog.py`, started/stopped in `base_lifespan`.
- **(3) Worker healthcheck** — `vibetuner worker-health` exits non-zero when no fresh streaq health key is found in Redis. The worker renews that key from inside its event loop, so a wedged or stopped worker reads as unhealthy. Wired as the `worker` service healthcheck in the scaffolded `compose.prod.yml`.

## Design notes

- **Why a watchdog, not just the socket timeout (#1936):** plain `docker compose` does **not** restart a container on healthcheck status, and the socket timeout only covers Redis-blocked reads. The in-loop watchdog is what actually recovers a wedge on plain Compose, for any stall cause.
- **Why reuse streaq's health key for the healthcheck:** streaq's web UI runs in a *separate* process, so it can't detect a wedged worker loop. The per-worker health key (`streaq:{queue}:health:{id}`, TTL renewed in-loop) reliably disappears when the loop wedges — so the check is a SCAN for a fresh key, no new key invented.
- **No autoheal sidecar** (per the chosen scope): the healthcheck is observability + orchestrator/autoheal integration; recovery comes from the watchdog.

## Testing

- `test_watchdog.py` — heartbeat refresh, force-exit on stall, no-exit when healthy, start/stop lifecycle.
- `test_worker_health.py` — exit 0 with a fresh key, exit 1 when none / Redis unconfigured / Redis errors.
- `test_worker_lifespan.py` — watchdog start/stop integration; existing cases updated to set the new setting.
- Full unit suite: **899 passed**. ruff + ty clean. Verified `vibetuner worker-health` registers and exits 1 with no Redis; `compose.prod.yml` healthcheck parses.
- Could not run a live-Redis integration test (the shared `*.ts.net` Redis isn't reachable from this environment); `scan_iter` is covered by unit tests with a fake client.

## Settings added

`WORKER_WATCHDOG_TIMEOUT` (60), `WORKER_WATCHDOG_INTERVAL` (5).

Docs updated: `background-tasks.md` (config table + Liveness watchdog + Worker healthcheck sections), `cli-reference.md` (`worker-health`), `llms-full.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)