### PR TITLE
fix: make hx-on/hx-live CSP-safe by default via hx-csp + safeEval

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -812,103 +812,70 @@ turn the response into an error page or a 0-byte download. App code
 should still set `media_type=` explicitly when it matters, but the
 guard prevents the worst-case UX when something slips through.
 
-### htmx CSP Protection (opt-in)
+### htmx CSP Protection (default-on)
 
 !!! note "Requires `htmx.org@4.0.0-beta4`"
     The `hx-csp` extension file ships with `htmx.org@4.0.0-beta4`, pulled
     transitively by the matching `@alltuner/vibetuner` release, and is
-    re-exported as `@alltuner/vibetuner/htmx/csp` (added in 10.20.0). On
-    older `@alltuner/vibetuner` releases that subpath does not exist, so
-    the bundler fails with
-    `Could not resolve "@alltuner/vibetuner/htmx/csp"` (releases shipping
-    htmx beta3 carried the extension as `hx-nonce.js`). Bump
-    `@alltuner/vibetuner` in `package.json` and re-run `bun install`
-    before enabling.
+    re-exported as `@alltuner/vibetuner/htmx/csp` (added in 10.20.0). When
+    upgrading from an older release that shipped htmx beta3, the extension
+    was carried as `hx-nonce.js`; see
+    [Beta3 to Beta4 Changes](htmx-migration.md#beta3-to-beta4-changes) for
+    the import-path update.
 
 htmx 4.0.0-beta4 ships an `hx-csp` extension (renamed from `hx-nonce`
 in beta3) that gates htmx attribute processing behind the page CSP
-nonce. Elements without a matching `hx-nonce` attribute are stripped
-at init time, providing a defence-in-depth layer against HTML
-injection attacks: even if an attacker manages to inject HTML, the
-browser will not honour any `hx-get`/`hx-post`/etc. attributes on
-injected elements. The HTML attribute is still named `hx-nonce`; only
-the extension itself was renamed.
+nonce. It is **loaded by default** from the framework-managed block of
+`config.js`, alongside `hx-preload` and `hx-live`:
 
-If you previously enabled the extension on a beta3-shipping vibetuner
-release, see
-[Beta3 to Beta4 Changes](htmx-migration.md#beta3-to-beta4-changes) in
-the migration guide for the import-path update.
+```javascript
+import "@alltuner/vibetuner/htmx/csp";
+```
 
-The framework's templates already stamp `hx-nonce="{{ csp_nonce }}"` on
-their htmx-bearing elements, so the extension is safe to enable from a
-fresh project as soon as you mirror the pattern in your own templates.
+You do not add this yourself — it ships in the part of `config.js` you
+must not edit. The HTML attribute is still named `hx-nonce`; only the
+extension itself was renamed.
 
-**To enable:**
+**Why it is required, not optional.** Vibetuner's CSP is
+`script-src 'nonce-…' 'strict-dynamic'` with **no** `'unsafe-eval'`. A
+nonce plus `strict-dynamic` does not permit `eval` / `new Function` —
+only `'unsafe-eval'` does. In beta4, both `hx-on:` and `hx-live`
+evaluate their JS through htmx core's `new Function()`, so without
+mitigation every such expression throws an `EvalError` under the
+enforced CSP and silently does nothing (an easy-to-miss runtime console
+error, not a build failure — and CSP is enforced in debug too unless you
+opt out). `hx-csp` fixes this: the framework-managed import flips
+`htmx.config.safeEval = true` **before** the extension registers, and
+with `safeEval` the extension replaces htmx's `new Function()`
+evaluation with nonce-based `<script>` injection — which a nonce +
+`strict-dynamic` CSP **does** permit. That is what makes `hx-on:` and
+`hx-live` genuinely CSP-safe with no `'unsafe-eval'`. No `safeEval` meta
+tag is required; it is enabled by the framework config.
 
-1. Add the import to your `config.js` custom imports section:
+**Fail-closed nonce gating, auto-stamped.** The extension is
+fail-closed: every element carrying an `hx-*` attribute must have an
+`hx-nonce` attribute whose value matches the page CSP nonce, or htmx
+strips its `hx-*` attributes. You do not stamp this manually.
+`SecurityHeadersMiddleware` auto-stamps `hx-nonce` on every htmx element
+in HTML responses, exactly the way it already injects the `nonce` into
+`<script>` tags. There is no `body_attrs` nonce to add and no
+per-element `hx-nonce="{{ csp_nonce }}"` to write.
 
-    ```javascript
-    // Add your custom imports below:
-    import "@alltuner/vibetuner/htmx/csp";
-    ```
+!!! warning "The gate trusts what the server renders"
+    Because the middleware stamps the nonce onto the rendered body, the
+    gate trusts whatever the server renders — the same trust model as the
+    existing script-nonce injection. If your project renders **untrusted**
+    HTML (markdown, user-supplied rich content), you must sanitize it;
+    `hx-csp` is not a substitute for sanitizing injected `hx-*` /
+    `<script>` in that content.
 
-    This re-export pulls the extension from the framework's pinned
-    `htmx.org`, so you do **not** need a direct `htmx.org` devDependency
-    (which would risk drifting from the framework's version). It mirrors
-    the existing `@alltuner/vibetuner/htmx/preload`, `…/sse`, and `…/live`
-    re-exports.
-
-2. Stamp the nonce on your htmx elements. The extension is fail-closed:
-   every element carrying an `hx-*` attribute needs a matching `hx-nonce`,
-   or its htmx attributes are stripped. Rather than stamping each element,
-   add a single inherited nonce on `<body>` via the skeleton's
-   `body_attrs` block — every htmx element inherits it:
-
-    ```jinja
-    {% block body_attrs %}hx-nonce:inherited="{{ csp_nonce }}"{% endblock body_attrs %}
-    ```
-
-    Stamp individual elements only where you want to opt out of the
-    inherited nonce:
-
-    ```html
-    <button hx-post="/save"
-            hx-target="#main-content"
-            hx-nonce="{{ csp_nonce }}">Save</button>
-    ```
-
-The extension reads the page nonce from the first `<script nonce>`
-element on the page. Vibetuner's `SecurityHeadersMiddleware` already
-stamps that nonce on your bundle script, so no extra wiring is required.
-
-**Trusted Types (further hardening):** Once the extension is enabled
-you can also tell the browser to refuse non-htmx HTML sinks by adding
+**Trusted Types (further hardening):** You can also tell the browser to
+refuse non-htmx HTML sinks by adding
 `require-trusted-types-for 'script'; trusted-types htmx` to your CSP.
 Configure this via `CSP_EXTRA_*` if you need to merge it with other
-directives, or extend `SecurityHeadersMiddleware` directly.
-
-**Safe eval:** vibetuner's CSP does not include `'unsafe-eval'`, so any
-htmx feature that requires `eval` (e.g. `hx-vals` with the `js:` prefix,
-`hx-on:` / `hx-on::` event handlers, `hx-confirm` with `js:`) is blocked
-by default — the handler silently never runs. If you use those features,
-enable `safeEval`: the extension replaces htmx's `new Function()` eval
-with nonce-based script injection so they work without `unsafe-eval`.
-
-Set it via the `htmx-config` meta tag rather than in JavaScript. The
-extension reads `htmx.config.safeEval` when its `init` runs, but ESM
-hoists imports, so a plain `htmx.config.safeEval = true` in `config.js`
-executes *after* the extension import and is too late. htmx reads the
-meta tag when its script first evaluates, so the tag must appear **before**
-the bundle script. Use the skeleton's `htmx_config` block, which renders
-in `<head>` just before the bundle for exactly this. The `extensions`
-key also applies the extension globally, so you don't need `hx-ext` on
-each element:
-
-```jinja
-{% block htmx_config %}
-    <meta name="htmx-config" content='extensions:"hx-csp",safeEval:true'>
-{% endblock htmx_config %}
-```
+directives, or extend `SecurityHeadersMiddleware` directly. With `hx-csp`
+default-on this works as-is; if you add a `trusted-types` directive it
+must include `htmx` in the allowlist.
 
 ### Strict `style-src` (opt-in)
 

--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -546,10 +546,11 @@ the changes specific to beta3 (which is the 4.0 release candidate).
 
 - **`hx-nonce`**: CSP nonce-based protection for inline scripts and
   `eval`-style code paths. Blocks elements without a matching `hx-nonce`
-  attribute, integrates with TrustedTypes, and defends against
-  `js:`/`javascript:` action URLs and unnonced boosted-form submitters.
-  Vibetuner enforces nonce-based CSP by default, so this extension is a
-  natural fit. See the
+  attribute, and defends against `js:`/`javascript:` action URLs and
+  unnonced boosted-form submitters. Vibetuner enforces nonce-based CSP by
+  default, and (under its renamed `hx-csp` form) loads this extension by
+  default — it is required for `hx-on:` / `hx-live` to work under the
+  strict `script-src`. See the
   [vibetuner CSP docs](development-guide.md#security-headers-and-csp-nonce).
   **Renamed to `hx-csp` in beta4** — see the
   [Beta3 to Beta4 Changes](#beta3-to-beta4-changes) section below.
@@ -706,13 +707,19 @@ event-listener boilerplate.
 ### Why it fits vibetuner
 
 Vibetuner's CSP runs `script-src 'nonce-X' 'strict-dynamic'` with
-no `'unsafe-inline'`, which blocks inline `onclick="..."` /
-`onchange="..."` attributes at the spec level. htmx attributes
-(`hx-on:`, `hx-live`) evaluate through htmx's nonced TrustedTypes
-pipeline, so they work where raw handler attributes do not. If you
-also enable `hx-csp` (formerly `hx-nonce`, see
-[Beta3 to Beta4 Changes](#beta3-to-beta4-changes)), every `hx-live`
-expression gets the same defence-in-depth as `hx-get` / `hx-post`.
+no `'unsafe-inline'` and no `'unsafe-eval'`, which blocks inline
+`onclick="..."` / `onchange="..."` attributes at the spec level, and
+would also reject htmx's own `new Function()` evaluation of `hx-on:` /
+`hx-live` expressions with an `EvalError`. The default-on `hx-csp`
+extension (formerly `hx-nonce`, see
+[Beta3 to Beta4 Changes](#beta3-to-beta4-changes)) is what makes them
+work: with `safeEval` on, htmx evaluates those expressions via
+nonce-based `<script>` injection, which the nonce + `strict-dynamic`
+CSP does permit. So `hx-on:` and `hx-live` are genuinely CSP-safe
+without `'unsafe-eval'`, where raw handler attributes are not.
+`hx-csp` is loaded by default (see
+[htmx CSP Protection](development-guide.md#htmx-csp-protection-default-on)),
+so no extra wiring is required.
 
 ### Idiomatic patterns
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2133,23 +2133,25 @@ templates for inline `style="..."` before flipping. On older releases
 the env var is silently ignored, so bump `vibetuner` in `pyproject.toml`
 and re-run `uv sync` first.
 
-**htmx CSP Protection (opt-in, requires `htmx.org@4.0.0-beta4`):**
+**htmx CSP Protection (default-on, requires `htmx.org@4.0.0-beta4`):**
 htmx 4.0.0-beta4 ships an `hx-csp` extension (renamed from `hx-nonce`
 in beta3) that strips htmx attributes from elements without a matching
-`hx-nonce`. Enable by adding `import "@alltuner/vibetuner/htmx/csp";` to
-`config.js` custom imports (re-exported from the framework's pinned
-htmx, so no direct `htmx.org` dep is needed; added in 10.20.0). Stamp
-the nonce once via the skeleton's `body_attrs` block —
-`hx-nonce:inherited="{{ csp_nonce }}"` — and every htmx element inherits
-it; stamp individual elements only to override. For features that need
-eval (`hx-on`, `hx-vals js:`, `hx-confirm js:`), enable `safeEval` via
-`<meta name="htmx-config" content='extensions:"hx-csp",safeEval:true'>`
-placed in the skeleton's `htmx_config` block (it must precede the bundle
-script, since htmx reads its meta config when the script evaluates).
-Useful defence-in-depth even though vibetuner already enforces strict
-script-src. The HTML attribute is still named `hx-nonce`; only the
-extension itself was renamed. On older releases that ship
-`htmx.org@4.0.0-beta3` the file is named `hx-nonce.js`.
+`hx-nonce`. It is loaded by default from the framework-managed block of
+`config.js` (`import "@alltuner/vibetuner/htmx/csp";`, re-exported from
+the framework's pinned htmx, so no direct `htmx.org` dep is needed;
+added in 10.20.0). It is not optional: it is what makes `hx-on:` /
+`hx-live` work at all under vibetuner's strict CSP. The extension is
+fail-closed — every element carrying an `hx-*` attribute needs a matching
+`hx-nonce` — but `SecurityHeadersMiddleware` auto-stamps `hx-nonce` on
+every htmx element (the same way it injects the `nonce` into `<script>`
+tags), so there is no `body_attrs` stamp and no per-element `hx-nonce`
+to add. The `csp` import also flips `htmx.config.safeEval = true` before
+the extension registers, so `hx-on` / `hx-vals js:` / `hx-confirm js:`
+are evaluated via nonce-based `<script>` injection rather than
+`new Function()`; no `safeEval` meta tag is required. The HTML attribute
+is still named `hx-nonce`; only the extension itself was renamed. On
+older releases that ship `htmx.org@4.0.0-beta3` the file is named
+`hx-nonce.js`.
 
 **htmx Live Reactivity (default-on, requires `@alltuner/vibetuner` ≥ 10.15.0):**
 htmx 4's `hx-live` extension is loaded by default from the
@@ -2160,10 +2162,13 @@ Reach for it before adding Alpine.js, Stimulus, or hand-rolled
 event-listener boilerplate.
 
 **Why it fits the stack.** Vibetuner's `script-src 'nonce-X' 'strict-dynamic'`
-CSP blocks inline `onclick="..."` / `onchange="..."` attributes at the spec
-level. `hx-on:` and `hx-live` evaluate through htmx's nonced TrustedTypes
-pipeline, so they work where raw handler attributes do not. Pair with the
-opt-in `hx-csp` extension for defence-in-depth.
+CSP (no `'unsafe-eval'`) blocks inline `onclick="..."` / `onchange="..."`
+attributes at the spec level, and would also reject htmx's own `new Function()`
+evaluation of `hx-on:` / `hx-live` expressions with an `EvalError`. The
+default-on `hx-csp` extension fixes that: with `safeEval` on, it evaluates
+those expressions via nonce-based `<script>` injection, which the nonce +
+`strict-dynamic` CSP does permit. That is what makes `hx-on:` and `hx-live`
+work where raw handler attributes do not — no `'unsafe-eval'` needed.
 
 **Primitives** (full reference at <https://four.htmx.org/extensions/hx-live/>):
 
@@ -2706,12 +2711,12 @@ relevant to vibetuner projects:
 
 - **`hx-csp` extension** (introduced in beta3 as `hx-nonce`, renamed in
   beta4) — gates htmx attribute processing behind the page CSP nonce.
-  Enable by importing `@alltuner/vibetuner/htmx/csp` in `config.js` (no
-  direct `htmx.org` dep; added in 10.20.0) and stamping the nonce once via
-  the skeleton's `body_attrs` block (`hx-nonce:inherited="{{ csp_nonce }}"`,
-  inherited by all htmx elements). Elements without a matching nonce
-  are stripped (fail-closed). The HTML attribute is still named
-  `hx-nonce`; only the extension itself was renamed
+  Loaded by default from the framework-managed block of `config.js`
+  (`import "@alltuner/vibetuner/htmx/csp"`; no direct `htmx.org` dep;
+  added in 10.20.0); `SecurityHeadersMiddleware` auto-stamps the matching
+  `hx-nonce` on every htmx element, so no manual stamping is needed.
+  Elements without a matching nonce are stripped (fail-closed). The HTML
+  attribute is still named `hx-nonce`; only the extension itself was renamed
 - **`hx-live` extension** — DOM-reactivity via `hx-live="..."` plus a
   richer `hx-on` JS surface (`q()`, `toggle()`, `debounce()`). **Default-on
   in vibetuner** since `@alltuner/vibetuner` 10.15.0; see the Live

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -138,25 +138,31 @@ Important notes:
   no `Content-Type` (e.g. a bare `Response(status_code=404)`), so bare responses do
   not get turned into 0-byte browser downloads (Safari/Firefox) or generic error
   pages (Chrome)
-- **htmx CSP Protection (opt-in)**: htmx 4.0.0-beta4 ships an `hx-csp` extension
+- **htmx CSP Protection (default-on)**: htmx 4.0.0-beta4 ships an `hx-csp` extension
   (renamed from `hx-nonce` in beta3) that gates htmx attribute processing behind the
-  page CSP nonce. Enable by adding `import "@alltuner/vibetuner/htmx/csp";` to
-  `config.js` (re-exported from the framework's pinned htmx, no direct `htmx.org`
-  dep needed; added in 10.20.0) and stamping the nonce once via the skeleton's
-  `body_attrs` block: `hx-nonce:inherited="{{ csp_nonce }}"` — every htmx element
-  inherits it. Elements without a matching `hx-nonce` are stripped (fail-closed).
-  For `hx-on`/`hx-vals js:` (which need eval), add
-  `<meta name="htmx-config" content='extensions:"hx-csp",safeEval:true'>` via the
-  skeleton's `htmx_config` block (must precede the bundle script). The HTML
-  attribute is still named `hx-nonce`; only the extension was renamed
+  page CSP nonce. It is loaded by default from the framework-managed block of
+  `config.js` (`import "@alltuner/vibetuner/htmx/csp";`, alongside `hx-preload` /
+  `hx-live`), and it is what makes `hx-on:` / `hx-live` work at all under vibetuner's
+  strict `script-src 'nonce-…' 'strict-dynamic'` (no `'unsafe-eval'`): the import also
+  flips `htmx.config.safeEval = true` so htmx evaluates those expressions via
+  nonce-based `<script>` injection instead of `new Function()` (which the nonce +
+  `strict-dynamic` CSP would reject with an `EvalError`). The extension is fail-closed —
+  any element carrying an `hx-*` attribute needs a matching `hx-nonce` — but
+  `SecurityHeadersMiddleware` auto-stamps `hx-nonce` on every htmx element (the same
+  way it injects the `nonce` into `<script>` tags), so no manual stamping, no
+  `body_attrs` nonce, and no `safeEval` meta tag are required. Because the gate trusts
+  whatever the server renders, projects that render untrusted HTML (markdown,
+  user-supplied content) must still sanitize it. The HTML attribute is still named
+  `hx-nonce`; only the extension was renamed
 - **htmx Live Reactivity (default-on)**: htmx 4's `hx-live` extension is
   loaded by default from `config.js` since `@alltuner/vibetuner` 10.15.0. Use
   `hx-live="<expr>"` for derived state that recomputes on any DOM mutation,
   `hx-on:event="..."` with the `q()` proxy / sigil-`toggle()` / per-element
-  `debounce()` for richer event handlers. CSP-clean (evaluates through htmx's
-  nonced TrustedTypes path) where raw inline `onclick=` is not. Vibetuner's
-  preferred path for chip lists, paired controls, live filters, and inline
-  form-field validation — use this before reaching for Alpine.js or Stimulus.
+  `debounce()` for richer event handlers. CSP-safe (the default-on `hx-csp`
+  extension's `safeEval` evaluates them via nonce-based script injection) where raw
+  inline `onclick=` is not. Vibetuner's preferred path for chip lists, paired
+  controls, live filters, and inline form-field validation — use this before
+  reaching for Alpine.js or Stimulus.
   See `vibetuner-docs/docs/htmx-migration.md#live-reactivity-with-hx-live` for
   idiomatic patterns and rough edges
 - **Health Checks**: `/health`, `/health/ping`, `/health/ready`, `/health/id` endpoints

--- a/vibetuner-js/htmx-csp.js
+++ b/vibetuner-js/htmx-csp.js
@@ -1,3 +1,4 @@
-// ABOUTME: Re-exports the htmx hx-csp extension via @alltuner/vibetuner/htmx/csp
-// ABOUTME: so scaffolded projects don't need a direct htmx.org dep to enable it.
+// ABOUTME: Re-exports the htmx hx-csp extension via @alltuner/vibetuner/htmx/csp and
+// ABOUTME: enables safeEval, so hx-on:/hx-live stay CSP-safe without unsafe-eval.
+import "./htmx-safeeval.js";
 import "htmx.org/dist/ext/hx-csp.js";

--- a/vibetuner-js/htmx-safeeval.js
+++ b/vibetuner-js/htmx-safeeval.js
@@ -1,0 +1,9 @@
+// ABOUTME: Turns on htmx safeEval before the hx-csp extension registers, so hx-csp
+// ABOUTME: evaluates hx-on:/hx-live via nonce-based script injection, not new Function().
+import htmx from "htmx.org";
+
+// hx-csp reads htmx.config.safeEval synchronously in its init (which runs the
+// moment the extension module evaluates), so this must be set first. Keeping it
+// in its own module lets htmx-csp.js import it ahead of the extension regardless
+// of how config.js orders the framework imports.
+htmx.config.safeEval = true;

--- a/vibetuner-py/src/vibetuner/frontend/AGENTS.md
+++ b/vibetuner-py/src/vibetuner/frontend/AGENTS.md
@@ -67,6 +67,13 @@ tags** in templates. The middleware handles this. Adding `nonce="{{ csp_nonce }}
 causes the middleware to skip injection (it sees `nonce=` already present), resulting in an empty
 nonce that silently breaks scripts in production while appearing to work in dev mode.
 
+The middleware also stamps `hx-nonce="<nonce>"` on every element carrying an `hx-*` attribute, so the
+default-on `hx-csp` extension (which is fail-closed and strips htmx from elements without a matching
+nonce) accepts server-rendered htmx. **Do NOT manually add `hx-nonce=` in templates** either — the
+middleware handles it, the same way it does for `<script>` tags. SSE payloads go out as
+`text/event-stream` and are not rewritten, so htmx attributes delivered over SSE are not stamped
+(hx-csp logs a `console.error` when it strips them).
+
 For `<style>` tags or other elements that need the nonce, use `{{ csp_nonce }}` (available in all
 templates via context provider). Configure extra CSP sources via `CSP_*` env vars.
 

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -112,6 +112,18 @@ class HtmxMiddleware:
 _SCRIPT_WITHOUT_NONCE_RE = re.compile(rb"<script(?![^>]*\snonce=)", re.IGNORECASE)
 _EMPTY_NONCE_RE = re.compile(rb'<script[^>]*\snonce=""\s*', re.IGNORECASE)
 
+# Opening of any start tag that carries an htmx attribute (`hx-…`, including
+# `hx-on:…`) but no `hx-nonce` yet. The hx-csp extension is a fail-closed gate:
+# it strips htmx from any element whose hx-nonce does not match the page nonce,
+# so the framework stamps the nonce here just like it does for <script> tags.
+# Anchored on the tag name so the attribute is inserted right after `<tag` and
+# never after the tag's closing `>` — that stays correct even when an
+# `hx-on`/`hx-live` expression value contains a literal `>`.
+_HX_ELEMENT_WITHOUT_NONCE_RE = re.compile(
+    rb"<([a-zA-Z][a-zA-Z0-9-]*)(?=[^>]*\shx-)(?![^>]*\shx-nonce[\s=>])",
+    re.IGNORECASE,
+)
+
 
 class SecurityHeadersMiddleware:
     """Pure ASGI middleware that adds security headers (CSP with nonce, etc.) to responses.
@@ -197,8 +209,10 @@ class SecurityHeadersMiddleware:
                 "CSP nonces are auto-injected by SecurityHeadersMiddleware; "
                 "do not add nonce= attributes manually in templates."
             )
-        replacement = f'<script nonce="{nonce}"'.encode()
-        return _SCRIPT_WITHOUT_NONCE_RE.sub(replacement, body)
+        script_replacement = f'<script nonce="{nonce}"'.encode()
+        body = _SCRIPT_WITHOUT_NONCE_RE.sub(script_replacement, body)
+        hx_replacement = rb'<\g<1> hx-nonce="' + nonce.encode() + rb'"'
+        return _HX_ELEMENT_WITHOUT_NONCE_RE.sub(hx_replacement, body)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":

--- a/vibetuner-py/src/vibetuner/templates/frontend/user/profile.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/user/profile.html.jinja
@@ -108,8 +108,7 @@
                                 <button class="btn btn-primary"
                                         hx-get="/user/edit"
                                         hx-target="#main-content"
-                                        hx-swap="innerHTML"
-                                        hx-nonce="{{ csp_nonce }}">{{ _("Edit Profile") }}</button>
+                                        hx-swap="innerHTML">{{ _("Edit Profile") }}</button>
                                 <form method="post" action="{{ url_for('auth_logout') }}">
                                     <button type="submit" class="btn btn-outline btn-error">{{ _("Sign Out") }}</button>
                                 </form>

--- a/vibetuner-py/tests/unit/test_security_headers_middleware.py
+++ b/vibetuner-py/tests/unit/test_security_headers_middleware.py
@@ -36,6 +36,10 @@ class _Settings:
 
 _SCRIPT_WITHOUT_NONCE_RE = re.compile(rb"<script(?![^>]*\snonce=)", re.IGNORECASE)
 _EMPTY_NONCE_RE = re.compile(rb'<script[^>]*\snonce=""\s*', re.IGNORECASE)
+_HX_ELEMENT_WITHOUT_NONCE_RE = re.compile(
+    rb"<([a-zA-Z][a-zA-Z0-9-]*)(?=[^>]*\shx-)(?![^>]*\shx-nonce[\s=>])",
+    re.IGNORECASE,
+)
 
 _logger = logging.getLogger("vibetuner.security")
 
@@ -123,8 +127,10 @@ class SecurityHeadersMiddleware:
                 "CSP nonces are auto-injected by SecurityHeadersMiddleware; "
                 "do not add nonce= attributes manually in templates."
             )
-        replacement = f'<script nonce="{nonce}"'.encode()
-        return _SCRIPT_WITHOUT_NONCE_RE.sub(replacement, body)
+        script_replacement = f'<script nonce="{nonce}"'.encode()
+        body = _SCRIPT_WITHOUT_NONCE_RE.sub(script_replacement, body)
+        hx_replacement = rb'<\g<1> hx-nonce="' + nonce.encode() + rb'"'
+        return _HX_ELEMENT_WITHOUT_NONCE_RE.sub(hx_replacement, body)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -486,6 +492,92 @@ class TestCspNonceAutoInjection:
         with caplog.at_level(logging.WARNING, logger="vibetuner.security"):
             client.get("/")
         assert not any("empty nonce" in r.message for r in caplog.records)
+
+
+class TestHxNonceAutoInjection:
+    """Test automatic hx-nonce injection into htmx elements in HTML responses.
+
+    Mirrors the hx-csp extension's fail-closed nonce gate: every element
+    carrying an htmx attribute must have a matching hx-nonce or htmx strips it.
+    """
+
+    def test_stamps_hx_nonce_on_htmx_element(self):
+        """An element with an htmx verb attribute gets hx-nonce injected."""
+        app = _make_app(html_body='<html><button hx-post="/save">Save</button></html>')
+        client = TestClient(app)
+        resp = client.get("/")
+        nonce = app._captured_nonces[0]
+        assert f'<button hx-nonce="{nonce}" hx-post="/save">' in resp.text
+
+    def test_stamps_hx_on_element(self):
+        """An element with hx-on: gets hx-nonce injected."""
+        app = _make_app(
+            html_body='<html><button hx-on:click="cycleTheme()">T</button></html>'
+        )
+        client = TestClient(app)
+        resp = client.get("/")
+        nonce = app._captured_nonces[0]
+        assert f'<button hx-nonce="{nonce}" hx-on:click="cycleTheme()">' in resp.text
+
+    def test_stamps_correctly_when_expression_contains_gt(self):
+        """A '>' inside an hx-on/hx-live expression must not corrupt injection."""
+        app = _make_app(
+            html_body="<html><input hx-live=\"q('#b').disabled = a > b\"></html>"
+        )
+        client = TestClient(app)
+        resp = client.get("/")
+        nonce = app._captured_nonces[0]
+        assert (
+            f'<input hx-nonce="{nonce}" hx-live="q(\'#b\').disabled = a > b">'
+            in resp.text
+        )
+
+    def test_does_not_double_stamp_existing_hx_nonce(self):
+        """Elements that already carry hx-nonce are left unchanged."""
+        app = _make_app(
+            html_body='<html><button hx-nonce="keep" hx-post="/x">X</button></html>'
+        )
+        client = TestClient(app)
+        resp = client.get("/")
+        assert resp.text.count("hx-nonce=") == 1
+        assert 'hx-nonce="keep"' in resp.text
+
+    def test_leaves_non_htmx_elements_alone(self):
+        """Elements without any htmx attribute do not get hx-nonce."""
+        app = _make_app(html_body='<html><div class="card">hi</div></html>')
+        client = TestClient(app)
+        resp = client.get("/")
+        assert "hx-nonce" not in resp.text
+
+    def test_stamps_multiple_htmx_elements(self):
+        """Every htmx element in the response gets its own hx-nonce."""
+        app = _make_app(
+            html_body=(
+                "<html>"
+                '<button hx-get="/a">A</button>'
+                '<input hx-live="this.value = 1">'
+                "</html>"
+            )
+        )
+        client = TestClient(app)
+        resp = client.get("/")
+        nonce = app._captured_nonces[0]
+        assert resp.text.count(f'hx-nonce="{nonce}"') == 2
+
+    def test_hx_nonce_matches_page_nonce(self):
+        """The injected hx-nonce value equals the per-request CSP nonce."""
+        app = _make_app(html_body='<html><a hx-boost="true" href="/x">x</a></html>')
+        client = TestClient(app)
+        resp = client.get("/")
+        nonce = app._captured_nonces[0]
+        assert f'hx-nonce="{nonce}"' in resp.text
+
+    def test_does_not_match_closing_tags(self):
+        """Closing tags are never stamped."""
+        app = _make_app(html_body="<html><button hx-get='/a'>A</button></html>")
+        client = TestClient(app)
+        resp = client.get("/")
+        assert "</button hx-nonce" not in resp.text
 
 
 class TestBareResponseContentType:

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -122,17 +122,34 @@ directly to elements or use `hx-on` attributes.
 See the [HTMX migration guide](https://vibetuner.alltuner.com/htmx-migration/)
 for full details.
 
-## htmx CSP Protection (opt-in)
+## htmx CSP Protection (default-on)
 
-The `hx-csp` extension (htmx 4.0.0-beta4+, renamed from `hx-nonce`)
-gates htmx attribute processing behind the page CSP nonce. Framework
-templates already stamp `hx-nonce="{{ csp_nonce }}"` on htmx-bearing
-elements; mirror that pattern in your own templates if you enable the
-extension. Add `import "./node_modules/htmx.org/dist/ext/hx-csp.js";`
-to your `config.js` custom imports section. Elements without a
-matching `hx-nonce` will be stripped (fail-closed). The HTML attribute
-is still named `hx-nonce`; only the extension itself was renamed. See
-the [CSP/htmx docs](https://vibetuner.alltuner.com/development-guide/#htmx-csp-protection-opt-in).
+The `hx-csp` extension (htmx 4.0.0-beta4+) is loaded by default from the
+framework-managed block of `config.js`, with `htmx.config.safeEval`
+enabled. It does two things under the project's strict `script-src`
+(`'nonce-…' 'strict-dynamic'`, **no** `'unsafe-eval'`):
+
+- **Gates htmx behind the page nonce (fail-closed).** Every element
+  carrying an htmx attribute must have an `hx-nonce` matching the page
+  nonce, or its `hx-*` attributes are stripped. `SecurityHeadersMiddleware`
+  **auto-stamps `hx-nonce` on every htmx element** in HTML responses,
+  exactly like it injects the nonce into `<script>` tags — so you do
+  **not** add `hx-nonce` manually (the same convention as script nonces).
+- **Makes `hx-on:` / `hx-live` CSP-safe** by routing their evaluation
+  through nonce-based `<script>` injection instead of `new Function()`.
+  A nonce + `'strict-dynamic'` does not permit `eval`/`new Function`, so
+  without this every `hx-on:`/`hx-live` expression would throw an
+  `EvalError` under the enforced production CSP (it is only report-only
+  in debug, which masks the failure locally).
+
+Security note: because the middleware stamps the nonce on the rendered
+body, the gate trusts whatever the server renders — the same trust model
+as the existing script-nonce injection. If you render **untrusted** HTML
+(markdown, user-supplied rich content), sanitize it; do not rely on
+`hx-csp` to neutralize injected `hx-*`/`<script>` in that content.
+
+See the
+[CSP/htmx docs](https://vibetuner.alltuner.com/development-guide/#htmx-csp-protection-default-on).
 
 ## htmx Live Reactivity (default-on)
 
@@ -167,10 +184,11 @@ Quick patterns:
 "></output>
 ```
 
-CSP-safe by design — `hx-on:` / `hx-live` attributes evaluate
-through htmx's nonced TrustedTypes path, where raw inline
-`onclick="..."` would be blocked by the project's `script-src`
-policy.
+CSP-safe under the strict default `script-src` — `hx-on:` / `hx-live`
+attributes evaluate through the `hx-csp` extension's nonce-based script
+injection (enabled by default, see *htmx CSP Protection* above), not
+`new Function()`, so they need no `'unsafe-eval'`. A raw inline
+`onclick="..."` stays blocked by the policy.
 
 Gotchas to remember: the DOM is the only source of truth (no
 JS-variable reactivity, share state via `data-*` or hidden inputs);

--- a/vibetuner-template/config.js
+++ b/vibetuner-template/config.js
@@ -2,6 +2,7 @@
 // Do not change anything between this comment and the next comment
 import htmx from "@alltuner/vibetuner/htmx";
 window.htmx = htmx;
+import "@alltuner/vibetuner/htmx/csp";
 import "@alltuner/vibetuner/htmx/preload";
 import "@alltuner/vibetuner/htmx/live";
 // Do not change anything between this comment and the previous one


### PR DESCRIPTION
Fixes #1956.

## Problem

The frontend rule and docs claimed `hx-on:` / `hx-live` are "CSP-safe by design" via a "nonced TrustedTypes path." Under the framework's default CSP (`script-src 'nonce-…' 'strict-dynamic'`, **no** `'unsafe-eval'`), that's false for the htmx 4.0.0-beta4 the framework pins.

## Root cause

In beta4, **both** `hx-on:` and `hx-live` evaluate their JS through htmx core's `new Function()` (`#executeJavaScript`). A nonce + `strict-dynamic` does not permit `eval`/`new Function` — only `'unsafe-eval'` does, and TrustedTypes doesn't exempt it. So every `hx-on:`/`hx-live` expression throws an `EvalError` and silently does nothing under the **enforced** production CSP. It's masked locally because CSP can be report-only in debug. (alpha7's `hx-live` was a tree-walking interpreter that didn't `eval` — the original "CSP-safe" claim was written against that.)

beta4 ships a real fix: the `hx-csp` extension with `htmx.config.safeEval` replaces `new Function()` with **nonce-based `<script>` injection** (which nonce + `strict-dynamic` *does* permit). But that was opt-in and off, while `hx-live` is loaded by default — the mismatch that broke the issue reporter's delete-confirm button.

## The fix (decided with @davidpoblador: make the CSP-safe path the default)

- **`vibetuner-js`**: new `htmx-safeeval.js` sets `htmx.config.safeEval = true` *before* the extension registers (ESM import hoisting means a statement can't precede an import in the same module; `htmx-csp.js` imports the safeeval module first). Verified in the actual bundle that `safeEval = true` runs before `registerExtension("hx-csp")` (which calls `init` synchronously).
- **`config.js`**: load `@alltuner/vibetuner/htmx/csp` in the framework-managed block.
- **Middleware auto-stamp**: `hx-csp` is fail-closed (it strips htmx from any element whose `hx-nonce` ≠ page nonce). `SecurityHeadersMiddleware` now stamps `hx-nonce` on every htmx element in HTML responses, mirroring its existing `<script>`-nonce injection — so no per-template stamping and no breakage for existing projects. The regex is anchored on the tag name, so a literal `>` inside an `hx-on`/`hx-live` expression can't corrupt the insertion.
- **Cleanup**: dropped the now-redundant manual `hx-nonce` in `profile.html.jinja` (the debug `oauth_app_form.html.jinja`, which uses `hx-on`/`hx-live` and was itself broken under enforced CSP, now works via auto-stamp).
- **Docs**: corrected the agent rule, `llms.txt`, `llms-full.txt`, `htmx-migration.md`, `development-guide.md`, and the framework `frontend/AGENTS.md` — removed the false TrustedTypes claim, reframed `hx-csp` from opt-in to default-on, and replaced the obsolete manual-stamp / safeEval-meta instructions.

## Verification

- New unit tests for the middleware `hx-nonce` stamping (incl. the `>`-in-expression case, no double-stamp, non-htmx elements untouched). Full suite: **926 passed**; `ruff` + `ty` clean.
- **End-to-end in Chrome**: a static page with an *enforced* strict CSP (no `unsafe-eval`), the real bundle, and `hx-live` elements carrying the stamped `hx-nonce`. The expressions evaluate on both initial render and reactive updates with **zero `EvalError`** and zero console errors — exactly the behavior the issue reported as broken.

## Security tradeoff (auto-stamp)

Because the middleware stamps the nonce onto the rendered body, `hx-csp`'s gate trusts whatever the server renders — the same trust model as the existing `<script>`-nonce injection (both lean on Jinja autoescaping). Projects rendering **untrusted** HTML (markdown, user content) must sanitize it; this is documented.

## Known limitation

SSE payloads go out as `text/event-stream` and aren't rewritten, so htmx attributes delivered *inside* an SSE fragment aren't stamped and get stripped client-side. Unlike the original bug this is **not silent** — `hx-csp` logs a `console.error` when it strips an element. Documented; a follow-up could stamp at the SSE render path if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)