### PR TITLE
feat: make strict-CSP hx-csp adoption ergonomic

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -790,11 +790,13 @@ guard prevents the worst-case UX when something slips through.
 
 !!! note "Requires `htmx.org@4.0.0-beta4`"
     The `hx-csp` extension file ships with `htmx.org@4.0.0-beta4`, pulled
-    transitively by the matching `@alltuner/vibetuner` release. On older
-    versions the bundler will fail with
-    `Could not resolve "./node_modules/htmx.org/dist/ext/hx-csp.js"`
-    (releases shipping htmx beta3 carry the extension as `hx-nonce.js`).
-    Bump `@alltuner/vibetuner` in `package.json` and re-run `bun install`
+    transitively by the matching `@alltuner/vibetuner` release, and is
+    re-exported as `@alltuner/vibetuner/htmx/csp` (added in 10.20.0). On
+    older `@alltuner/vibetuner` releases that subpath does not exist, so
+    the bundler fails with
+    `Could not resolve "@alltuner/vibetuner/htmx/csp"` (releases shipping
+    htmx beta3 carried the extension as `hx-nonce.js`). Bump
+    `@alltuner/vibetuner` in `package.json` and re-run `bun install`
     before enabling.
 
 htmx 4.0.0-beta4 ships an `hx-csp` extension (renamed from `hx-nonce`
@@ -821,11 +823,27 @@ fresh project as soon as you mirror the pattern in your own templates.
 
     ```javascript
     // Add your custom imports below:
-    import "./node_modules/htmx.org/dist/ext/hx-csp.js";
+    import "@alltuner/vibetuner/htmx/csp";
     ```
 
-2. Add `hx-nonce="{{ csp_nonce }}"` to every element in your templates
-   that uses any `hx-*` attribute:
+    This re-export pulls the extension from the framework's pinned
+    `htmx.org`, so you do **not** need a direct `htmx.org` devDependency
+    (which would risk drifting from the framework's version). It mirrors
+    the existing `@alltuner/vibetuner/htmx/preload`, `…/sse`, and `…/live`
+    re-exports.
+
+2. Stamp the nonce on your htmx elements. The extension is fail-closed:
+   every element carrying an `hx-*` attribute needs a matching `hx-nonce`,
+   or its htmx attributes are stripped. Rather than stamping each element,
+   add a single inherited nonce on `<body>` via the skeleton's
+   `body_attrs` block — every htmx element inherits it:
+
+    ```jinja
+    {% block body_attrs %}hx-nonce:inherited="{{ csp_nonce }}"{% endblock body_attrs %}
+    ```
+
+    Stamp individual elements only where you want to opt out of the
+    inherited nonce:
 
     ```html
     <button hx-post="/save"
@@ -845,10 +863,26 @@ directives, or extend `SecurityHeadersMiddleware` directly.
 
 **Safe eval:** vibetuner's CSP does not include `'unsafe-eval'`, so any
 htmx feature that requires `eval` (e.g. `hx-vals` with the `js:` prefix,
-`hx-on:` handlers that reference globals) will be blocked by default.
-If you use those features, set `safeEval:true` in your htmx config —
-the extension replaces htmx's `new Function()` eval with nonce-based
-script injection so the features work without `unsafe-eval`.
+`hx-on:` / `hx-on::` event handlers, `hx-confirm` with `js:`) is blocked
+by default — the handler silently never runs. If you use those features,
+enable `safeEval`: the extension replaces htmx's `new Function()` eval
+with nonce-based script injection so they work without `unsafe-eval`.
+
+Set it via the `htmx-config` meta tag rather than in JavaScript. The
+extension reads `htmx.config.safeEval` when its `init` runs, but ESM
+hoists imports, so a plain `htmx.config.safeEval = true` in `config.js`
+executes *after* the extension import and is too late. htmx reads the
+meta tag when its script first evaluates, so the tag must appear **before**
+the bundle script. Use the skeleton's `htmx_config` block, which renders
+in `<head>` just before the bundle for exactly this. The `extensions`
+key also applies the extension globally, so you don't need `hx-ext` on
+each element:
+
+```jinja
+{% block htmx_config %}
+    <meta name="htmx-config" content='extensions:"hx-csp",safeEval:true'>
+{% endblock htmx_config %}
+```
 
 ### Strict `style-src` (opt-in)
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2039,9 +2039,16 @@ and re-run `uv sync` first.
 **htmx CSP Protection (opt-in, requires `htmx.org@4.0.0-beta4`):**
 htmx 4.0.0-beta4 ships an `hx-csp` extension (renamed from `hx-nonce`
 in beta3) that strips htmx attributes from elements without a matching
-`hx-nonce`. Stamp `hx-nonce="{{ csp_nonce }}"` on every htmx-bearing
-element and add `import "htmx.org/dist/ext/hx-csp.js";` to `config.js`
-custom imports. Framework templates already include the attribute.
+`hx-nonce`. Enable by adding `import "@alltuner/vibetuner/htmx/csp";` to
+`config.js` custom imports (re-exported from the framework's pinned
+htmx, so no direct `htmx.org` dep is needed; added in 10.20.0). Stamp
+the nonce once via the skeleton's `body_attrs` block —
+`hx-nonce:inherited="{{ csp_nonce }}"` — and every htmx element inherits
+it; stamp individual elements only to override. For features that need
+eval (`hx-on`, `hx-vals js:`, `hx-confirm js:`), enable `safeEval` via
+`<meta name="htmx-config" content='extensions:"hx-csp",safeEval:true'>`
+placed in the skeleton's `htmx_config` block (it must precede the bundle
+script, since htmx reads its meta config when the script evaluates).
 Useful defence-in-depth even though vibetuner already enforces strict
 script-src. The HTML attribute is still named `hx-nonce`; only the
 extension itself was renamed. On older releases that ship
@@ -2602,9 +2609,10 @@ relevant to vibetuner projects:
 
 - **`hx-csp` extension** (introduced in beta3 as `hx-nonce`, renamed in
   beta4) — gates htmx attribute processing behind the page CSP nonce.
-  Stamp `hx-nonce="{{ csp_nonce }}"` on every htmx-bearing element and
-  import `htmx.org/dist/ext/hx-csp.js` in `config.js` to enable. Framework
-  templates already follow the pattern. Elements without a matching nonce
+  Enable by importing `@alltuner/vibetuner/htmx/csp` in `config.js` (no
+  direct `htmx.org` dep; added in 10.20.0) and stamping the nonce once via
+  the skeleton's `body_attrs` block (`hx-nonce:inherited="{{ csp_nonce }}"`,
+  inherited by all htmx elements). Elements without a matching nonce
   are stripped (fail-closed). The HTML attribute is still named
   `hx-nonce`; only the extension itself was renamed
 - **`hx-live` extension** — DOM-reactivity via `hx-live="..."` plus a

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -136,13 +136,15 @@ Important notes:
   pages (Chrome)
 - **htmx CSP Protection (opt-in)**: htmx 4.0.0-beta4 ships an `hx-csp` extension
   (renamed from `hx-nonce` in beta3) that gates htmx attribute processing behind the
-  page CSP nonce. Framework templates stamp `hx-nonce="{{ csp_nonce }}"` on
-  htmx-bearing elements; mirror that pattern in user templates and add
-  `import "htmx.org/dist/ext/hx-csp.js";` to `config.js` to enable. Elements without
-  a matching `hx-nonce` are stripped (fail-closed). The HTML attribute is still
-  named `hx-nonce`; only the extension itself was renamed. Requires
-  `@alltuner/vibetuner` shipping `htmx.org@4.0.0-beta4` (older releases shipped the
-  extension as `hx-nonce.js`)
+  page CSP nonce. Enable by adding `import "@alltuner/vibetuner/htmx/csp";` to
+  `config.js` (re-exported from the framework's pinned htmx, no direct `htmx.org`
+  dep needed; added in 10.20.0) and stamping the nonce once via the skeleton's
+  `body_attrs` block: `hx-nonce:inherited="{{ csp_nonce }}"` — every htmx element
+  inherits it. Elements without a matching `hx-nonce` are stripped (fail-closed).
+  For `hx-on`/`hx-vals js:` (which need eval), add
+  `<meta name="htmx-config" content='extensions:"hx-csp",safeEval:true'>` via the
+  skeleton's `htmx_config` block (must precede the bundle script). The HTML
+  attribute is still named `hx-nonce`; only the extension was renamed
 - **htmx Live Reactivity (default-on)**: htmx 4's `hx-live` extension is
   loaded by default from `config.js` since `@alltuner/vibetuner` 10.15.0. Use
   `hx-live="<expr>"` for derived state that recomputes on any DOM mutation,

--- a/vibetuner-js/htmx-csp.js
+++ b/vibetuner-js/htmx-csp.js
@@ -1,0 +1,3 @@
+// ABOUTME: Re-exports the htmx hx-csp extension via @alltuner/vibetuner/htmx/csp
+// ABOUTME: so scaffolded projects don't need a direct htmx.org dep to enable it.
+import "htmx.org/dist/ext/hx-csp.js";

--- a/vibetuner-js/package.json
+++ b/vibetuner-js/package.json
@@ -27,7 +27,8 @@
     "./htmx": "./htmx.js",
     "./htmx/preload": "./htmx-preload.js",
     "./htmx/sse": "./htmx-sse.js",
-    "./htmx/live": "./htmx-live.js"
+    "./htmx/live": "./htmx-live.js",
+    "./htmx/csp": "./htmx-csp.js"
   },
   "bin": {
     "tailwindcss": "./bin/tailwindcss.js"

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -29,6 +29,11 @@
         <link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
         {% include "base/theme.html.jinja" %}
 
+        {# Pre-script head hook. Anything here is parsed before the bundle
+           below, so htmx reads a `<meta name="htmx-config">` placed here at
+           startup (it reads config when the script evaluates, not later). -#}
+        {% block htmx_config %}
+        {% endblock htmx_config %}
         {% block scripts %}
             <script src="{{ url_for('js', path='bundle.js').path }}"></script>
         {% endblock scripts %}
@@ -43,7 +48,10 @@
         {% block head %}
         {% endblock head %}
     </head>
-    <body preload="mousedown" class="{{ BODY_CLASS }}">
+    <body preload="mousedown"
+          class="{{ BODY_CLASS }}"
+          {% block body_attrs %}
+          {% endblock body_attrs %}>
         {% block start_of_body %}
         {% endblock start_of_body %}
         {% block header %}

--- a/vibetuner-py/tests/unit/test_skeleton_extension_points.py
+++ b/vibetuner-py/tests/unit/test_skeleton_extension_points.py
@@ -180,6 +180,29 @@ def test_extension_blocks_empty_by_default():
         assert marker not in out
 
 
+# ── body_attrs block ─────────────────────────────────────────────────
+
+
+class TestBodyAttrs:
+    def test_attrs_render_inside_body_tag(self):
+        """Override content lands inside the opening <body> tag."""
+        env = _make_env(
+            child_body=(
+                '{% block body_attrs %}hx-nonce:inherited="{{ csp_nonce }}"'
+                "{% endblock body_attrs %}"
+            )
+        )
+        out = _render(env)
+        flat = " ".join(out.split())
+        body_open = flat[flat.index("<body") : flat.index(">", flat.index("<body"))]
+        assert 'hx-nonce:inherited="n"' in body_open
+
+    def test_empty_by_default(self):
+        """The <body> tag carries no extra attributes when not overridden."""
+        out = _render(_make_env())
+        assert "hx-nonce" not in out
+
+
 # ── cascade-order invariants ─────────────────────────────────────────
 
 
@@ -215,6 +238,18 @@ def test_extra_scripts_block_renders_after_bundle_js():
     )
     out = _render(env)
     assert out.index("bundle.js") < out.index("<!-- AFTER_BUNDLE -->")
+
+
+def test_htmx_config_block_renders_before_bundle_js():
+    """htmx reads its meta config when the bundle evaluates, so the
+    htmx_config block must precede the bundle script."""
+    env = _make_env(
+        child_body=(
+            "{% block htmx_config %}<!-- HTMX_CONFIG -->{% endblock htmx_config %}"
+        )
+    )
+    out = _render(env)
+    assert out.index("<!-- HTMX_CONFIG -->") < out.index("bundle.js")
 
 
 def test_before_main_and_after_main_wrap_body():


### PR DESCRIPTION
## Summary

Closes #1938. Smooths the four friction points the issue hit when adopting the htmx `hx-csp` extension under a strict (no `unsafe-eval`) CSP.

### 1. Re-export the extension (friction #1 + #2)
- New `vibetuner-js/htmx-csp.js` + `"./htmx/csp"` export, mirroring the existing `htmx/preload`, `htmx/sse`, `htmx/live`. Projects now `import "@alltuner/vibetuner/htmx/csp";` with **no direct `htmx.org` devDependency** — which previously had to be pinned by hand and would drift from the framework's htmx the moment it bumped.
- Verified the re-export bundles with bun (`htmx.registerExtension("hx-csp")` lands in the output).

### 2. `body_attrs` skeleton block (friction #4)
- The `<body>` tag had no attribute hook, forcing a full skeleton override just to add the nonce. Added `{% block body_attrs %}` so projects stamp a **single inherited nonce**: `hx-nonce:inherited="{{ csp_nonce }}"`. Verified against the htmx 4 source that `:inherited` resolves `hx-nonce` from ancestors and the extension reads it via the same `attributeValue` path — so one stamp on `<body>` covers every htmx element.

### 3. `htmx_config` skeleton block (friction #3)
- `htmx.config.safeEval` must be set before the extension's `init`, but ESM hoists imports so `htmx.config.safeEval = true` in `config.js` runs too late. The htmx-native fix is the `<meta name="htmx-config">` tag — **but** htmx reads that meta *synchronously when its script evaluates* (`#initHtmxConfig` in the constructor), not at DOMContentLoaded. The skeleton's `head` block renders *after* the bundle script, so it would be too late.
- Added a dedicated `{% block htmx_config %}` positioned **just before** the bundle script, so a meta placed there is parsed first. Documented:
  ```jinja
  {% block htmx_config %}
      <meta name="htmx-config" content='extensions:"hx-csp",safeEval:true'>
  {% endblock htmx_config %}
  ```

### 4. Docs
- `development-guide.md`, `llms.txt`, `llms-full.txt` updated to the new import path, the `body_attrs` single-stamp pattern, and the `htmx_config`/meta safeEval approach.

## Testing
- `test_skeleton_extension_points.py`: new `TestBodyAttrs` (renders inside `<body>`, empty by default) and `test_htmx_config_block_renders_before_bundle_js` (ordering invariant — the whole point of the block).
- Full unit suite: **902 passed**. ruff, djlint, rumdl all clean (pre-commit green). `node --check` on the new JS, and a bun build of the re-export.

## Notes
- Docs reference "added in 10.20.0" as the version that introduces the `@alltuner/vibetuner/htmx/csp` subpath (next minor after the just-released 10.19.0).
- The existing explicit `hx-nonce` on `user/profile.html.jinja` is left as-is — harmless, and it inherits correctly whether or not a project sets `body_attrs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)