### PR TITLE
fix: set anti-buffering headers on SSE responses

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -1830,6 +1830,16 @@ Connect an SSE endpoint to HTMX using the built-in SSE support:
 When Redis is configured (`REDIS_URL`), broadcasts are relayed across
 all worker processes via Redis pub/sub automatically. No extra setup needed.
 
+### Reverse Proxies and CDNs
+
+SSE responses are sent with `Cache-Control: no-cache` and
+`X-Accel-Buffering: no`, which tell reverse proxies and CDNs (Caddy, nginx,
+Cloudflare) to stream events through immediately instead of buffering the
+response. Without these headers a buffering proxy can hold the connection
+open and deliver nothing to the client until it closes, making live updates
+appear to "only work on reload." Because the framework sets them for you, no
+extra proxy configuration is required for SSE to work in production.
+
 ## Template Context Providers
 
 Inject variables into every `render_template()` call without passing them

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1266,6 +1266,12 @@ await broadcast(
 SSE uses in-process channels by default. When Redis is configured, events are
 automatically bridged via Redis pub/sub for multi-worker support.
 
+SSE responses are sent with `Cache-Control: no-cache` and `X-Accel-Buffering: no`
+so reverse proxies and CDNs (Caddy, nginx, Cloudflare) stream events through
+immediately instead of buffering them. Without these, a proxy can hold the
+response open and deliver nothing to the client until the connection closes — so
+no extra proxy configuration is needed for live updates to work in production.
+
 **HTMX client example:**
 
 ```html

--- a/vibetuner-py/src/vibetuner/sse.py
+++ b/vibetuner-py/src/vibetuner/sse.py
@@ -96,6 +96,15 @@ def _format_event(
     )
 
 
+# Headers that stop reverse proxies and CDNs (Caddy, nginx, Cloudflare) from
+# buffering the event stream. Without them the proxy holds the response, so the
+# client gets a 200 that never delivers any bytes until the connection closes.
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "X-Accel-Buffering": "no",
+}
+
+
 # ────────────────────────────────────────────────────────────────
 #  In-process connection registry
 # ────────────────────────────────────────────────────────────────
@@ -483,7 +492,8 @@ def sse_endpoint(
 
             if gen is not None:
                 return EventSourceResponse(
-                    _stream_from_generator(gen, template, request)
+                    _stream_from_generator(gen, template, request),
+                    headers=_SSE_HEADERS,
                 )
 
             if ch is None:
@@ -502,7 +512,8 @@ def sse_endpoint(
             return EventSourceResponse(
                 _stream_from_channel(
                     ch, last_event_id=_parse_last_event_id(request)
-                )
+                ),
+                headers=_SSE_HEADERS,
             )
 
         if router is not None:

--- a/vibetuner-py/tests/unit/test_sse.py
+++ b/vibetuner-py/tests/unit/test_sse.py
@@ -6,6 +6,7 @@ import asyncio
 
 import pytest
 from fastapi import APIRouter, Request
+from starlette.requests import Request as StarletteRequest
 from vibetuner.sse import (
     _channel_buffers,
     _dispatch_local,
@@ -14,6 +15,19 @@ from vibetuner.sse import (
     _stream_from_channel,
     sse_endpoint,
 )
+
+
+def _make_request(path: str = "/events") -> StarletteRequest:
+    """Build a minimal ASGI GET request for invoking an SSE endpoint directly."""
+    return StarletteRequest(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "query_string": b"",
+        }
+    )
 
 
 class TestEventBuffer:
@@ -175,3 +189,37 @@ class TestSseEndpointBuffering:
             pass
 
         assert "no-buf-test" not in _channel_buffers
+
+
+class TestSseAntiBufferingHeaders:
+    """SSE responses must defeat proxy/CDN buffering (Caddy, nginx, Cloudflare).
+
+    Without these headers a buffering reverse proxy holds ``text/event-stream``
+    responses, so the client sees a 200 that never delivers any bytes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_channel_response_disables_buffering(self):
+        @sse_endpoint("/events-hdr-chan", channel="hdr-chan-test")
+        async def stream(request: Request):
+            pass
+
+        response = await stream(request=_make_request("/events-hdr-chan"))
+        try:
+            assert response.headers["cache-control"] == "no-cache"
+            assert response.headers["x-accel-buffering"] == "no"
+        finally:
+            await response.body_iterator.aclose()
+
+    @pytest.mark.asyncio
+    async def test_generator_response_disables_buffering(self):
+        @sse_endpoint("/events-hdr-gen")
+        async def stream(request: Request):
+            yield {"event": "tick", "data": "ping"}
+
+        response = await stream(request=_make_request("/events-hdr-gen"))
+        try:
+            assert response.headers["cache-control"] == "no-cache"
+            assert response.headers["x-accel-buffering"] == "no"
+        finally:
+            await response.body_iterator.aclose()


### PR DESCRIPTION
## Summary

Fixes #1958. `vibetuner.sse` endpoints returned `text/event-stream` responses
**without** `Cache-Control` or `X-Accel-Buffering` headers. Behind a buffering
reverse proxy or CDN (the issue's deployment is **Caddy + Cloudflare**; also
nginx) the proxy holds the response open and delivers nothing to the client
until the connection closes — so SSE-driven live updates silently degrade to
"only work on reload" in real deployments.

This sets `Cache-Control: no-cache` and `X-Accel-Buffering: no` on every SSE
response (both channel-based and generator-based), the standard pair every SSE
library emits, so proxies stream events through immediately. No proxy config
changes are needed.

## Root cause investigation

The issue hypothesized the per-connection Redis listener task was being torn
down with the request context. I could **not** reproduce that: I ran the SSE
stack under granian against real Redis across every configuration in the report
— dev (1 worker, `reload=True`), prod (4 workers), the full framework
middleware stack (rate-limit `BaseHTTPMiddleware`, security headers, session,
i18n, context), uvloop, and broadcasts from a separate process via Redis only.
**Delivery worked in all of them.** The listener task is a module global with a
strong ref and escapes the request's anyio task group, so it keeps delivering.

What was actually missing were the anti-buffering headers — which matches the
report's "degrades in real deployments" framing exactly, since granian itself
chunks fine and the problem only appears behind a buffering proxy.

## Verification

- Added unit tests asserting both headers on channel- and generator-based SSE
  responses (red → green).
- End-to-end under granian + real Redis: confirmed `cache-control: no-cache` and
  `x-accel-buffering: no` reach the wire, and cross-process broadcasts still
  deliver.
- Full unit suite: 920 passed. `ruff check` and `ty` clean.

## Docs

- `development-guide.md` — new "Reverse Proxies and CDNs" subsection under SSE.
- `llms-full.txt` — note on the headers in the SSE section.

## Follow-up (separate issue, not in this PR)

While investigating I found a **double-delivery** bug: `broadcast()` does a local
dispatch *and* publishes to Redis, and the same process's listener receives its
own publish, so a worker that both broadcasts and holds a local subscriber
delivers each event twice (reproduced: 2 broadcasts → 4 client events in
single-worker dev). Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)