### PR TITLE
fix: pass coredis-compatible kwargs to the streaq worker

### DIFF
--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -584,7 +584,7 @@ vibetuner run prod worker --workers 4
 | Socket timeout | `REDIS_SOCKET_TIMEOUT` | `30` | Seconds before a hung Redis read raises (0 disables) |
 | Connect timeout | `REDIS_SOCKET_CONNECT_TIMEOUT` | `10` | Seconds before a Redis connect attempt gives up (0 disables) |
 | Keepalive | `REDIS_SOCKET_KEEPALIVE` | `true` | Enable TCP keepalive on the Redis connection |
-| Health check | `REDIS_HEALTH_CHECK_INTERVAL` | `30` | Seconds between PINGs on idle connections (0 disables) |
+| Idle recycling | `REDIS_HEALTH_CHECK_INTERVAL` | `30` | Seconds before an idle connection is recycled instead of reused (0 disables) |
 | Watchdog timeout | `WORKER_WATCHDOG_TIMEOUT` | `60` | Seconds of event-loop stall before the process force-exits (0 disables) |
 | Watchdog interval | `WORKER_WATCHDOG_INTERVAL` | `5` | Seconds between watchdog heartbeats/checks |
 

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -430,21 +430,25 @@ class CoreConfiguration(BaseSettings):
         return self.redis_url is not None
 
     @property
-    def redis_socket_kwargs(self) -> dict[str, Any]:
-        """Connection-resilience kwargs for long-lived Redis clients.
+    def worker_redis_kwargs(self) -> dict[str, Any]:
+        """Connection-resilience kwargs for the streaq worker's coredis client.
 
-        Passed through to the underlying redis-py client so a dead connection
-        raises instead of hanging the event loop. A timeout of 0 is omitted,
-        which redis-py treats as no timeout.
+        Streaq builds its Redis client with coredis, so these use coredis
+        kwarg names. ``stream_timeout`` turns a silently-dropped connection's
+        blocking read into a raised error instead of an indefinite hang, and
+        ``max_idle_time`` recycles long-idle connections so a stale one is
+        never reused. A timeout of 0 is omitted, which coredis treats as no
+        timeout.
         """
         kwargs: dict[str, Any] = {
             "socket_keepalive": self.redis_socket_keepalive,
-            "health_check_interval": self.redis_health_check_interval,
         }
         if self.redis_socket_timeout > 0:
-            kwargs["socket_timeout"] = self.redis_socket_timeout
+            kwargs["stream_timeout"] = self.redis_socket_timeout
         if self.redis_socket_connect_timeout > 0:
-            kwargs["socket_connect_timeout"] = self.redis_socket_connect_timeout
+            kwargs["connect_timeout"] = self.redis_socket_connect_timeout
+        if self.redis_health_check_interval > 0:
+            kwargs["max_idle_time"] = int(self.redis_health_check_interval)
         return kwargs
 
     @cached_property

--- a/vibetuner-py/src/vibetuner/tasks/worker.py
+++ b/vibetuner-py/src/vibetuner/tasks/worker.py
@@ -9,7 +9,7 @@ from vibetuner.tasks.lifespan import lifespan
 worker: Worker | None = (
     Worker(
         redis_url=str(settings.redis_url),
-        redis_kwargs=settings.redis_socket_kwargs,
+        redis_kwargs=settings.worker_redis_kwargs,
         queue_name=settings.redis_key_prefix.rstrip(":"),
         lifespan=lifespan,
         concurrency=settings.worker_concurrency,

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -173,31 +173,52 @@ class TestLoadProjectConfig:
             assert result.project_slug == "default_project"
 
 
-class TestRedisSocketKwargs:
-    """Test redis_socket_kwargs resilience options for long-lived clients."""
+class TestWorkerRedisKwargs:
+    """Test worker_redis_kwargs resilience options for the streaq coredis client."""
 
     def test_defaults_enable_resilience(self):
-        """By default, socket timeouts, keepalive and health checks are on."""
+        """By default, stream/connect timeouts, keepalive and idle recycling are on."""
         config = CoreConfiguration(project=ProjectConfiguration())
-        kwargs = config.redis_socket_kwargs
-        assert kwargs["socket_timeout"] == 30.0
-        assert kwargs["socket_connect_timeout"] == 10.0
+        kwargs = config.worker_redis_kwargs
+        assert kwargs["stream_timeout"] == 30.0
+        assert kwargs["connect_timeout"] == 10.0
         assert kwargs["socket_keepalive"] is True
-        assert kwargs["health_check_interval"] == 30.0
+        assert kwargs["max_idle_time"] == 30
 
-    def test_socket_timeout_disabled_when_zero(self):
-        """A zero socket_timeout is omitted so redis-py treats it as no timeout."""
+    def test_kwargs_accepted_by_coredis_connection(self):
+        """The kwargs must construct a coredis connection without raising.
+
+        Regression for the 10.19.0 startup crash: redis-py kwarg names
+        (health_check_interval, socket_timeout) reached streaq's coredis client
+        and coredis rejected them with a TypeError during lifespan startup.
+        """
+        from coredis.connection import TCPConnection, TCPLocation
+
+        config = CoreConfiguration(project=ProjectConfiguration())
+        location = TCPLocation(host="localhost", port=6379)
+        # Constructs the connection object (does not open a socket).
+        TCPConnection(location, **config.worker_redis_kwargs)
+
+    def test_stream_timeout_disabled_when_zero(self):
+        """A zero socket_timeout is omitted so coredis treats it as no timeout."""
         config = CoreConfiguration(
             project=ProjectConfiguration(), redis_socket_timeout=0
         )
-        assert "socket_timeout" not in config.redis_socket_kwargs
+        assert "stream_timeout" not in config.worker_redis_kwargs
 
     def test_connect_timeout_disabled_when_zero(self):
         """A zero socket_connect_timeout is omitted."""
         config = CoreConfiguration(
             project=ProjectConfiguration(), redis_socket_connect_timeout=0
         )
-        assert "socket_connect_timeout" not in config.redis_socket_kwargs
+        assert "connect_timeout" not in config.worker_redis_kwargs
+
+    def test_idle_recycling_disabled_when_zero(self):
+        """A zero health_check_interval omits max_idle_time."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(), redis_health_check_interval=0
+        )
+        assert "max_idle_time" not in config.worker_redis_kwargs
 
     def test_overrides_from_env_vars(self):
         """REDIS_SOCKET_* and REDIS_HEALTH_CHECK_INTERVAL env vars are honored."""
@@ -212,11 +233,11 @@ class TestRedisSocketKwargs:
             clear=False,
         ):
             config = CoreConfiguration(project=ProjectConfiguration())
-            kwargs = config.redis_socket_kwargs
-            assert kwargs["socket_timeout"] == 5.0
-            assert kwargs["socket_connect_timeout"] == 2.0
+            kwargs = config.worker_redis_kwargs
+            assert kwargs["stream_timeout"] == 5.0
+            assert kwargs["connect_timeout"] == 2.0
             assert kwargs["socket_keepalive"] is False
-            assert kwargs["health_check_interval"] == 15.0
+            assert kwargs["max_idle_time"] == 15
 
 
 class TestCoreConfigurationLocaleDetection:

--- a/vibetuner-py/tests/unit/test_worker.py
+++ b/vibetuner-py/tests/unit/test_worker.py
@@ -11,13 +11,13 @@ from unittest.mock import MagicMock, patch
 class TestWorkerConstruction:
     """Verify how the module-level worker is built from settings."""
 
-    def test_passes_redis_socket_kwargs(self):
+    def test_passes_worker_redis_kwargs(self):
         """The worker is constructed with the configured resilience kwargs."""
-        resilience = {"socket_timeout": 30.0, "socket_keepalive": True}
+        resilience = {"stream_timeout": 30.0, "socket_keepalive": True}
         fake_settings = MagicMock()
         fake_settings.workers_available = True
         fake_settings.redis_url = "redis://localhost:6379/0"
-        fake_settings.redis_socket_kwargs = resilience
+        fake_settings.worker_redis_kwargs = resilience
         fake_settings.redis_key_prefix = "myproject:"
         fake_settings.worker_concurrency = 16
 


### PR DESCRIPTION
## Summary

Fixes #1945 — on vibetuner 10.19.0+ the **frontend crashes during lifespan
startup** whenever `REDIS_URL` is set:

```
TypeError: BaseConnection.__init__() got an unexpected keyword argument 'health_check_interval'
```

## Root cause

The streaq worker is built with **coredis**, not redis-py, but
`redis_socket_kwargs` (added in #1936) assembled **redis-py-shaped** kwargs
(`health_check_interval`, `socket_timeout`, `socket_connect_timeout`). streaq
forwards `redis_kwargs` straight to `coredis.Redis.from_url(...)`, whose
connections reject the first foreign kwarg with the `TypeError` above.

The introducing PR's description assumed "streaq forwards these straight to
`Redis.from_url`" meaning redis-py's — but streaq 6.x uses coredis.

## Fix

Translate the resilience settings into coredis kwarg names in a renamed
`worker_redis_kwargs` property:

| Setting | redis-py (was) | coredis (now) |
|---|---|---|
| `REDIS_SOCKET_TIMEOUT` | `socket_timeout` | `stream_timeout` |
| `REDIS_SOCKET_CONNECT_TIMEOUT` | `socket_connect_timeout` | `connect_timeout` |
| `REDIS_SOCKET_KEEPALIVE` | `socket_keepalive` | `socket_keepalive` |
| `REDIS_HEALTH_CHECK_INTERVAL` | `health_check_interval` | `max_idle_time` |

coredis has no pre-use PING; `max_idle_time` (recycle long-idle connections) is
its closest analogue, so a stale connection is never reused. The critical
hang-into-error guard is `stream_timeout`. The user-facing `REDIS_*` env vars
are unchanged, so existing `.env` files keep working.

## Tests

- Renamed config/worker tests to the new property.
- Added a **regression test that constructs a real `coredis` connection** with
  the kwargs — guarding the exact boundary that crashed (no mock).

## Docs

- `background-tasks.md`: corrected the `REDIS_HEALTH_CHECK_INTERVAL` row
  (idle recycling, not PINGs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)