### PR TITLE
fix: stop SSE pub/sub subscriber dying on socket read timeout (#1958)

### DIFF
--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -457,6 +457,49 @@ class CoreConfiguration(BaseSettings):
         return kwargs
 
     @property
+    def _redis_resilience_kwargs(self) -> dict[str, Any]:
+        """Shared resilience kwargs for redis-py clients (``redis.asyncio``).
+
+        ``socket_keepalive`` and a periodic ``health_check_interval`` PING let a
+        silently-dropped TCP connection be detected and recycled. A timeout of 0
+        omits the corresponding kwarg.
+        """
+        kwargs: dict[str, Any] = {
+            "socket_keepalive": self.redis_socket_keepalive,
+        }
+        if self.redis_socket_connect_timeout > 0:
+            kwargs["socket_connect_timeout"] = self.redis_socket_connect_timeout
+        if self.redis_health_check_interval > 0:
+            kwargs["health_check_interval"] = int(self.redis_health_check_interval)
+        return kwargs
+
+    @property
+    def redis_client_kwargs(self) -> dict[str, Any]:
+        """redis-py kwargs for command clients (cache, health, SSE publish).
+
+        These run only non-blocking commands, so a ``socket_timeout`` safely turns
+        a silently-dropped connection's blocking read into a raised error instead
+        of an indefinite hang. A timeout of 0 omits it.
+        """
+        kwargs = self._redis_resilience_kwargs
+        if self.redis_socket_timeout > 0:
+            kwargs["socket_timeout"] = self.redis_socket_timeout
+        return kwargs
+
+    @property
+    def redis_subscriber_kwargs(self) -> dict[str, Any]:
+        """redis-py kwargs for the SSE pub/sub subscriber connection.
+
+        A subscriber blocks indefinitely waiting for the next message, so it must
+        never carry a ``socket_timeout`` — that would raise ``TimeoutError`` on any
+        channel idle longer than the timeout and kill the listener. Liveness relies
+        on ``health_check_interval`` PINGs and TCP keepalive instead.
+        """
+        kwargs = self._redis_resilience_kwargs
+        kwargs["socket_timeout"] = None
+        return kwargs
+
+    @property
     def resolved_test_mongodb_url(self) -> MongoDsn | None:
         """MongoDB server the test fixtures target.
 

--- a/vibetuner-py/src/vibetuner/redis.py
+++ b/vibetuner-py/src/vibetuner/redis.py
@@ -30,7 +30,9 @@ async def get_redis_client():
 
         import redis.asyncio as aioredis
 
-        _client = aioredis.from_url(str(settings.redis_url))
+        _client = aioredis.from_url(
+            str(settings.redis_url), **settings.redis_client_kwargs
+        )
         logger.debug("Shared Redis client initialized")
         return _client
 
@@ -70,7 +72,8 @@ def create_redis_client():
     """Create a new, independent async Redis client.
 
     Unlike :func:`get_redis_client`, each call returns a **separate** connection.
-    Use this when a dedicated connection is needed (e.g. pub/sub).
+    Use this for the SSE pub/sub subscriber, whose blocking ``listen()`` must not
+    carry a socket read timeout (see ``settings.redis_subscriber_kwargs``).
 
     Returns None if ``redis_url`` is not configured.
     """
@@ -81,4 +84,6 @@ def create_redis_client():
 
     import redis.asyncio as aioredis
 
-    return aioredis.from_url(str(settings.redis_url))
+    return aioredis.from_url(
+        str(settings.redis_url), **settings.redis_subscriber_kwargs
+    )

--- a/vibetuner-py/src/vibetuner/sse.py
+++ b/vibetuner-py/src/vibetuner/sse.py
@@ -207,51 +207,74 @@ def _parse_redis_message(message: dict, prefix: str) -> tuple[str, dict] | None:
     }
 
 
-async def _redis_listen_loop(pubsub, client, prefix: str) -> None:
-    """Run the Redis pub/sub listen loop, dispatching to local subscribers."""
-    try:
-        async for message in pubsub.listen():
-            parsed = _parse_redis_message(message, prefix)
-            if parsed is not None:
-                _dispatch_local(*parsed)
-    except asyncio.CancelledError:
-        pass
-    finally:
-        await pubsub.punsubscribe()
+_LISTENER_RECONNECT_DELAY = 1.0
+
+
+async def _close_subscriber(pubsub, client) -> None:
+    """Tear down a pub/sub subscriber and its connection, ignoring errors."""
+    with suppress(Exception):
+        await pubsub.aclose()
+    with suppress(Exception):
         await client.aclose()
 
 
-async def start_redis_listener() -> None:
-    """Start a background task that relays Redis pub/sub messages to local queues.
+async def _redis_listen_loop(prefix: str) -> None:
+    """Relay Redis pub/sub messages to local queues, reconnecting on failure.
 
-    Owned by the frontend lifespan so the worker's ``psubscribe`` stays live for
-    the whole process, not just one request. A task that has finished (cancelled
-    or errored) is replaced so the worker re-subscribes instead of going silent.
+    The subscriber connection carries no socket read timeout (see
+    ``settings.redis_subscriber_kwargs``), so an idle channel never raises. A
+    dropped connection or other Redis error closes the subscriber and the loop
+    re-subscribes after a short delay rather than exiting and leaving the worker
+    silent (``PUBSUB NUMPAT`` decaying to 0).
     """
-    global _redis_listener_task
-    if _redis_listener_task is not None and not _redis_listener_task.done():
-        return
+    from redis.exceptions import RedisError
 
-    try:
-        from vibetuner.config import settings
-        from vibetuner.redis import create_redis_client
+    from vibetuner.redis import create_redis_client
 
+    while True:
         client = create_redis_client()
         if client is None:
             return
 
         pubsub = client.pubsub()
-        prefix = f"{settings.redis_key_prefix}sse:"
-        await pubsub.psubscribe(f"{prefix}*")
+        try:
+            await pubsub.psubscribe(f"{prefix}*")
+            logger.debug("SSE Redis pub/sub listener subscribed to {}*", prefix)
+            async for message in pubsub.listen():
+                parsed = _parse_redis_message(message, prefix)
+                if parsed is not None:
+                    _dispatch_local(*parsed)
+        except asyncio.CancelledError:
+            await _close_subscriber(pubsub, client)
+            raise
+        except RedisError as e:
+            logger.warning(
+                "SSE Redis listener lost its connection, reconnecting: {}", e
+            )
+            await _close_subscriber(pubsub, client)
+            await asyncio.sleep(_LISTENER_RECONNECT_DELAY)
 
-        _redis_listener_task = asyncio.create_task(
-            _redis_listen_loop(pubsub, client, prefix)
-        )
-        logger.debug("SSE Redis pub/sub listener started")
-    except ImportError:
-        logger.debug("Redis not available, SSE broadcasting is local-only")
-    except Exception as e:
-        logger.warning("Failed to start SSE Redis listener: {}", e)
+
+async def start_redis_listener() -> None:
+    """Start a process-lifetime task relaying Redis pub/sub to local queues.
+
+    Owned by the frontend lifespan so the worker's ``psubscribe`` stays live for
+    the whole process, not just one request. The loop reconnects on its own, so a
+    running task is never duplicated; it is only (re)created when absent or done.
+    """
+    global _redis_listener_task
+    if _redis_listener_task is not None and not _redis_listener_task.done():
+        return
+
+    from vibetuner.config import settings
+
+    if settings.redis_url is None:
+        logger.debug("Redis not configured, SSE broadcasting is local-only")
+        return
+
+    prefix = f"{settings.redis_key_prefix}sse:"
+    _redis_listener_task = asyncio.create_task(_redis_listen_loop(prefix))
+    logger.debug("SSE Redis pub/sub listener started")
 
 
 async def stop_redis_listener() -> None:

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -274,6 +274,67 @@ class TestWorkerRedisKwargs:
             assert kwargs["max_idle_time"] == 15
 
 
+class TestRedisClientKwargs:
+    """Test redis-py kwargs for the shared async clients (redis.asyncio)."""
+
+    def test_command_client_carries_read_timeout(self):
+        """Command clients (cache, health, SSE publish) get a socket read timeout.
+
+        They run only non-blocking commands, so a read timeout safely turns a
+        silently-dropped connection's blocking read into a raised error.
+        """
+        config = CoreConfiguration(project=ProjectConfiguration())
+        kwargs = config.redis_client_kwargs
+        assert kwargs["socket_timeout"] == 30.0
+        assert kwargs["socket_connect_timeout"] == 10.0
+        assert kwargs["socket_keepalive"] is True
+        assert kwargs["health_check_interval"] == 30
+
+    def test_subscriber_never_carries_read_timeout(self):
+        """The SSE pub/sub subscriber must never carry a socket read timeout.
+
+        A subscriber blocks indefinitely between messages; a read timeout would
+        raise on any idle channel and kill the listener (issue #1958). Liveness
+        relies on health_check_interval PINGs and TCP keepalive instead.
+        """
+        config = CoreConfiguration(project=ProjectConfiguration())
+        kwargs = config.redis_subscriber_kwargs
+        assert kwargs["socket_timeout"] is None
+        assert kwargs["socket_connect_timeout"] == 10.0
+        assert kwargs["socket_keepalive"] is True
+        assert kwargs["health_check_interval"] == 30
+
+    def test_subscriber_drops_timeout_even_when_configured(self):
+        """A non-zero redis_socket_timeout still leaves the subscriber timeout-free."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(), redis_socket_timeout=5
+        )
+        assert config.redis_subscriber_kwargs["socket_timeout"] is None
+
+    def test_command_kwargs_accepted_by_redis_connection(self):
+        """The kwargs must construct a redis-py async client without raising."""
+        import redis.asyncio as aioredis
+
+        config = CoreConfiguration(project=ProjectConfiguration())
+        client = aioredis.Redis(**config.redis_client_kwargs)
+        assert client is not None
+
+    def test_command_timeout_disabled_when_zero(self):
+        """A zero socket_timeout is omitted from command kwargs."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(), redis_socket_timeout=0
+        )
+        assert "socket_timeout" not in config.redis_client_kwargs
+
+    def test_health_check_disabled_when_zero(self):
+        """A zero health_check_interval omits health_check_interval from both."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(), redis_health_check_interval=0
+        )
+        assert "health_check_interval" not in config.redis_client_kwargs
+        assert "health_check_interval" not in config.redis_subscriber_kwargs
+
+
 class TestCoreConfigurationLocaleDetection:
     """Test locale_detection field in CoreConfiguration."""
 

--- a/vibetuner-py/tests/unit/test_redis.py
+++ b/vibetuner-py/tests/unit/test_redis.py
@@ -21,7 +21,7 @@ class TestGetRedisClient:
 
     @pytest.mark.asyncio
     async def test_creates_client_when_url_configured(self):
-        """Creates and caches a client when redis_url is set."""
+        """Creates and caches a command client with resilience kwargs when set."""
         redis_mod._client = None
         mock_client = AsyncMock()
 
@@ -30,10 +30,13 @@ class TestGetRedisClient:
             patch("redis.asyncio.from_url", return_value=mock_client) as mock_from_url,
         ):
             mock_settings.redis_url = "redis://localhost:6379/0"
+            mock_settings.redis_client_kwargs = {"socket_timeout": 30.0}
             result = await redis_mod.get_redis_client()
 
         assert result is mock_client
-        mock_from_url.assert_called_once_with("redis://localhost:6379/0")
+        mock_from_url.assert_called_once_with(
+            "redis://localhost:6379/0", socket_timeout=30.0
+        )
 
         # Cleanup
         redis_mod._client = None
@@ -80,3 +83,29 @@ class TestResetRedisClient:
         redis_mod._client = AsyncMock()
         redis_mod.reset_redis_client()
         assert redis_mod._client is None
+
+
+class TestCreateRedisClient:
+    """Test the dedicated pub/sub subscriber client factory."""
+
+    def test_returns_none_when_no_redis_url(self):
+        """Returns None if redis_url is not configured."""
+        with patch("vibetuner.config.settings") as mock_settings:
+            mock_settings.redis_url = None
+            assert redis_mod.create_redis_client() is None
+
+    def test_uses_timeout_free_subscriber_kwargs(self):
+        """The subscriber client is built with the timeout-free subscriber kwargs."""
+        mock_client = object()
+        with (
+            patch("vibetuner.config.settings") as mock_settings,
+            patch("redis.asyncio.from_url", return_value=mock_client) as mock_from_url,
+        ):
+            mock_settings.redis_url = "redis://localhost:6379/0"
+            mock_settings.redis_subscriber_kwargs = {"socket_timeout": None}
+            result = redis_mod.create_redis_client()
+
+        assert result is mock_client
+        mock_from_url.assert_called_once_with(
+            "redis://localhost:6379/0", socket_timeout=None
+        )

--- a/vibetuner-py/tests/unit/test_sse.py
+++ b/vibetuner-py/tests/unit/test_sse.py
@@ -324,6 +324,51 @@ class _FakeClient:
         pass
 
 
+class _FlakyPubSub:
+    """A subscriber whose first connection's ``listen()`` raises a Redis error."""
+
+    def __init__(self, fail: bool, subscribed: list[str], reconnected) -> None:
+        self._fail = fail
+        self._subscribed = subscribed
+        self._reconnected = reconnected
+
+    async def psubscribe(self, pattern: str) -> None:
+        self._subscribed.append(pattern)
+        if len(self._subscribed) >= 2:
+            self._reconnected.set()
+
+    async def punsubscribe(self) -> None:
+        pass
+
+    async def aclose(self) -> None:
+        pass
+
+    async def listen(self):
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+
+        if self._fail:
+            raise RedisTimeoutError("Timeout reading from localhost:6379")
+        while True:
+            await asyncio.sleep(3600)
+            yield {}
+
+
+class _FlakyClient:
+    def __init__(self, fail: bool, subscribed: list[str], reconnected) -> None:
+        self._pubsub = _FlakyPubSub(fail, subscribed, reconnected)
+
+    def pubsub(self) -> _FlakyPubSub:
+        return self._pubsub
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _enable_redis(monkeypatch) -> None:
+    """Make ``settings.redis_url`` look configured so the listener task starts."""
+    monkeypatch.setattr("vibetuner.config.settings.redis_url", "redis://localhost:6379")
+
+
 @pytest_asyncio.fixture
 async def sse_module():
     import vibetuner.sse as sse
@@ -349,6 +394,7 @@ class TestRedisListenerLifecycle:
     @pytest.mark.asyncio
     async def test_start_is_idempotent_while_alive(self, sse_module, monkeypatch):
         sse = sse_module
+        _enable_redis(monkeypatch)
         monkeypatch.setattr(
             "vibetuner.redis.create_redis_client", lambda: _FakeClient()
         )
@@ -363,6 +409,7 @@ class TestRedisListenerLifecycle:
     @pytest.mark.asyncio
     async def test_start_replaces_dead_task(self, sse_module, monkeypatch):
         sse = sse_module
+        _enable_redis(monkeypatch)
         monkeypatch.setattr(
             "vibetuner.redis.create_redis_client", lambda: _FakeClient()
         )
@@ -380,3 +427,42 @@ class TestRedisListenerLifecycle:
         second = sse._redis_listener_task
         assert second is not None and second is not first
         assert not second.done()
+
+    @pytest.mark.asyncio
+    async def test_no_task_without_redis_url(self, sse_module, monkeypatch):
+        """With Redis unconfigured the listener stays local-only (no task)."""
+        sse = sse_module
+        monkeypatch.setattr("vibetuner.config.settings.redis_url", None)
+
+        await start_redis_listener()
+        assert sse._redis_listener_task is None
+
+    @pytest.mark.asyncio
+    async def test_listener_reconnects_after_redis_error(self, sse_module, monkeypatch):
+        """A Redis error re-subscribes instead of killing the listener.
+
+        Issue #1958: the subscriber's 30s read timeout raised TimeoutError on idle
+        channels; the loop only caught CancelledError, so the task died and
+        PUBSUB NUMPAT decayed to 0. The loop must reconnect and re-subscribe.
+        """
+        sse = sse_module
+        _enable_redis(monkeypatch)
+        monkeypatch.setattr(sse, "_LISTENER_RECONNECT_DELAY", 0)
+
+        subscribed: list[str] = []
+        reconnected = asyncio.Event()
+        clients = iter(
+            [
+                _FlakyClient(fail=True, subscribed=subscribed, reconnected=reconnected),
+                _FlakyClient(
+                    fail=False, subscribed=subscribed, reconnected=reconnected
+                ),
+            ]
+        )
+        monkeypatch.setattr(
+            "vibetuner.redis.create_redis_client", lambda: next(clients)
+        )
+
+        await start_redis_listener()
+        await asyncio.wait_for(reconnected.wait(), timeout=2)
+        assert len(subscribed) >= 2


### PR DESCRIPTION
## Problem

Closes #1958. SSE delivers nothing under a long-lived granian worker. Root cause (credit to the filing agent's analysis on the issue):

The SSE Redis **subscriber** connection carried the command client's 30s socket read timeout. A subscriber blocks indefinitely waiting for the next message, so after ~30s with no broadcast, `pubsub.listen()` raises `redis.exceptions.TimeoutError`. `_redis_listen_loop` only caught `asyncio.CancelledError`, so the exception killed the task; its `finally` ran `punsubscribe()` → `PUBSUB NUMPAT` dropped to 0 → the worker went silent. The lazy re-arm on the next SSE connect re-subscribed and died again 30s later, so a broadcast was only ever delivered in the rare window where it landed within 30s of a fresh subscription on the same worker.

## Fix

A subscriber must never carry a socket read timeout. Split the redis-py kwargs:

- **`redis_client_kwargs`** — command clients (cache, health, SSE publish). Keeps `socket_timeout`, which safely turns a silently-dropped connection's blocking read into a raised error.
- **`redis_subscriber_kwargs`** — the SSE pub/sub subscriber. Forces `socket_timeout=None`; liveness relies on `health_check_interval` PINGs and TCP keepalive instead.

`create_redis_client()` (pub/sub) now uses the timeout-free set; `get_redis_client()` (commands) uses the full set.

Belt-and-suspenders: `_redis_listen_loop` now owns connect/subscribe and **reconnects on any `RedisError`** instead of exiting, so a transient drop re-subscribes rather than leaving the worker silent.

## Tests

- `redis_client_kwargs` carries `socket_timeout`; `redis_subscriber_kwargs` forces it to `None` even when `redis_socket_timeout` is configured.
- `create_redis_client` / `get_redis_client` pass the right kwargs to `from_url`.
- The listener re-subscribes after a `RedisError` from `listen()` instead of dying.
- No listener task is started when Redis is unconfigured.

944 unit tests pass; ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)