### PR TITLE
docs: note Beanie class-level query false positives in ty

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -228,6 +228,23 @@ class Post(Document):
 
 No `__init__.py` registration needed. The framework auto-discovers Beanie Documents.
 
+!!! note "Beanie class-level queries and `ty`"
+    Beanie builds queries from class-level field access (`Post.title == "x"`,
+    `Eq(cls.author.id, user.id)`). Static type checkers don't model this: `ty`
+    resolves `Model.field` from the field's *instance* annotation, not as a
+    query expression. Most comparisons type-check fine, but two patterns surface
+    a spurious `unresolved-attribute` from `just lint`. The first is an optional
+    link used in a query: `field: Link[X] | None` with `cls.field.id` reports
+    `id is not defined on None`. This one is fundamental, since `ty` rejects
+    attribute access on any `X | None`, so it can't be fixed by changing the
+    field type or the `Link` alias. The second is a query inside a classmethod
+    on a non-`Document` mixin (a `BaseModel` mixin), where `cls.find` and
+    `cls.field` aren't known to the checker.
+    Silence these on the exact line with an inline directive, e.g.
+    `await cls.find_one(Eq(cls.author.id, user.id))  # ty: ignore[unresolved-attribute]`.
+    `ty` flags directives that stop matching (`unused-ignore-comment`), so keep
+    the comment on the line that errors and drop it once it's no longer needed.
+
 #### SQL (SQLModel)
 
 ```python

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -257,6 +257,22 @@ class Post(Document):
         name = "posts"
 ```
 
+Beanie builds queries from class-level field access (`Post.title == "x"`,
+`Eq(cls.author.id, user.id)`), which static checkers don't model: `ty` resolves
+`Model.field` from the field's instance annotation, not as a query expression.
+Most comparisons type-check, but two patterns trip a spurious `unresolved-attribute`
+in `just lint`: an optional link in a query (`field: Link[X] | None` with
+`cls.field.id` → `id is not defined on None`, fundamental to how `ty` treats
+`X | None`, not fixable via field/alias changes), and queries inside a classmethod
+on a non-`Document` (`BaseModel`) mixin. Silence on the exact line:
+
+```python
+return await cls.find_one(Eq(cls.author.id, user.id))  # ty: ignore[unresolved-attribute]
+```
+
+`ty` reports directives that stop matching (`unused-ignore-comment`), so keep the
+comment on the erroring line and remove it when no longer needed.
+
 **SQL (SQLModel)**
 
 ```python

--- a/vibetuner-template/.claude/rules/development.md
+++ b/vibetuner-template/.claude/rules/development.md
@@ -53,6 +53,15 @@ class Post(Document, TimeStampMixin):
 
 Export from `__init__.py`, list in `tune.py` `models=[]`.
 
+**`ty` and class-level queries**: `ty` doesn't model Beanie's class-level
+query access, so `just lint` flags spurious `unresolved-attribute` for an
+optional link in a query (`field: Link[X] | None` → `cls.field.id`) and for
+queries in a classmethod on a `BaseModel` mixin. This is a checker gap, not a
+bug; don't change field types or the `Link` alias to chase it (the `| None`
+error is fundamental to how `ty` treats unions). Suppress on the exact line:
+`await cls.find_one(Eq(cls.author.id, x))  # ty: ignore[unresolved-attribute]`.
+`ty` flags unused directives, so keep them on the erroring line only.
+
 **Soft delete**: Use `DocumentWithSoftDelete` instead of `Document`.
 `delete()` sets `deleted_at`, queries auto-filter deleted docs.
 `hard_delete()` for permanent removal.

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -244,6 +244,13 @@ class Post(Document, TimeStampMixin):
 
 Export from `__init__.py`, list in `tune.py` `models=[]`.
 
+`just lint` (`ty`) reports spurious `unresolved-attribute` on Beanie
+class-level queries: an optional link in a query
+(`field: Link[X] | None` with `cls.field.id`) or a query in a classmethod
+on a `BaseModel` mixin. It's a checker gap, not a bug; don't rework field
+types or the `Link` alias. Suppress on the erroring line with
+`# ty: ignore[unresolved-attribute]`.
+
 For detailed patterns (soft delete, encrypted fields, CRUD factory,
 SSE, HTMX helpers, caching, background tasks, deployment, testing,
 configuration, localization), see


### PR DESCRIPTION
## What

Documents the `ty` `unresolved-attribute` false positives on Beanie class-level
query access (issue #1954), plus the per-line escape hatch.

## Why the "real fix" isn't shipped here

I investigated the issue's requests empirically (ty 0.0.35, beanie 2.1.0):

- **Typed query descriptors (item 1): infeasible.** ty has no plugin system,
  beanie 2.1.0 ships no class-level query descriptors, and ty resolves
  `Model.field` from the field's *instance* annotation.
- **Changing the `Link` alias (item 2): counterproductive.** The `| None`
  attribute error is fundamental — ty rejects attribute access on *any*
  `X | None` (even `Any | None`). The current `_T` TypeAlias is already optimal:
  it silences non-optional link access *and* preserves instance assignment. A
  real generic `Link` class fixes nothing and breaks instance assignment.

So the genuine false positives reduce to two patterns, and the actionable
deliverable is documentation (items 3/4):

1. An optional link in a query: `field: Link[X] | None` with `cls.field.id`.
2. A query in a classmethod on a non-`Document` `BaseModel` mixin.

## Changes

Adds a note + the `# ty: ignore[unresolved-attribute]` escape hatch (and that ty
flags unused directives) to:

- `vibetuner-docs/docs/development-guide.md` (Beanie ODM section)
- `vibetuner-docs/docs/llms-full.txt`
- `vibetuner-template/.claude/rules/development.md`
- `vibetuner-template/AGENTS.md`

Per maintainer decision, no `ty.toml` change and no `types.py` change.

Closes #1954

🤖 Generated with [Claude Code](https://claude.com/claude-code)