### PR TITLE
fix: keep SSE Redis listener alive per worker, de-dup self-published events (#1958)

### DIFF
--- a/vibetuner-py/src/vibetuner/frontend/lifespan.py
+++ b/vibetuner-py/src/vibetuner/frontend/lifespan.py
@@ -23,6 +23,12 @@ async def base_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await init_mongodb()
     await init_sqlmodel()
 
+    # Own the SSE Redis listener for the worker's whole life, so its psubscribe
+    # stays live for every connection instead of being tied to one request.
+    from vibetuner.sse import start_redis_listener
+
+    await start_redis_listener()
+
     # Initialize runtime config cache after MongoDB is ready
     from vibetuner.config import settings
     from vibetuner.runtime_config import RuntimeConfig
@@ -53,6 +59,10 @@ async def base_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Vibetuner frontend stopping")
     if ctx.DEBUG:
         await hotreload.shutdown()
+
+    from vibetuner.sse import stop_redis_listener
+
+    await stop_redis_listener()
 
     from vibetuner.redis import close_redis_client
 

--- a/vibetuner-py/src/vibetuner/sse.py
+++ b/vibetuner-py/src/vibetuner/sse.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import re
+import uuid
 from collections import deque
 from collections.abc import AsyncGenerator, Callable
 from contextlib import suppress
@@ -81,9 +82,7 @@ class _EventBuffer:
 # ────────────────────────────────────────────────────────────────
 
 
-def _format_event(
-    payload: dict[str, str], *, event_id: str | None = None
-) -> bytes:
+def _format_event(payload: dict[str, str], *, event_id: str | None = None) -> bytes:
     """Encode an SSE payload dict into wire-format bytes.
 
     Wraps fastapi.sse.format_sse_event for internal use.
@@ -152,6 +151,12 @@ def _dispatch_local(channel: str, payload: dict[str, str]) -> int | None:
 _redis_listener_task: asyncio.Task | None = None
 _redis_publish_client = None
 
+# Identifies this process among all workers sharing the Redis pub/sub bus. Every
+# published message carries it so the publishing worker's own listener can skip
+# the message it already delivered locally (see _parse_redis_message).
+_WORKER_ID = uuid.uuid4().hex
+_ORIGIN_KEY = "_origin"
+
 
 def _parse_redis_message(message: dict, prefix: str) -> tuple[str, dict] | None:
     """Parse a Redis pub/sub message into (channel, payload) or None.
@@ -185,6 +190,11 @@ def _parse_redis_message(message: dict, prefix: str) -> tuple[str, dict] | None:
         )
         return None
 
+    # broadcast() already dispatched this to local subscribers before publishing,
+    # so the publishing worker must ignore its own loopback to avoid double delivery.
+    if payload.get(_ORIGIN_KEY) == _WORKER_ID:
+        return None
+
     if "event" not in payload and "data" not in payload:
         logger.warning(
             "SSE Redis message missing 'event' and 'data' keys on {}", channel
@@ -211,10 +221,15 @@ async def _redis_listen_loop(pubsub, client, prefix: str) -> None:
         await client.aclose()
 
 
-async def _start_redis_listener() -> None:
-    """Start a background task that relays Redis pub/sub messages to local queues."""
+async def start_redis_listener() -> None:
+    """Start a background task that relays Redis pub/sub messages to local queues.
+
+    Owned by the frontend lifespan so the worker's ``psubscribe`` stays live for
+    the whole process, not just one request. A task that has finished (cancelled
+    or errored) is replaced so the worker re-subscribes instead of going silent.
+    """
     global _redis_listener_task
-    if _redis_listener_task is not None:
+    if _redis_listener_task is not None and not _redis_listener_task.done():
         return
 
     try:
@@ -239,7 +254,7 @@ async def _start_redis_listener() -> None:
         logger.warning("Failed to start SSE Redis listener: {}", e)
 
 
-async def _stop_redis_listener() -> None:
+async def stop_redis_listener() -> None:
     """Cancel the Redis listener task and close the publish client."""
     global _redis_listener_task
     if _redis_listener_task is not None:
@@ -278,7 +293,8 @@ async def _publish_to_redis(channel: str, payload: dict[str, str]) -> None:
         from vibetuner.config import settings
 
         redis_channel = f"{settings.redis_key_prefix}sse:{channel}"
-        await client.publish(redis_channel, json.dumps(payload))
+        message = {**payload, _ORIGIN_KEY: _WORKER_ID}
+        await client.publish(redis_channel, json.dumps(message))
     except (ConnectionError, OSError):
         logger.debug(
             "Redis SSE publish failed due to connection error, resetting client"
@@ -379,9 +395,7 @@ async def _stream_from_channel(
     try:
         while True:
             try:
-                event_id, payload = await asyncio.wait_for(
-                    queue.get(), timeout=30
-                )
+                event_id, payload = await asyncio.wait_for(queue.get(), timeout=30)
                 yield _format_event(
                     payload,
                     event_id=str(event_id) if event_id is not None else None,
@@ -486,7 +500,9 @@ def sse_endpoint(
         @wraps(func)
         async def endpoint(**kwargs):
             request: Request = kwargs["request"]
-            await _start_redis_listener()
+            # The frontend lifespan normally owns the listener; this is a fallback
+            # for contexts that serve SSE without it. It no-ops if already running.
+            await start_redis_listener()
 
             ch, gen = await _resolve_channel_or_generator(func, kwargs, channel)
 
@@ -510,9 +526,7 @@ def sse_endpoint(
                 _channel_buffers[ch] = _EventBuffer(maxlen=buffer_size)
 
             return EventSourceResponse(
-                _stream_from_channel(
-                    ch, last_event_id=_parse_last_event_id(request)
-                ),
+                _stream_from_channel(ch, last_event_id=_parse_last_event_id(request)),
                 headers=_SSE_HEADERS,
             )
 

--- a/vibetuner-py/tests/unit/test_sse.py
+++ b/vibetuner-py/tests/unit/test_sse.py
@@ -3,17 +3,24 @@
 # ruff: noqa: S101
 
 import asyncio
+import contextlib
+import json
 
 import pytest
+import pytest_asyncio
 from fastapi import APIRouter, Request
 from starlette.requests import Request as StarletteRequest
 from vibetuner.sse import (
+    _WORKER_ID,
     _channel_buffers,
     _dispatch_local,
     _EventBuffer,
     _format_event,
+    _parse_redis_message,
+    _publish_to_redis,
     _stream_from_channel,
     sse_endpoint,
+    start_redis_listener,
 )
 
 
@@ -127,9 +134,7 @@ class TestStreamFromChannelResumption:
 
         try:
             gen = _stream_from_channel(ch, last_event_id=1)
-            items = await asyncio.wait_for(
-                self._collect_n(gen, 2), timeout=2.0
-            )
+            items = await asyncio.wait_for(self._collect_n(gen, 2), timeout=2.0)
             assert len(items) == 2
             assert b"data: b\n" in items[0]
             assert b"id: 2\n" in items[0]
@@ -223,3 +228,155 @@ class TestSseAntiBufferingHeaders:
             assert response.headers["x-accel-buffering"] == "no"
         finally:
             await response.body_iterator.aclose()
+
+
+def _redis_pmessage(prefix: str, channel: str, payload: dict) -> dict:
+    """Build a Redis pmessage dict as redis-py delivers it to the listen loop."""
+    return {
+        "type": "pmessage",
+        "pattern": f"{prefix}*".encode(),
+        "channel": f"{prefix}{channel}".encode(),
+        "data": json.dumps(payload).encode(),
+    }
+
+
+class TestRedisLoopbackDedup:
+    """Origin tagging stops a worker from re-delivering events it published itself.
+
+    ``broadcast()`` dispatches locally *and* publishes to Redis; the worker's own
+    listener then receives that publish. Without a same-origin filter the local
+    subscriber would see every event twice once the listener is reliably alive.
+    """
+
+    def test_parse_skips_own_published_message(self):
+        msg = _redis_pmessage(
+            "app:sse:",
+            "room",
+            {"event": "update", "data": "1", "_origin": _WORKER_ID},
+        )
+        assert _parse_redis_message(msg, "app:sse:") is None
+
+    def test_parse_dispatches_foreign_message(self):
+        msg = _redis_pmessage(
+            "app:sse:",
+            "room",
+            {"event": "update", "data": "1", "_origin": "some-other-worker"},
+        )
+        parsed = _parse_redis_message(msg, "app:sse:")
+        assert parsed is not None
+        channel, payload = parsed
+        assert channel == "room"
+        assert payload == {"event": "update", "data": "1"}
+
+    def test_parse_dispatches_message_without_origin(self):
+        # Messages from a publisher that predates origin tagging must still flow.
+        msg = _redis_pmessage("app:sse:", "room", {"event": "update", "data": "1"})
+        parsed = _parse_redis_message(msg, "app:sse:")
+        assert parsed is not None
+        _, payload = parsed
+        assert payload == {"event": "update", "data": "1"}
+
+    @pytest.mark.asyncio
+    async def test_publish_tags_message_with_worker_origin(self, monkeypatch):
+        published: list[tuple[str, str]] = []
+
+        class _Client:
+            async def publish(self, channel: str, data: str) -> None:
+                published.append((channel, data))
+
+        import vibetuner.sse as sse
+
+        monkeypatch.setattr(sse, "_redis_publish_client", _Client())
+        await _publish_to_redis("room", {"event": "update", "data": "1"})
+
+        assert len(published) == 1
+        _, raw = published[0]
+        sent = json.loads(raw)
+        assert sent["event"] == "update"
+        assert sent["data"] == "1"
+        assert sent["_origin"] == _WORKER_ID
+
+
+class _FakePubSub:
+    def __init__(self) -> None:
+        self.patterns: list[str] = []
+
+    async def psubscribe(self, pattern: str) -> None:
+        self.patterns.append(pattern)
+
+    async def punsubscribe(self) -> None:
+        pass
+
+    async def listen(self):
+        while True:
+            await asyncio.sleep(3600)
+            yield {}
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self._pubsub = _FakePubSub()
+
+    def pubsub(self) -> _FakePubSub:
+        return self._pubsub
+
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest_asyncio.fixture
+async def sse_module():
+    import vibetuner.sse as sse
+
+    sse._redis_listener_task = None
+    yield sse
+    task = sse._redis_listener_task
+    if task is not None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    sse._redis_listener_task = None
+
+
+class TestRedisListenerLifecycle:
+    """The listener is a process-lifetime task, not tied to a single request.
+
+    A dead task must be replaced; a live one must not be duplicated. Issue #1958
+    was the lazy guard treating a dead-but-non-None task as still subscribed, so
+    the worker never re-subscribed and ``PUBSUB NUMPAT`` decayed to 0.
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent_while_alive(self, sse_module, monkeypatch):
+        sse = sse_module
+        monkeypatch.setattr(
+            "vibetuner.redis.create_redis_client", lambda: _FakeClient()
+        )
+
+        await start_redis_listener()
+        first = sse._redis_listener_task
+        assert first is not None and not first.done()
+
+        await start_redis_listener()
+        assert sse._redis_listener_task is first
+
+    @pytest.mark.asyncio
+    async def test_start_replaces_dead_task(self, sse_module, monkeypatch):
+        sse = sse_module
+        monkeypatch.setattr(
+            "vibetuner.redis.create_redis_client", lambda: _FakeClient()
+        )
+
+        await start_redis_listener()
+        first = sse._redis_listener_task
+        assert first is not None
+
+        first.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await first
+        assert first.done()
+
+        await start_redis_listener()
+        second = sse._redis_listener_task
+        assert second is not None and second is not first
+        assert not second.done()


### PR DESCRIPTION
Fixes #1958. Also resolves the separate SSE double-delivery bug (fixed together because they share a root knot).

## Problem

Two coupled SSE defects under the granian server:

- **#1958 (zero delivery):** the Redis pub/sub listener was started lazily inside the SSE request handler and guarded by `if _redis_listener_task is not None`. Once that task ever finished, the dead task satisfied the guard, so the worker never re-subscribed — `PUBSUB NUMPAT` decayed to 0 and cross-process `broadcast()`s reached no client. Multi-worker made it worse: the lazy listener lived on whichever worker first served a connection, rarely the one holding a given client's stream.
- **Double-delivery:** `broadcast()` dispatches locally *and* publishes to Redis; the same worker's listener receives that publish and dispatches it a second time. It was masked only because the listener was usually dead — fixing #1958 would have made it manifest on every self-broadcast.

## Fix

- **Lifespan-owned listener.** `start_redis_listener()` now runs from `base_lifespan` as a process-lifetime task, so each worker's `psubscribe` stays live for its whole life. The request-handler call remains as a no-op fallback.
- **Dead-task recovery.** The guard now checks `not _redis_listener_task.done()`, so a cancelled/errored listener is replaced instead of treated as alive forever.
- **Origin tagging.** Each process gets a `_WORKER_ID`; published messages carry an `_origin` field; the listen loop skips its own loopback. `broadcast()` keeps dispatching locally first, preserving the "local delivery never depends on a successful Redis round-trip" invariant.

## Verification

- New unit tests (TDD): origin-loopback dedup, publish-tags-origin, listener idempotent-while-alive, and dead-task replacement.
- Full suite: **934 passed** (only Docker-dependent integration tests error, environment-only). `ruff` + `ty` clean.
- **Live against real Redis:** `NUMPAT` stays at 1 after start, own-origin broadcast delivers exactly once (no double), foreign-origin delivers once — exercising the real redis-py `pubsub.listen()` path.

No docs change needed: `llms-full.txt` already promises multi-worker support via Redis; the bug made that false in production and this makes it true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)