### PR TITLE
fix: disable msgmerge fuzzy matching in i18n recipes

### DIFF
--- a/.justfiles/i18n.justfile
+++ b/.justfiles/i18n.justfile
@@ -36,9 +36,31 @@ new-framework-locale LANG:
 [group('localization')]
 update-framework-locales:
     @cd vibetuner-py && find src/vibetuner/locales -type f -path "*/LC_MESSAGES/messages.po" \
-        -exec sh -c 'echo " ↺ {}"; msguniq "{}" -o "{}"; msgmerge --add-location=file --update --backup=none --previous "{}" src/vibetuner/locales/messages.pot' \;
+        -exec sh -c 'echo " ↺ {}"; msguniq "{}" -o "{}"; msgmerge --add-location=file --no-fuzzy-matching --update --backup=none --previous "{}" src/vibetuner/locales/messages.pot' \;
 
 # Compile framework .po files to .mo files (the wheel ships .mo only)
 [group('localization')]
 compile-framework-locales:
     @cd vibetuner-py && uv run --frozen pybabel compile -d src/vibetuner/locales
+
+# Report any fuzzy-marked entries across framework catalogs (gettext ignores them at runtime)
+[group('localization')]
+i18n-framework-fuzzy-audit:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    found=0
+    for po in $(find vibetuner-py/src/vibetuner/locales -type f -path "*/LC_MESSAGES/messages.po"); do
+        count=$(grep -c '^#, fuzzy' "${po}" || true)
+        if [ "${count}" -gt 0 ]; then
+            echo " ⚠ ${po}: ${count} fuzzy entr$([ "${count}" -eq 1 ] && echo y || echo ies)"
+            found=$((found + count))
+        fi
+    done
+
+    if [ "${found}" -eq 0 ]; then
+        echo "✓ No fuzzy entries found"
+    else
+        echo "Found ${found} fuzzy entr$([ "${found}" -eq 1 ] && echo y || echo ies); review the listed catalogs."
+        exit 1
+    fi

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -120,7 +120,16 @@ just update-locale-files     # Update existing .po files
 just compile-locales         # Compile .po to .mo files
 just new-locale LANG         # Create new language (e.g., just new-locale es)
 just dump-untranslated DIR   # Export untranslated strings
+just i18n-fuzzy-audit        # Report any fuzzy-marked entries across catalogs
 ```
+
+`update-locale-files` runs `msgmerge --no-fuzzy-matching`, so new or
+changed strings land with an empty `msgstr` (an honest "untranslated"
+that falls back to the English `msgid`) rather than a confident wrong
+guess copied from a textually similar entry. Run `just i18n-fuzzy-audit`
+to find any leftover `#, fuzzy` entries — gettext ignores them at
+runtime, but they read as real translations in the `.po` file and should
+be cleaned up.
 
 ### CI/CD & Deployment
 
@@ -1253,6 +1262,11 @@ just compile-framework-locales       # produce messages.mo
 The full workflow is also wrapped as `just i18n-framework`. Both `.po`
 and `.mo` files are committed to the repo so end users don't need
 `pybabel` at install time — the wheel ships the `.mo` files directly.
+
+`update-framework-locales` uses `msgmerge --no-fuzzy-matching` so new
+strings stay empty rather than inheriting a wrong guess from a similar
+entry; `just i18n-framework-fuzzy-audit` reports any `#, fuzzy` entries
+in the framework catalogs.
 
 ### Extracting Translations
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -146,7 +146,12 @@ just extract-translations    # Extract translatable strings
 just update-locale-files     # Update existing .po files
 just compile-locales         # Compile .po to .mo files
 just new-locale LANG         # Create new language (e.g., just new-locale es)
+just i18n-fuzzy-audit        # Report fuzzy-marked entries across catalogs
 ```
+
+`update-locale-files` runs `msgmerge --no-fuzzy-matching`: new strings
+land with an empty `msgstr` (honest untranslated → English fallback)
+instead of a wrong guess copied from a textually similar entry.
 
 **CI/CD & Deployment:**
 
@@ -1713,7 +1718,7 @@ just new-framework-locale es
 # Edit the new file:
 #   vibetuner-py/src/vibetuner/locales/es/LC_MESSAGES/messages.po
 
-# Merge new msgids into existing locales (fuzzy-marks ambiguous ones)
+# Merge new msgids into existing locales (new strings stay empty, no fuzzy guesses)
 just update-framework-locales
 
 # Compile every locale's .po to .mo so the wheel ships them
@@ -1721,6 +1726,9 @@ just compile-framework-locales
 
 # Or run all four in sequence
 just i18n-framework
+
+# Report any fuzzy-marked entries left in the catalogs
+just i18n-framework-fuzzy-audit
 ```
 
 Both `.po` and `.mo` files are committed to the repo. The wheel build
@@ -1742,8 +1750,10 @@ compilation step.
 
 If you add a new `_()` call to any framework template or to
 framework Python code, re-run `just i18n-framework` so the existing
-locales get the new msgid (English defaults to the msgid; non-English
-locales get a fuzzy entry waiting for translation).
+locales get the new msgid. The merge uses `msgmerge --no-fuzzy-matching`,
+so new strings land with an empty `msgstr` (English falls back to the
+msgid; non-English locales get a blank entry waiting for translation)
+instead of a fuzzy guess copied from a similar string.
 
 ### Brand Configuration
 

--- a/vibetuner-template/.justfiles/i18n.justfile
+++ b/vibetuner-template/.justfiles/i18n.justfile
@@ -16,12 +16,34 @@ new-locale LANG:
 # Updates existing language files for localization
 [group('localization')]
 update-locale-files:
-    @find locales -type f -path "*/LC_MESSAGES/messages.po" -exec sh -c 'echo " ↺ {}"; msguniq "{}" -o "{}"; msgmerge --add-location=file --update --backup=none --previous "{}" locales/messages.pot' \;
+    @find locales -type f -path "*/LC_MESSAGES/messages.po" -exec sh -c 'echo " ↺ {}"; msguniq "{}" -o "{}"; msgmerge --add-location=file --no-fuzzy-matching --update --backup=none --previous "{}" locales/messages.pot' \;
 
 # Compiles the language files into binary format
 [group('localization')]
 compile-locales:
     @uv run --frozen pybabel compile -d locales
+
+# Report any fuzzy-marked entries across all catalogs (gettext ignores them at runtime)
+[group('localization')]
+i18n-fuzzy-audit:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    found=0
+    for po in $(find locales -type f -path "*/LC_MESSAGES/messages.po"); do
+        count=$(grep -c '^#, fuzzy' "${po}" || true)
+        if [ "${count}" -gt 0 ]; then
+            echo " ⚠ ${po}: ${count} fuzzy entr$([ "${count}" -eq 1 ] && echo y || echo ies)"
+            found=$((found + count))
+        fi
+    done
+
+    if [ "${found}" -eq 0 ]; then
+        echo "✓ No fuzzy entries found"
+    else
+        echo "Found ${found} fuzzy entr$([ "${found}" -eq 1 ] && echo y || echo ies); review the listed catalogs."
+        exit 1
+    fi
 
 # Dump untranslated strings per language to a given DEST directory
 [group('localization')]

--- a/vibetuner-template/AGENTS.md
+++ b/vibetuner-template/AGENTS.md
@@ -170,6 +170,11 @@ Key commands: `just format` (all code), `just lint` (all code),
 > override a framework translation, redefine the same `msgid` in
 > your project's catalog; it wins on collision. See
 > [Framework Translation Catalogs](https://vibetuner.alltuner.com/development-guide/#framework-shipped-translations).
+>
+> `just i18n` merges with `msgmerge --no-fuzzy-matching`, so new strings
+> arrive with an empty `msgstr` (untranslated → English fallback), never a
+> wrong guess copied from a similar entry. Translate the blank entries;
+> `just i18n-fuzzy-audit` flags any stray `#, fuzzy` ones.
 
 `just dev` builds an all-in-one dev container (Python + bun + watchers)
 and brings up mongo/redis alongside. Edits to `src/`, `templates/`, or


### PR DESCRIPTION
## Problem

The scaffolded `update-locale-files` and the framework's `update-framework-locales` run `msgmerge` without `--no-fuzzy-matching`. msgmerge defaults to **fuzzy matching**: when a new `msgid` is textually close to an existing one, it copies that entry's `msgstr` and marks the new entry `#, fuzzy`. The recipes then commit those guesses.

gettext ignores `#, fuzzy` at runtime (falls back to the English `msgid`), so it "works" — but catalogs silently accumulate confident-looking **wrong** translations, translators see nonsense pre-fills, and genuine regressions get masked. See #1959 for concrete bulletin examples.

## Fix

- Add `--no-fuzzy-matching` to both `msgmerge` calls (scaffolded template + framework root). New/changed strings now land with an **empty** `msgstr` (honest untranslated → English fallback) instead of a wrong guess.
- Add `just i18n-fuzzy-audit` (scaffold) and `just i18n-framework-fuzzy-audit` (framework) to surface any leftover `#, fuzzy` entries for cleanup. Both exit non-zero if any are found.
- Update docs (`development-guide.md`, `llms-full.txt`, template `AGENTS.md`) — `llms-full.txt` previously described fuzzy marking as the expected behavior, which is now corrected.

## Verification

- Both audit recipes parse and run; framework catalogs are currently clean (`✓ No fuzzy entries found`).
- `just lint-md` shows only pre-existing README issues; no new violations in edited docs.
- Pre-commit hooks (including rumdl) pass.

Closes #1959

🤖 Generated with [Claude Code](https://claude.com/claude-code)