### PR TITLE
feat: ship a no-flash theme setter in the skeleton

### DIFF
--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1395,6 +1395,35 @@ The top-level symlink makes `@plugin "daisyui/theme"` resolvable.
 For per-request runtime overrides on top of the build-time palette
 (per-tenant branding), see the next section.
 
+### Light / Dark / System Toggle
+
+The skeleton ships a CSP-nonced **no-flash theme setter**
+(`base/theme_init.html.jinja`) that runs synchronously high in `<head>`,
+before `bundle.css`. It sets `data-theme` on `<html>` before first
+paint, so the page never flashes the wrong theme.
+
+State:
+
+- `localStorage['theme']` — persisted preference (`"light"` / `"dark"`;
+  absent means *system*).
+- `data-theme-mode` on `<html>` — chosen mode (`system` / `light` / `dark`).
+- `data-theme` on `<html>` — concrete theme DaisyUI renders. In `system`
+  mode it resolves against `prefers-color-scheme` and live-updates when
+  the OS theme changes.
+
+Default mode is `system`, so a fresh visitor sees their OS preference.
+The setter exposes `window.cycleTheme()`, cycling `system → light → dark`
+and persisting the choice. Wire a toggle through htmx's nonced `hx-on`
+path (a raw inline `onclick` would be blocked by `script-src`):
+
+```html
+<button class="btn btn-ghost btn-sm" hx-on:click="cycleTheme()">Theme</button>
+```
+
+Override just `base/theme_init.html.jinja` for different theming logic.
+Projects replacing the skeleton wholesale must include it *before* the
+`bundle.css` link.
+
 ### Per-Tenant Theming
 
 Multi-tenant apps can swap DaisyUI role colors per tenant without rebuilding

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -26,7 +26,7 @@ Important notes:
 - [Background Tasks](https://vibetuner.alltuner.com/background-tasks/): Background task system powered by Streaq and Redis with retries, cron scheduling, and SSE integration
 - [Runtime Configuration](https://vibetuner.alltuner.com/runtime-config/): Layered configuration system with MongoDB persistence, debug UI, and feature flags
 - [HTMX v2 to v4 Migration](https://vibetuner.alltuner.com/htmx-migration/): Breaking changes and migration guide for upgrading from HTMX v2 to v4
-- [Theming](https://vibetuner.alltuner.com/theming/): Build-time brand palette via cascade override of DaisyUI's `[data-theme="…"]` selectors in `config.css` (no consumer-side `daisyui` dep needed), plus runtime per-tenant overrides via the embedded `TenantTheme` model + opt-in `register_tenant_theme_provider()` helper + shipped `base/theme.html.jinja` partial that injects DaisyUI role-color overrides at request time
+- [Theming](https://vibetuner.alltuner.com/theming/): Build-time brand palette via cascade override of DaisyUI's `[data-theme="…"]` selectors in `config.css` (no consumer-side `daisyui` dep needed), a CSP-nonced no-flash light/dark/system setter (`base/theme_init.html.jinja`) that sets `data-theme` before first paint and exposes `window.cycleTheme()`, plus runtime per-tenant overrides via the embedded `TenantTheme` model + opt-in `register_tenant_theme_provider()` helper + shipped `base/theme.html.jinja` partial that injects DaisyUI role-color overrides at request time
 
 ## Features
 

--- a/vibetuner-docs/docs/theming.md
+++ b/vibetuner-docs/docs/theming.md
@@ -63,6 +63,45 @@ The top-level symlink makes `@plugin "daisyui/theme"` resolvable from
 `config.css`. Most projects don't need this — overriding
 `[data-theme="…"]` is enough.
 
+## Light / dark / system toggle
+
+Vibetuner's skeleton ships a tiny, CSP-nonced **no-flash theme setter**
+(`base/theme_init.html.jinja`) that runs synchronously high in `<head>`,
+before `bundle.css`. It sets `data-theme` on `<html>` *before first
+paint*, so the page never flashes the wrong theme (the "flash of
+inaccurate theme" you get when JS switches the theme after the first
+render).
+
+Three pieces of state:
+
+- **`localStorage['theme']`** — the persisted preference. Holds
+  `"light"` or `"dark"`; absent means *system*.
+- **`data-theme-mode`** on `<html>` — the chosen mode (`system`,
+  `light`, or `dark`).
+- **`data-theme`** on `<html>` — the concrete theme DaisyUI renders
+  (`light` or `dark`). In `system` mode this resolves against
+  `prefers-color-scheme` and live-updates if the OS theme changes.
+
+The default mode is `system`, so a fresh visitor sees their OS
+preference. The setter also exposes `window.cycleTheme()`, which cycles
+`system → light → dark` and persists the choice.
+
+Wire a toggle with htmx's nonced `hx-on` path (a raw inline
+`onclick="…"` would be blocked by the project's `script-src` CSP):
+
+```html
+<button class="btn btn-ghost btn-sm" hx-on:click="cycleTheme()">
+  Theme
+</button>
+```
+
+For the toggle to have a visible effect, define both a `light` and a
+`dark` palette (DaisyUI ships both by default — see the build-time
+palette section above).
+
+Projects that want different theming logic can override just
+`base/theme_init.html.jinja` instead of the whole skeleton.
+
 ## Per-tenant theming
 
 Multi-tenant Vibetuner apps often need per-tenant visual identity — at minimum
@@ -163,9 +202,11 @@ Vibetuner's `base/skeleton.html.jinja` already includes
 apps that haven't registered the provider see no extra markup.
 
 If you've replaced the skeleton wholesale in your project, mirror the same
-include order:
+include order — the no-flash setter goes *before* the stylesheet, the
+per-tenant overrides go *after* it:
 
 ```jinja
+{% include "base/theme_init.html.jinja" %}
 <link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
 {% include "base/theme.html.jinja" %}
 {% block head %}{% endblock head %}

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -26,6 +26,8 @@
            applies to existing projects on framework upgrade without
            rebuilding their CSS bundle. -#}
         <style nonce="{{ csp_nonce }}">html { scrollbar-gutter: stable; }</style>
+        {% include "base/theme_init.html.jinja" %}
+
         <link rel="stylesheet" href="{{ url_for('css', path='bundle.css').path }}" />
         {% include "base/theme.html.jinja" %}
 

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/theme_init.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/theme_init.html.jinja
@@ -1,0 +1,43 @@
+{# No-flash theme setter. Runs synchronously high in <head>, before
+   bundle.css, so `data-theme` is on <html> before first paint and the
+   page never flashes the wrong theme (FOUC / flash of inaccurate theme).
+
+   Behavior:
+   - reads the persisted preference from localStorage ('theme'), defaulting
+     to 'system';
+   - resolves 'system' against `prefers-color-scheme` and writes both
+     `data-theme` (the concrete light/dark theme DaisyUI renders) and
+     `data-theme-mode` (the chosen system/light/dark mode) on <html>;
+   - exposes `window.cycleTheme()` cycling system -> light -> dark;
+   - live-updates `data-theme` when the OS theme changes while in 'system'.
+
+   Nonced so it survives a strict `script-src` CSP. Projects that want
+   different theming logic can override just this partial. -#}
+<script nonce="{{ csp_nonce }}">
+    (function () {
+        var root = document.documentElement;
+        function osTheme() {
+            return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+        function apply(mode) {
+            root.setAttribute("data-theme", mode === "system" ? osTheme() : mode);
+            root.setAttribute("data-theme-mode", mode);
+        }
+        apply(localStorage.getItem("theme") || "system");
+        window.cycleTheme = function () {
+            var current = root.getAttribute("data-theme-mode");
+            var next = current === "system" ? "light" : current === "light" ? "dark" : "system";
+            if (next === "system") {
+                localStorage.removeItem("theme");
+            } else {
+                localStorage.setItem("theme", next);
+            }
+            apply(next);
+        };
+        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function () {
+            if (root.getAttribute("data-theme-mode") === "system") {
+                root.setAttribute("data-theme", osTheme());
+            }
+        });
+    })();
+</script>

--- a/vibetuner-py/tests/unit/test_skeleton_extension_points.py
+++ b/vibetuner-py/tests/unit/test_skeleton_extension_points.py
@@ -295,3 +295,32 @@ class TestScrollbarGutter:
         the cascade if a project chooses to override it."""
         out = _render(_make_env())
         assert out.index("scrollbar-gutter") < out.index("bundle.css")
+
+
+# ── no-flash theme setter ────────────────────────────────────────────
+
+
+class TestThemeInit:
+    def test_sets_data_theme_and_mode(self):
+        out = _render(_make_env())
+        assert 'setAttribute("data-theme"' in out
+        assert 'setAttribute("data-theme-mode"' in out
+
+    def test_exposes_cycle_theme(self):
+        out = _render(_make_env())
+        assert "window.cycleTheme" in out
+
+    def test_uses_csp_nonce(self):
+        """The inline setter must carry the nonce to pass script-src CSP."""
+        out = _render(_make_env())
+        cycle_idx = out.index("window.cycleTheme")
+        script_open = out.rfind("<script", 0, cycle_idx)
+        assert script_open != -1
+        script_close = out.index(">", script_open)
+        assert 'nonce="n"' in out[script_open:script_close]
+
+    def test_renders_before_bundle_css(self):
+        """The setter must run before the stylesheet so data-theme is on
+        <html> before first paint (no flash of inaccurate theme)."""
+        out = _render(_make_env())
+        assert out.index("window.cycleTheme") < out.index("bundle.css")

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -45,6 +45,25 @@ For per-request runtime overrides (per-tenant branding), use
 `register_tenant_theme_provider` — see the
 [theming guide](https://vibetuner.alltuner.com/theming/).
 
+## Light / dark / system toggle
+
+The skeleton ships a CSP-nonced no-flash setter
+(`base/theme_init.html.jinja`) that sets `data-theme` on `<html>` before
+first paint. Default mode is `system` (honors `prefers-color-scheme`);
+the choice persists in `localStorage['theme']`. It exposes
+`window.cycleTheme()` cycling `system → light → dark`.
+
+Wire a toggle with htmx's nonced `hx-on` (a raw inline `onclick` is
+blocked by `script-src`):
+
+```html
+<button class="btn btn-ghost btn-sm" hx-on:click="cycleTheme()">Theme</button>
+```
+
+Do **not** add your own `<head>` theme script — that's what the shipped
+setter is for. Override `base/theme_init.html.jinja` only if you need
+different logic.
+
 ## SSE
 
 **Import from `vibetuner.sse`** (NOT `vibetuner.frontend.sse`):


### PR DESCRIPTION
## What

Adds `base/theme_init.html.jinja` — a CSP-nonced inline script the framework skeleton runs **synchronously, before `bundle.css`** — so `data-theme` lands on `<html>` *before first paint*. No more flash of inaccurate theme (FOUC).

Behavior (faithful port of the reference implementation in #1942, formatted readably):

- reads the persisted preference from `localStorage['theme']`, defaulting to `system`;
- resolves `system` against `prefers-color-scheme`, writing both `data-theme` (concrete light/dark) and `data-theme-mode` (system/light/dark) on `<html>`;
- exposes `window.cycleTheme()` cycling `system → light → dark`;
- live-updates `data-theme` when the OS theme changes while in `system` mode.

Shipped as an **overridable include** (consistent with `base/theme.html.jinja`), so CSP-strict projects that want theming no longer need to override the whole skeleton.

## Behavior change (intentional)

DaisyUI ships `light`/`dark` with `light` as default and **no `prefersdark`**, so today every page paints `light`. With this setter always-on, projects start honoring OS dark-mode + `localStorage` the moment they upgrade. This was a deliberate call (always-on over a config flag).

## Wiring a toggle

`hx-on` keeps it CSP-safe (raw inline `onclick` would be blocked by `script-src`):

```html
<button class="btn btn-ghost btn-sm" hx-on:click="cycleTheme()">Theme</button>
```

## Tests

`TestThemeInit` in `test_skeleton_extension_points.py`: sets `data-theme`/`data-theme-mode`, exposes `window.cycleTheme`, carries the CSP nonce, renders before `bundle.css`. Full unit suite green (906 passed).

## Docs

Updated all four surfaces: `theming.md`, `llms.txt`, `llms-full.txt`, and the scaffold's `.claude/rules/frontend.md`.

Closes #1942

🤖 Generated with [Claude Code](https://claude.com/claude-code)