### PR TITLE
fix: load ProjectConfiguration deploy-config from .env (#1970)

### DIFF
--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -289,7 +289,9 @@ class ProjectConfiguration(BaseSettings):
         )
         return f"© {year_part}{f' {self.company_name}' if self.company_name else ''}"
 
-    model_config = SettingsConfigDict(case_sensitive=False, extra="ignore")
+    model_config = SettingsConfigDict(
+        case_sensitive=False, extra="ignore", env_file=_ENV_FILES
+    )
 
 
 class CoreConfiguration(BaseSettings):

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -6,10 +6,39 @@ from unittest.mock import patch
 
 import pytest
 from vibetuner.config import (
+    _ENV_FILES,
     CoreConfiguration,
     LocaleDetectionSettings,
     ProjectConfiguration,
 )
+
+
+class TestProjectConfigurationEnvFile:
+    """Test that ProjectConfiguration loads deploy-config from .env files.
+
+    Deploy-time fields like from_email have no stable home in the copier
+    questionnaire (non-template keys are stripped on copier update), so they
+    must be settable via .env like the other settings classes (#1970).
+    """
+
+    def test_declares_env_file(self):
+        """ProjectConfiguration wires .env loading, matching the sibling
+        settings classes (CoreConfiguration, MailSettings, BrandSettings, ...)."""
+        assert ProjectConfiguration.model_config.get("env_file") == _ENV_FILES
+
+    def test_from_email_loads_from_dotenv(self, tmp_path):
+        """from_email is populated from a .env file at the project root."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("FROM_EMAIL=ops@example.com\n")
+        with patch.dict("os.environ", {}, clear=True):
+            project = ProjectConfiguration(_env_file=str(env_file))
+            assert project.from_email == "ops@example.com"
+
+    def test_from_email_falls_back_to_default(self):
+        """Without .env or env var, from_email keeps its default."""
+        with patch.dict("os.environ", {}, clear=True):
+            project = ProjectConfiguration(_env_file=None)
+            assert project.from_email == "no-reply@example.com"
 
 
 class TestCoreConfigurationEnvironment:


### PR DESCRIPTION
## Summary

Fixes #1970. `ProjectConfiguration` did not set `env_file` in its `model_config`, so deploy-time fields that live on it (notably `from_email`) could **not** be configured via a `.env` file in development. They only resolved from:

- real OS environment variables (works in Docker/prod), or
- `.copier-answers.yml`, where non-template keys are silently stripped on `copier update` — a fragile home for deploy config.

Every sibling settings class (`CoreConfiguration`, `MailSettings`, `BrandSettings`, `RateLimitSettings`, `LocaleDetectionSettings`, `SecurityHeadersSettings`) already declares `env_file=_ENV_FILES`. This change brings `ProjectConfiguration` in line, so `FROM_EMAIL=...` in `.env` works in dev as the docs already describe.

## Change

- `config.py`: add `env_file=_ENV_FILES` to `ProjectConfiguration.model_config`.

## Tests

Added `TestProjectConfigurationEnvFile` in `test_config.py`:
- `test_declares_env_file` — guards the `model_config` wiring (fails on `main`, passes here).
- `test_from_email_loads_from_dotenv` — `from_email` is read from a `.env` file.
- `test_from_email_falls_back_to_default` — default preserved with no `.env`/env var.

Verified the structural test fails before the fix and passes after.

## Precedence note

When `ProjectConfiguration` is built from `.copier-answers.yml` via `ProjectConfiguration(**yaml_data)`, init kwargs remain the highest-priority source — so a `from_email` present in `.copier-answers.yml` still wins over `.env`. The `.env` value applies precisely when the key is absent from the questionnaire, which is the scenario the issue wants.

## Docs

No doc change: `FROM_EMAIL` in `.env` is already documented (`authentication.md`, `deployment.md`, `llms-full.txt`). This fix makes the code honor the existing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)