### PR TITLE
fix: keep i18n catalogs single-line with --no-wrap (#1967)

### DIFF
--- a/.justfiles/i18n.justfile
+++ b/.justfiles/i18n.justfile
@@ -16,6 +16,7 @@ i18n-framework: extract-framework-translations update-framework-locales compile-
 [group('localization')]
 extract-framework-translations:
     @cd vibetuner-py && uv run --frozen pybabel extract \
+        --no-wrap \
         --add-location=file \
         -F babel.cfg \
         --project=vibetuner \
@@ -28,6 +29,7 @@ extract-framework-translations:
 [group('localization')]
 new-framework-locale LANG:
     @cd vibetuner-py && uv run --frozen pybabel init \
+        --no-wrap \
         -i src/vibetuner/locales/messages.pot \
         -d src/vibetuner/locales \
         -l {{ LANG }}
@@ -36,7 +38,7 @@ new-framework-locale LANG:
 [group('localization')]
 update-framework-locales:
     @cd vibetuner-py && find src/vibetuner/locales -type f -path "*/LC_MESSAGES/messages.po" \
-        -exec sh -c 'echo " ↺ {}"; msguniq "{}" -o "{}"; msgmerge --add-location=file --no-fuzzy-matching --update --backup=none --previous "{}" src/vibetuner/locales/messages.pot' \;
+        -exec sh -c 'echo " ↺ {}"; msguniq --no-wrap "{}" -o "{}"; msgmerge --no-wrap --add-location=file --no-fuzzy-matching --update --backup=none --previous "{}" src/vibetuner/locales/messages.pot' \;
 
 # Compile framework .po files to .mo files (the wheel ships .mo only)
 [group('localization')]

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -1233,7 +1233,9 @@ and `.mo` files are committed to the repo so end users don't need
 `update-framework-locales` uses `msgmerge --no-fuzzy-matching` so new
 strings stay empty rather than inheriting a wrong guess from a similar
 entry; `just i18n-framework-fuzzy-audit` reports any `#, fuzzy` entries
-in the framework catalogs.
+in the framework catalogs. The recipes pass `--no-wrap` so entries stay
+single-line and don't drift when gettext's line-wrapping differs between
+macOS and the Linux used in CI.
 
 ### Extracting Translations
 
@@ -1248,6 +1250,11 @@ This scans your code and templates for `{% trans %}` blocks and `gettext()` call
 Catalog references record the source **file** only (`#: templates/frontend/index.html.jinja`),
 not the line number. Moving a translatable string within a file therefore produces no catalog
 churn, so a pure line shift never drifts `messages.pot` or your `.po` files.
+
+The recipes also pass `--no-wrap`, so every `msgid`/`msgstr` stays on a single line. GNU
+gettext's default line wrapping varies between versions and platforms (macOS vs the Linux used
+in CI), which would otherwise rewrap long strings differently and drift the catalogs between a
+developer's machine and CI. Single-line entries are deterministic everywhere.
 
 ### Adding New Languages
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -151,7 +151,10 @@ just i18n-fuzzy-audit        # Report fuzzy-marked entries across catalogs
 
 `update-locale-files` runs `msgmerge --no-fuzzy-matching`: new strings
 land with an empty `msgstr` (honest untranslated → English fallback)
-instead of a wrong guess copied from a textually similar entry.
+instead of a wrong guess copied from a textually similar entry. The i18n
+recipes also pass `--no-wrap`, keeping every `msgid`/`msgstr` on a single
+line so catalogs don't drift when gettext's line-wrapping differs between
+macOS and the Linux used in CI.
 
 **CI/CD & Deployment:**
 

--- a/vibetuner-py/src/vibetuner/locales/ca/LC_MESSAGES/messages.po
+++ b/vibetuner-py/src/vibetuner/locales/ca/LC_MESSAGES/messages.po
@@ -139,8 +139,7 @@ msgstr "No veus el correu?"
 
 #: src/vibetuner/templates/frontend/email_sent.html.jinja
 msgid "Check your spam folder or try signing in again."
-msgstr ""
-"Comprova la carpeta de correu brossa o torna a provar d'iniciar sessió."
+msgstr "Comprova la carpeta de correu brossa o torna a provar d'iniciar sessió."
 
 #: src/vibetuner/templates/frontend/email_sent.html.jinja
 msgid "Try Again"
@@ -247,9 +246,7 @@ msgstr "Això anul·larà la detecció d'idioma del navegador"
 
 #: src/vibetuner/templates/frontend/user/edit.html.jinja
 msgid "Email cannot be changed and is managed through your OAuth provider"
-msgstr ""
-"El correu electrònic no es pot canviar i es gestiona des del teu proveïdor "
-"OAuth"
+msgstr "El correu electrònic no es pot canviar i es gestiona des del teu proveïdor OAuth"
 
 #: src/vibetuner/templates/frontend/user/edit.html.jinja
 msgid "Save Changes"
@@ -260,13 +257,8 @@ msgid "About Language Preferences"
 msgstr "Sobre les preferències d'idioma"
 
 #: src/vibetuner/templates/frontend/user/edit.html.jinja
-msgid ""
-"Your language preference will take priority over URL parameters, cookies, "
-"and browser settings. Leave empty to use automatic detection."
-msgstr ""
-"La teva preferència d'idioma té prioritat sobre els paràmetres de l'URL, les "
-"galetes i la configuració del navegador. Deixa-ho buit per fer servir la "
-"detecció automàtica."
+msgid "Your language preference will take priority over URL parameters, cookies, and browser settings. Leave empty to use automatic detection."
+msgstr "La teva preferència d'idioma té prioritat sobre els paràmetres de l'URL, les galetes i la configuració del navegador. Deixa-ho buit per fer servir la detecció automàtica."
 
 #: src/vibetuner/templates/frontend/user/profile.html.jinja
 msgid "User Profile"

--- a/vibetuner-py/src/vibetuner/locales/en/LC_MESSAGES/messages.po
+++ b/vibetuner-py/src/vibetuner/locales/en/LC_MESSAGES/messages.po
@@ -257,12 +257,8 @@ msgid "About Language Preferences"
 msgstr "About Language Preferences"
 
 #: src/vibetuner/templates/frontend/user/edit.html.jinja
-msgid ""
-"Your language preference will take priority over URL parameters, cookies, "
-"and browser settings. Leave empty to use automatic detection."
-msgstr ""
-"Your language preference will take priority over URL parameters, cookies, "
-"and browser settings. Leave empty to use automatic detection."
+msgid "Your language preference will take priority over URL parameters, cookies, and browser settings. Leave empty to use automatic detection."
+msgstr "Your language preference will take priority over URL parameters, cookies, and browser settings. Leave empty to use automatic detection."
 
 #: src/vibetuner/templates/frontend/user/profile.html.jinja
 msgid "User Profile"

--- a/vibetuner-py/src/vibetuner/locales/messages.pot
+++ b/vibetuner-py/src/vibetuner/locales/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vibetuner VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/alltuner/vibetuner/issues\n"
-"POT-Creation-Date: 2026-06-02 12:40+0200\n"
+"POT-Creation-Date: 2026-06-02 16:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -256,9 +256,7 @@ msgid "About Language Preferences"
 msgstr ""
 
 #: src/vibetuner/templates/frontend/user/edit.html.jinja
-msgid ""
-"Your language preference will take priority over URL parameters, cookies,"
-" and browser settings. Leave empty to use automatic detection."
+msgid "Your language preference will take priority over URL parameters, cookies, and browser settings. Leave empty to use automatic detection."
 msgstr ""
 
 #: src/vibetuner/templates/frontend/user/profile.html.jinja

--- a/vibetuner-template/.justfiles/i18n.justfile
+++ b/vibetuner-template/.justfiles/i18n.justfile
@@ -6,17 +6,17 @@ i18n: extract-translations update-locale-files compile-locales
 # Extracts translations from source files
 [group('localization')]
 extract-translations:
-    @uv run --frozen pybabel extract --add-location=file -F babel.cfg -o locales/messages.pot .
+    @uv run --frozen pybabel extract --no-wrap --add-location=file -F babel.cfg -o locales/messages.pot .
 
 # Creates a new language file for localization
 [group('localization')]
 new-locale LANG:
-    @uv run --frozen pybabel init -i locales/messages.pot -d locales -l {{ LANG }}
+    @uv run --frozen pybabel init --no-wrap -i locales/messages.pot -d locales -l {{ LANG }}
 
 # Updates existing language files for localization
 [group('localization')]
 update-locale-files:
-    @find locales -type f -path "*/LC_MESSAGES/messages.po" -exec sh -c 'echo " ↺ {}"; msguniq "{}" -o "{}"; msgmerge --add-location=file --no-fuzzy-matching --update --backup=none --previous "{}" locales/messages.pot' \;
+    @find locales -type f -path "*/LC_MESSAGES/messages.po" -exec sh -c 'echo " ↺ {}"; msguniq --no-wrap "{}" -o "{}"; msgmerge --no-wrap --add-location=file --no-fuzzy-matching --update --backup=none --previous "{}" locales/messages.pot' \;
 
 # Compiles the language files into binary format
 [group('localization')]


### PR DESCRIPTION
## Problem

GNU gettext wraps long `msgid`/`msgstr` lines by default, and the wrap heuristic differs across gettext versions and platforms (macOS vs the Linux used in CI). Multi-line catalog entries therefore rewrap differently between a developer's machine and CI, drifting the `.po`/`.pot` catalogs on pure regeneration.

The committed framework catalogs (`vibetuner-py/src/vibetuner/locales/`) contained wrapped multi-line entries, making them vulnerable to exactly this cross-platform drift.

## Fix

Pass `--no-wrap` to `pybabel extract`/`init`, `msguniq`, and `msgmerge` in **both** i18n recipe sets:

- `.justfiles/i18n.justfile` (framework)
- `vibetuner-template/.justfiles/i18n.justfile` (scaffold)

Every `msgid`/`msgstr` now stays on a single line, so regeneration is deterministic across platforms. The framework catalogs are regenerated here to collapse the existing wrapped entries — the diff is **purely unwrapping** (no `msgid`/`msgstr` content changes), and re-running `just i18n-framework` is idempotent.

Docs (development-guide, llms-full) updated with the determinism rationale.

## Note on #1967

The issue's history (a dropped `--no-wrap`, a contradicting comment, a `catalog-round-trip` CI job) describes a downstream scaffolded app, not this repo — `--no-wrap` was never in these justfiles per git history, and #1950 only *added* `--add-location=file`. The underlying fix is correct regardless, so it's implemented with accurate framing.

Closes #1967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)