### PR TITLE
feat: support TEST_MONGODB_URL for isolated local test runs

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -2061,7 +2061,27 @@ async def test_create_post(vibetuner_db):
     assert await Post.get(post.id) is not None
 ```
 
-Skips the test automatically if `MONGODB_URL` is not set.
+The throwaway database is created on the configured Mongo **server**. By
+default that is `MONGODB_URL`, so if your `.env` points at a remote or
+production cluster the suite reaches that infrastructure (slow, and not
+isolated). Set `TEST_MONGODB_URL` to keep tests on a local Mongo while
+`MONGODB_URL` stays pointed at your app's database:
+
+```bash
+# .env (or .env.local)
+MONGODB_URL=mongodb://prod-cluster.internal:27017/
+TEST_MONGODB_URL=mongodb://localhost:27017/
+```
+
+```bash
+# Or stand up a throwaway local Mongo just for the suite
+docker run -d --rm -p 27017:27017 mongo:7
+TEST_MONGODB_URL=mongodb://localhost:27017/ pytest
+```
+
+When `TEST_MONGODB_URL` is unset the fixtures fall back to `MONGODB_URL`,
+and the session start logs the resolved server and throwaway database name.
+The test is skipped when neither variable is set.
 
 **Caveats:**
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1965,7 +1965,7 @@ auto-discovered.
 |---------|-------------|
 | `vibetuner_client` | Async HTTP test client with full middleware |
 | `vibetuner_app` | The FastAPI app instance (override for custom apps) |
-| `vibetuner_db` | Session-scoped MongoDB DB; collections truncated per test |
+| `vibetuner_db` | Session-scoped MongoDB DB on `TEST_MONGODB_URL` (falls back to `MONGODB_URL`); collections truncated per test |
 | `mock_auth` | Mock authentication without real sessions |
 | `mock_tasks` | Mock background tasks without Redis |
 | `override_config` | Override RuntimeConfig values with auto-cleanup |
@@ -1998,6 +1998,31 @@ async def test_feature_flag(override_config):
     value = await RuntimeConfig.get("features.dark_mode")
     assert value is True
 ```
+
+**Running tests against a local Mongo:**
+
+The `vibetuner_db` fixture creates a uniquely-named throwaway database on the
+configured Mongo *server* and builds indexes there once per session. It targets
+the server pointed at by `MONGODB_URL` unless `TEST_MONGODB_URL` is set, in which
+case that wins. So if your `.env` points `MONGODB_URL` at a remote/production
+cluster, set `TEST_MONGODB_URL` to a local Mongo to keep the suite fast and off
+prod infrastructure — no per-invocation env juggling:
+
+```bash
+# .env (or .env.local) — prod stays for the app, tests use local Mongo
+MONGODB_URL=mongodb://prod-cluster.internal:27017/
+TEST_MONGODB_URL=mongodb://localhost:27017/
+```
+
+```bash
+# Or spin up a throwaway local Mongo just for the suite
+docker run -d --rm -p 27017:27017 mongo:7
+TEST_MONGODB_URL=mongodb://localhost:27017/ pytest
+```
+
+The session start logs the resolved server and throwaway database name, so it is
+always obvious where the test database is being created. The suite is skipped
+entirely when neither `TEST_MONGODB_URL` nor `MONGODB_URL` is set.
 
 ### Default Language Configuration
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -185,7 +185,8 @@ Important notes:
   block on secret keys showing the env-var name, CLI command, and `.env`
   entry, with a worker/frontend restart reminder
 - **Testing Fixtures**: `vibetuner_client`, `mock_auth`, `mock_tasks`,
-  `override_config`, `vibetuner_db` pytest fixtures
+  `override_config`, `vibetuner_db` pytest fixtures. Set `TEST_MONGODB_URL` to
+  run the suite against a local Mongo while `MONGODB_URL` stays pointed at prod
 - **Error Messages**: Actionable error messages with env var examples, Docker
   commands, and documentation links
 - **Docker Builds**: Production Docker image builds (linux/amd64) via

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -304,6 +304,11 @@ class CoreConfiguration(BaseSettings):
     redis_url: RedisDsn | None = None
     database_url: PostgresDsn | MariaDBDsn | MySQLDsn | SQLiteDsn | None = None
 
+    # Optional test-only MongoDB DSN. When set, the pytest fixtures target this
+    # server instead of ``mongodb_url`` so a project whose ``.env`` points at a
+    # remote/production cluster can still run its suite against a local Mongo.
+    test_mongodb_url: MongoDsn | None = None
+
     # Mail provider settings (MAIL_* env vars)
     mail: MailSettings = Field(default_factory=MailSettings)
 
@@ -450,6 +455,16 @@ class CoreConfiguration(BaseSettings):
         if self.redis_health_check_interval > 0:
             kwargs["max_idle_time"] = int(self.redis_health_check_interval)
         return kwargs
+
+    @property
+    def resolved_test_mongodb_url(self) -> MongoDsn | None:
+        """MongoDB server the test fixtures target.
+
+        Prefers ``test_mongodb_url`` (``TEST_MONGODB_URL``) when set so a
+        prod-pointing ``mongodb_url`` stays out of the test path, falling back
+        to ``mongodb_url`` otherwise.
+        """
+        return self.test_mongodb_url or self.mongodb_url
 
     @cached_property
     def mongo_dbname(self) -> str:

--- a/vibetuner-py/src/vibetuner/mongo.py
+++ b/vibetuner-py/src/vibetuner/mongo.py
@@ -17,14 +17,28 @@ BeanieDocumentType = type[Document] | type[UnionDoc] | type[View]
 
 
 def _mongo_endpoint(url: object) -> str:
-    """Return a ``host:port`` string for log messages, or ``"unknown"``."""
+    """Return a ``host:port`` string for log messages, or ``"unknown"``.
+
+    ``MongoDsn`` is a multi-host URL: it carries its hosts in ``hosts()``
+    rather than ``.host``/``.port``, so single-host DSN types are handled
+    first and multi-host DSNs fall back to joining every ``host:port`` pair.
+    """
     if url is None:
         return "unknown"
     host = getattr(url, "host", None)
     port = getattr(url, "port", None)
-    if host is None:
-        return "unknown"
-    return f"{host}:{port}" if port is not None else str(host)
+    if host is not None:
+        return f"{host}:{port}" if port is not None else str(host)
+    hosts = getattr(url, "hosts", None)
+    if callable(hosts):
+        parts = [
+            f"{h['host']}:{h['port']}" if h.get("port") is not None else str(h["host"])
+            for h in hosts()
+            if h.get("host")
+        ]
+        if parts:
+            return ",".join(parts)
+    return "unknown"
 
 
 # Global singleton, created lazily

--- a/vibetuner-py/src/vibetuner/testing.py
+++ b/vibetuner-py/src/vibetuner/testing.py
@@ -14,6 +14,7 @@ from pymongo.asynchronous.database import AsyncDatabase
 from starlette.authentication import AuthCredentials
 
 from vibetuner.frontend.oauth import WebUser
+from vibetuner.logging import logger
 from vibetuner.runtime_config import RuntimeConfig
 
 
@@ -79,27 +80,44 @@ async def _vibetuner_db_session() -> AsyncGenerator[str, None]:
     so the only thing shared across tests is the database itself
     (collections + indexes living server-side).
 
-    Skips the session if ``MONGODB_URL`` is not set.
+    The throwaway database is created on ``TEST_MONGODB_URL`` when set,
+    otherwise on ``MONGODB_URL``. Pointing ``TEST_MONGODB_URL`` at a local
+    Mongo keeps the suite off a prod-pointing ``MONGODB_URL``. The resolved
+    server and database name are logged at session start so it is obvious
+    where the throwaway database lives.
+
+    Skips the session if neither ``TEST_MONGODB_URL`` nor ``MONGODB_URL`` is
+    set.
     """
     from beanie import init_beanie
 
     from vibetuner.config import settings
-    from vibetuner.mongo import get_all_models
+    from vibetuner.mongo import _mongo_endpoint, get_all_models
 
-    if settings.mongodb_url is None:
-        pytest.skip("MongoDB not configured (MONGODB_URL not set)")
+    test_url = settings.resolved_test_mongodb_url
+    if test_url is None:
+        pytest.skip("MongoDB not configured (set TEST_MONGODB_URL or MONGODB_URL)")
 
     worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
     test_db_name = f"test_{worker_id}_{uuid.uuid4().hex[:8]}"
 
-    # Make every consumer of ``settings.mongo_dbname`` (framework code,
-    # user code) target the session test database for the whole run.
+    logger.info(
+        "Test MongoDB session: creating throwaway database {!r} on {}",
+        test_db_name,
+        _mongo_endpoint(test_url),
+    )
+
+    # Redirect every consumer of ``settings.mongodb_url`` (framework code via
+    # ``_ensure_client``, user code) and ``settings.mongo_dbname`` at the test
+    # server + throwaway database for the whole run.
+    original_url = settings.mongodb_url
+    settings.mongodb_url = test_url
     original = type(settings).mongo_dbname
     type(settings).mongo_dbname = property(lambda self: test_db_name)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     settings.__dict__.pop("mongo_dbname", None)
 
     session_client: AsyncMongoClient = AsyncMongoClient(
-        host=str(settings.mongodb_url),
+        host=str(test_url),
         compressors=["zstd"],
     )
     try:
@@ -113,6 +131,7 @@ async def _vibetuner_db_session() -> AsyncGenerator[str, None]:
             await session_client.drop_database(test_db_name)
         finally:
             await session_client.close()
+            settings.mongodb_url = original_url
             type(settings).mongo_dbname = original  # type: ignore[assignment]
             settings.__dict__.pop("mongo_dbname", None)
 

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -160,6 +160,40 @@ class TestLocaleDetectionSettings:
         assert settings.accept_language is False
 
 
+class TestResolvedTestMongodbUrl:
+    """Test resolved_test_mongodb_url fallback for the test fixtures."""
+
+    def test_falls_back_to_mongodb_url_when_test_url_unset(self):
+        """Without TEST_MONGODB_URL, tests target the production mongodb_url."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(),
+            mongodb_url="mongodb://prod-host:27017/",
+        )
+        assert str(config.resolved_test_mongodb_url) == "mongodb://prod-host:27017/"
+
+    def test_prefers_test_url_when_set(self):
+        """TEST_MONGODB_URL wins over mongodb_url so a prod .env stays isolated."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(),
+            mongodb_url="mongodb://prod-host:27017/",
+            test_mongodb_url="mongodb://localhost:27018/",
+        )
+        assert str(config.resolved_test_mongodb_url) == "mongodb://localhost:27018/"
+
+    def test_is_none_when_neither_set(self):
+        """Resolves to None when no Mongo URL is configured at all."""
+        config = CoreConfiguration(project=ProjectConfiguration())
+        assert config.resolved_test_mongodb_url is None
+
+    def test_test_url_from_env_var(self):
+        """test_mongodb_url is read from the TEST_MONGODB_URL env var."""
+        with patch.dict(
+            "os.environ", {"TEST_MONGODB_URL": "mongodb://localhost:27018/"}
+        ):
+            config = CoreConfiguration(project=ProjectConfiguration())
+            assert str(config.resolved_test_mongodb_url) == "mongodb://localhost:27018/"
+
+
 class TestLoadProjectConfig:
     """Test _load_project_config behavior outside a project directory."""
 

--- a/vibetuner-py/tests/unit/test_mongo_init_warning.py
+++ b/vibetuner-py/tests/unit/test_mongo_init_warning.py
@@ -80,3 +80,29 @@ async def test_logs_error_on_connection_failure():
         assert "Failed to connect to MongoDB" in error_msg
         fmt_args = mock_logger.error.call_args[0]
         assert "mongo.example.com:27017" in fmt_args[1]
+
+
+class TestMongoEndpoint:
+    """_mongo_endpoint must resolve a host:port from real DSN types."""
+
+    def test_resolves_single_host_mongodsn(self):
+        """MongoDsn exposes hosts via hosts(), not .host/.port."""
+        from pydantic import MongoDsn
+        from vibetuner.mongo import _mongo_endpoint
+
+        assert (
+            _mongo_endpoint(MongoDsn("mongodb://localhost:27018/")) == "localhost:27018"
+        )
+
+    def test_resolves_multi_host_mongodsn(self):
+        """A replica-set DSN lists every host."""
+        from pydantic import MongoDsn
+        from vibetuner.mongo import _mongo_endpoint
+
+        endpoint = _mongo_endpoint(MongoDsn("mongodb://a:27017,b:27018/"))
+        assert endpoint == "a:27017,b:27018"
+
+    def test_returns_unknown_for_none(self):
+        from vibetuner.mongo import _mongo_endpoint
+
+        assert _mongo_endpoint(None) == "unknown"

--- a/vibetuner-template/.claude/rules/testing.md
+++ b/vibetuner-template/.claude/rules/testing.md
@@ -19,5 +19,12 @@ async def test_dashboard(vibetuner_client, mock_auth):
     assert resp.status_code == 200
 ```
 
+`vibetuner_db` creates a throwaway database on the configured Mongo
+*server* (it never touches your project DB). It targets `MONGODB_URL`
+unless `TEST_MONGODB_URL` is set. If `.env` points `MONGODB_URL` at a
+remote/prod cluster, set `TEST_MONGODB_URL=mongodb://localhost:27017/`
+so the suite runs locally instead of reaching prod. The session start
+logs the resolved server + DB name.
+
 Dev server must be running (`just local-all`). Playwright MCP available
 at `http://localhost:8000`.


### PR DESCRIPTION
## Summary

Closes #1953.

The `vibetuner_db` pytest fixtures create a uniquely-named throwaway database on the Mongo **server** pointed at by `MONGODB_URL`. For a project whose `.env` points at a remote/production cluster, running the suite reaches prod infrastructure to create/drop databases and build indexes — slow (WAN/Tailscale latency reads like a hang) and quietly non-isolated.

This adds an opt-in test DSN and makes the resolution visible.

## Changes

- **`TEST_MONGODB_URL` setting** (`config.py`): new `test_mongodb_url` field plus a `resolved_test_mongodb_url` property that prefers it and falls back to `MONGODB_URL`. A project can keep a prod-pointing `MONGODB_URL` and point tests at a local Mongo with zero per-invocation env juggling.
- **Fixtures** (`testing.py`): `_vibetuner_db_session` targets the resolved test DSN for both the session client and `_ensure_client`, and **logs the resolved server + throwaway DB name** at session start. Skips only when neither variable is set.
- **Bug fix** (`mongo.py`): `_mongo_endpoint` never resolved `MongoDsn` (a multi-host URL carries hosts in `hosts()`, not `.host`/`.port`) — it always logged `"unknown"`, including in the existing connection-failure error. Now handles both single- and multi-host DSNs.
- **Docs**: `development-guide.md`, `llms.txt`, `llms-full.txt`, and the scaffold `testing.md` rule.

`TEST_REDIS_URL` was intentionally left out — no provided fixture connects to Redis live (it's mocked via `mock_tasks`), so the config would be dead plumbing.

## Testing

- 918 unit tests pass; `ty` clean; markdown lint clean. New: 4 config-resolution tests, 3 `_mongo_endpoint` tests (TDD).
- Verified end-to-end against a live Mongo on `localhost:27018` with `MONGODB_URL` pointed at an unreachable host — insert/read succeeded, proving the test DSN wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)