### PR TITLE
feat: log Resend rate-limit and quota response headers

### DIFF
--- a/vibetuner-docs/docs/authentication.md
+++ b/vibetuner-docs/docs/authentication.md
@@ -424,6 +424,20 @@ When multiple providers are configured, auto-detection prefers Resend, then
 Mailjet, then Cloudflare. Set `MAIL_PROVIDER=cloudflare` (or `resend` /
 `mailjet`) to pick explicitly.
 
+### Resend rate limits and quota
+
+Resend caps sends at 5 requests/second per team and enforces a monthly quota.
+When a send exceeds either limit, Resend returns HTTP 429 and the provider
+raises a `RateLimitError` — the send fails loudly rather than silently, so a
+burst of magic-link requests can surface errors. The framework does **not**
+retry or queue these; handle bursts upstream (for example, by sending mail from
+a background task) if you expect to approach 5 req/s.
+
+On every send the provider logs Resend's `ratelimit-*` and
+`x-resend-monthly-quota` response headers at `DEBUG`, and logs a `WARNING` with
+those headers when a `RateLimitError` is raised. Raise the log level to `DEBUG`
+to watch your remaining per-second budget and monthly usage.
+
 ### How It Works
 
 1. User enters email address

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -940,6 +940,17 @@ When multiple providers are configured, auto-detection prefers Resend, then
 Mailjet, then Cloudflare. Set `MAIL_PROVIDER=cloudflare` (or `resend` /
 `mailjet`) to pick explicitly.
 
+**Resend rate limits and quota**
+
+Resend caps sends at 5 requests/second per team and enforces a monthly quota.
+When a send exceeds either limit, Resend returns HTTP 429 and the provider
+raises a `RateLimitError` — the send fails loudly rather than silently. The
+framework does **not** retry or queue these; handle bursts upstream (for
+example, by sending mail from a background task) if you expect to approach
+5 req/s. On every send the provider logs Resend's `ratelimit-*` and
+`x-resend-monthly-quota` response headers at `DEBUG`, and logs a `WARNING` with
+those headers when a `RateLimitError` is raised.
+
 **How It Works**
 
 1. User enters email address

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -117,7 +117,11 @@ Important notes:
   `MAIL_MAILJET_API_SECRET`), or Cloudflare Email Service
   (`MAIL_CLOUDFLARE_API_TOKEN` + `MAIL_CLOUDFLARE_ACCOUNT_ID`). Auto-detected
   from available credentials; `MAIL_PROVIDER=resend|mailjet|cloudflare` to
-  pick explicitly. Auto-detection priority: resend > mailjet > cloudflare
+  pick explicitly. Auto-detection priority: resend > mailjet > cloudflare.
+  Resend caps sends at 5 req/s plus a monthly quota; on HTTP 429 the provider
+  raises `RateLimitError` (no retry/queue) and logs a `WARNING` with the
+  `ratelimit-*`/`x-resend-monthly-quota` headers, which are logged at `DEBUG`
+  on every send
 - **CSP Nonce Auto-Injection**: `SecurityHeadersMiddleware` generates a unique CSP nonce
   per request and auto-injects it into all `<script>` tags in HTML responses. Do NOT
   manually add `nonce=` attributes to `<script>` tags in templates, the middleware handles

--- a/vibetuner-py/src/vibetuner/services/email/resend.py
+++ b/vibetuner-py/src/vibetuner/services/email/resend.py
@@ -5,11 +5,31 @@ from typing import TYPE_CHECKING, Any, cast
 
 from asyncer import asyncify
 
+from vibetuner.logging import logger
 from vibetuner.services.email.base import EmailAddress, format_email_str
 
 
 if TYPE_CHECKING:
     from resend.emails._emails import Emails as _ResendEmails
+
+
+# Resend's per-send rate-limit and quota signals. Informational on a successful
+# send and populated on a RateLimitError; the rest of the response headers carry
+# nothing relevant to limit observability.
+_RATE_LIMIT_HEADERS = (
+    "ratelimit-limit",
+    "ratelimit-remaining",
+    "ratelimit-reset",
+    "ratelimit-policy",
+    "x-resend-monthly-quota",
+)
+
+
+def _rate_limit_info(headers: dict[str, str] | None) -> dict[str, str]:
+    """Pick the rate-limit/quota headers out of a Resend response."""
+    if not headers:
+        return {}
+    return {key: headers[key] for key in _RATE_LIMIT_HEADERS if key in headers}
 
 
 class ResendEmailProvider:
@@ -30,6 +50,8 @@ class ResendEmailProvider:
         text_body: str,
         tags: dict[str, str] | None = None,
     ) -> dict[str, Any]:
+        from resend.exceptions import RateLimitError
+
         params: dict[str, Any] = {
             "from": format_email_str(from_addr),
             "to": [format_email_str(to_addr)],
@@ -40,5 +62,19 @@ class ResendEmailProvider:
         if tags:
             params["tags"] = [{"name": k, "value": v} for k, v in tags.items()]
         send_params = cast("_ResendEmails.SendParams", params)
-        result = await asyncify(self._resend.Emails.send)(send_params)
-        return dict(result)
+        try:
+            result = await asyncify(self._resend.Emails.send)(send_params)
+        except RateLimitError as exc:
+            logger.warning(
+                "Resend rate limit hit ({}): {}",
+                exc.error_type,
+                _rate_limit_info(exc.headers),
+            )
+            raise
+        result_dict = dict(result)
+        info = _rate_limit_info(
+            cast("dict[str, str] | None", result_dict.get("http_headers"))
+        )
+        if info:
+            logger.debug("Resend rate limit status: {}", info)
+        return result_dict

--- a/vibetuner-py/tests/unit/test_email_service.py
+++ b/vibetuner-py/tests/unit/test_email_service.py
@@ -123,6 +123,84 @@ async def test_resend_send_named_addresses(resend_provider):
         assert call_params["to"] == ["John Doe <john@example.com>"]
 
 
+@pytest.mark.asyncio
+async def test_resend_send_logs_rate_limit_headers(resend_provider, log_sink):
+    """Resend's ratelimit/quota response headers are logged at DEBUG."""
+    mock_result = {
+        "id": "abc123",
+        "http_headers": {
+            "ratelimit-limit": "5",
+            "ratelimit-remaining": "4",
+            "ratelimit-reset": "1",
+            "x-resend-monthly-quota": "1",
+            "content-type": "application/json",
+        },
+    }
+
+    with patch("vibetuner.services.email.resend.asyncify") as mock_asyncify:
+        mock_asyncify.return_value = AsyncMock(return_value=mock_result)
+
+        await resend_provider.send(
+            from_addr="sender@example.com",
+            to_addr="recipient@example.com",
+            subject="Test",
+            html_body="<p>Hi</p>",
+            text_body="Hi",
+        )
+
+    logged = "".join(log_sink)
+    assert "ratelimit-remaining" in logged
+    assert "x-resend-monthly-quota" in logged
+    # Only the rate-limit headers are surfaced, not unrelated response headers.
+    assert "content-type" not in logged
+
+
+@pytest.mark.asyncio
+async def test_resend_send_no_log_without_rate_limit_headers(resend_provider, log_sink):
+    """No rate-limit log line is emitted when the headers are absent."""
+    with patch("vibetuner.services.email.resend.asyncify") as mock_asyncify:
+        mock_asyncify.return_value = AsyncMock(return_value={"id": "abc123"})
+
+        await resend_provider.send(
+            from_addr="sender@example.com",
+            to_addr="recipient@example.com",
+            subject="Test",
+            html_body="<p>Hi</p>",
+            text_body="Hi",
+        )
+
+    assert not any("ratelimit" in m for m in log_sink)
+
+
+@pytest.mark.asyncio
+async def test_resend_send_warns_and_reraises_on_rate_limit(resend_provider, log_sink):
+    """A Resend RateLimitError is logged at WARNING with its headers, then re-raised."""
+    from resend.exceptions import RateLimitError
+
+    error = RateLimitError(
+        message="Too many requests.",
+        error_type="rate_limit_exceeded",
+        code=429,
+        headers={"ratelimit-remaining": "0", "ratelimit-reset": "1"},
+    )
+
+    with patch("vibetuner.services.email.resend.asyncify") as mock_asyncify:
+        mock_asyncify.return_value = AsyncMock(side_effect=error)
+
+        with pytest.raises(RateLimitError):
+            await resend_provider.send(
+                from_addr="sender@example.com",
+                to_addr="recipient@example.com",
+                subject="Test",
+                html_body="<p>Hi</p>",
+                text_body="Hi",
+            )
+
+    warnings = [m for m in log_sink if "WARNING" in m]
+    assert any("rate limit" in m.lower() for m in warnings)
+    assert any("ratelimit-remaining" in m for m in warnings)
+
+
 # ── MailjetEmailProvider tests ───────────────────────────────────────
 
 

--- a/vibetuner-template/.claude/rules/development.md
+++ b/vibetuner-template/.claude/rules/development.md
@@ -68,7 +68,10 @@ No registration needed — just import where used. Email via
 `vibetuner.services.email.EmailService`. Configure with
 `MAIL_RESEND_API_KEY`, `MAIL_MAILJET_API_KEY` /
 `MAIL_MAILJET_API_SECRET`, or `MAIL_CLOUDFLARE_API_TOKEN` /
-`MAIL_CLOUDFLARE_ACCOUNT_ID` (public beta) in `.env`.
+`MAIL_CLOUDFLARE_ACCOUNT_ID` (public beta) in `.env`. Resend caps sends at
+5 req/s plus a monthly quota; on 429 the provider raises `RateLimitError`
+(no retry/queue) and logs the `ratelimit-*` / `x-resend-monthly-quota`
+headers.
 
 ## Template Filters
 


### PR DESCRIPTION
Closes #1948.

## What

The Resend provider previously discarded the `ratelimit-*` and
`x-resend-monthly-quota` response headers Resend returns on every send.
This adds observability:

- **Successful send:** log the rate-limit/quota headers at `DEBUG`.
- **`RateLimitError`:** log a `WARNING` with those headers, then re-raise.

## Why this scope (and not more)

Investigating #1948 turned up that its core premise was partly wrong: the
Resend SDK already raises `RateLimitError` (a `ResendError` subclass) on
HTTP 429 for `rate_limit_exceeded` / `daily_quota_exceeded` /
`monthly_quota_exceeded`. So hitting the cap fails **loudly** — it does not
silently show a success page. The only real gap was early-warning
observability.

The issue's "warn when monthly quota is low" idea isn't well-supported by
the headers: `x-resend-monthly-quota` is a *used* count with no companion
limit/remaining header, and `ratelimit-remaining` is a per-second window
that resets every second — there's nothing reliably actionable to threshold
on. So this is log-only: no false-alarm thresholds, no retry/backoff (the
SDK raises a typed error; retrying on the synchronous magic-link auth path
would just add latency).

## Docs

Updated `authentication.md`, `llms.txt`, `llms-full.txt`, and the template's
`.claude/rules/development.md`.

## Tests

Added three unit tests (headers logged at DEBUG, no log when headers absent,
WARNING + re-raise on `RateLimitError`). Full unit suite green (911 passed).

## Follow-up (out of scope)

The provider calls the SDK's sync `Emails.send` via `asyncify` rather than
the native `send_async`. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)