### PR TITLE
fix: negotiate Accept-Language with language-only subtag fallback (#1973)

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -1379,6 +1379,12 @@ Languages are detected in this order (first match wins):
 6. Accept-Language header (browser preference)
 7. Default language
 
+The Accept-Language step negotiates region-aware: each browser preference is
+matched against the supported languages by its full tag first, then by its
+language-only subtag, so a region-qualified top preference like `ca-ES` resolves
+to a supported `ca` instead of losing to a lower-ranked exact match such as `es`.
+The highest-quality preference with any supported match wins.
+
 #### Custom Locale Resolvers (`register_locale_resolver`)
 
 For per-tenant or domain-specific locale rules, register a custom resolver at

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1577,7 +1577,7 @@ it, which is a different mechanism. Tracked in
 
 ### i18n Primitives
 
-`vibetuner.i18n` exposes three primitives for apps that need to override
+`vibetuner.i18n` exposes primitives for apps that need to override
 locale detection or render language switchers without hardcoding language
 lists.
 
@@ -1679,6 +1679,28 @@ template variable (set of codes) are unchanged.
 Need native names but want a single source of truth? Call
 `language_picker(code)` once per language instead of reading
 `locale_names`.
+
+#### `negotiate_accept_language(header, supported)` / `LocaleFromAcceptLanguage`
+
+The built-in `Accept-Language` selector vibetuner installs in
+`LocaleMiddleware`. It walks the header's language tags from highest to
+lowest quality and returns the first that matches a supported locale,
+either by full tag (`ca_ES` against supported `ca_ES`) or by language-only
+subtag (`ca_ES` against supported `ca`). A higher-quality region-qualified
+preference therefore wins over a lower-quality exact match:
+
+```python
+from vibetuner.i18n import negotiate_accept_language
+
+supported = ["ca", "es", "eu", "nl", "sv", "en"]
+negotiate_accept_language("ca-ES,es;q=0.9,en;q=0.8", supported)  # "ca"
+negotiate_accept_language("ca-ES", supported)                    # "ca"
+```
+
+Tags with `q=0` (explicitly unacceptable) and the `*` wildcard are
+skipped. `LocaleFromAcceptLanguage(supported_locales)` is the selector
+wrapper; `negotiate_accept_language` is the pure function it delegates to,
+exposed for direct reuse and testing.
 
 ### Framework Translation Catalogs
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -100,7 +100,11 @@ Important notes:
   returning `[{code, name}]` with names rendered in the current request's locale
   (browsing in Spanish gives "inglés / español / catalán"; never English-only).
   `language_picker` is also registered as a Jinja global so templates can call
-  it directly without overriding any existing template variable
+  it directly without overriding any existing template variable. The
+  Accept-Language selector (`LocaleFromAcceptLanguage` / `negotiate_accept_language`)
+  negotiates region-aware with language-only subtag fallback, so a region-qualified
+  top preference (`ca-ES`) resolves to supported `ca` instead of losing to a
+  lower-ranked exact match (`es`)
 - **Framework Translation Catalogs**: vibetuner ships compiled
   `.mo` files under `vibetuner/locales/<lang>/LC_MESSAGES/messages.mo`
   (currently `en`, `ca`). `frontend/middleware.py` loads them before the

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -14,7 +14,6 @@ from starlette.responses import Response as StarletteResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 from starlette_babel import (
     LocaleFromCookie,
-    LocaleFromHeader,
     LocaleFromQuery,
     LocaleMiddleware,
     get_translator,
@@ -579,7 +578,7 @@ def _build_locale_selectors() -> list:
     4. cookie - language cookie
     5. accept_language - browser Accept-Language header
     """
-    from vibetuner.i18n import combined_locale_selector
+    from vibetuner.i18n import LocaleFromAcceptLanguage, combined_locale_selector
 
     selectors: list = [combined_locale_selector]
     config = settings.locale_detection
@@ -593,7 +592,9 @@ def _build_locale_selectors() -> list:
     if config.cookie:
         selectors.append(LocaleFromCookie())
     if config.accept_language:
-        selectors.append(LocaleFromHeader(supported_locales=ctx.supported_languages))
+        selectors.append(
+            LocaleFromAcceptLanguage(supported_locales=ctx.supported_languages)
+        )
 
     return selectors
 

--- a/vibetuner-py/src/vibetuner/i18n.py
+++ b/vibetuner-py/src/vibetuner/i18n.py
@@ -16,6 +16,10 @@ user-driven language flows:
 * :func:`language_picker` — produce ``[{code, name}]`` for a language
   switcher, with names rendered in the *current* display locale (not
   hard-coded to English).
+* :func:`negotiate_accept_language` / :class:`LocaleFromAcceptLanguage`
+  — region-aware ``Accept-Language`` negotiation that honors a
+  region-qualified top preference (``ca-ES``) against a language-only
+  supported locale (``ca``).
 
 ``language_picker`` is also exposed as a Jinja global so templates can
 call it directly — no new context variable, no override of the existing
@@ -23,7 +27,7 @@ call it directly — no new context variable, no override of the existing
 codes).
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 from babel import Locale, UnknownLocaleError
 from fastapi.requests import HTTPConnection
@@ -35,16 +39,97 @@ from vibetuner.logging import logger
 
 
 __all__ = [
+    "LocaleFromAcceptLanguage",
     "LocaleResolver",
     "combined_locale_selector",
     "get_locale_resolvers",
     "language_picker",
+    "negotiate_accept_language",
     "register_locale_resolver",
     "set_request_language",
 ]
 
 
 LocaleResolver = Callable[[HTTPConnection], str | None]
+
+
+def _rank_accept_language(header: str) -> list[str]:
+    """Return ``Accept-Language`` tags ordered best-preference first.
+
+    Tags are sorted by quality descending, ties broken by their order in
+    the header. The ``*`` wildcard and any tag with ``q=0`` (explicitly
+    unacceptable) are dropped.
+    """
+    ranked: list[tuple[float, int, str]] = []
+    for index, part in enumerate(header.split(",")):
+        tag, _, params = part.strip().partition(";")
+        tag = tag.strip()
+        if not tag or tag == "*":
+            continue
+        quality = 1.0
+        if params:
+            _, _, value = params.partition("=")
+            try:
+                quality = float(value.strip())
+            except ValueError:
+                quality = 1.0
+        if quality <= 0:
+            continue
+        ranked.append((quality, index, tag))
+    ranked.sort(key=lambda item: (-item[0], item[1]))
+    return [tag for _, _, tag in ranked]
+
+
+def negotiate_accept_language(header: str, supported: Iterable[str]) -> str | None:
+    """Pick the best supported locale for an ``Accept-Language`` header.
+
+    Walks the header's language tags from highest to lowest quality and
+    returns the first that matches a supported locale, either exactly
+    (``ca_ES`` against supported ``ca_ES``) or by its language-only
+    subtag (``ca_ES`` against supported ``ca``). A higher-quality
+    region-qualified tag therefore wins over a lower-quality exact match.
+
+    :class:`starlette_babel.LocaleFromHeader` matches by full identifier
+    only, so it silently drops a region-qualified top preference and lets
+    a lower-ranked exact match win; this function exists to negotiate
+    correctly in that case.
+
+    Returns ``None`` when nothing matches, so the caller falls through to
+    the next selector or the default locale.
+    """
+    by_full: dict[str, str] = {}
+    by_language: dict[str, str] = {}
+    for code in supported:
+        normalized = code.lower().replace("-", "_")
+        by_full.setdefault(normalized, code)
+        by_language.setdefault(normalized.split("_")[0], code)
+
+    for tag in _rank_accept_language(header):
+        normalized = tag.lower().replace("-", "_")
+        if normalized in by_full:
+            return by_full[normalized]
+        match = by_language.get(normalized.split("_")[0])
+        if match is not None:
+            return match
+    return None
+
+
+class LocaleFromAcceptLanguage:
+    """Locale selector that negotiates the ``Accept-Language`` header.
+
+    Mirrors :class:`starlette_babel.LocaleFromHeader`'s selector
+    interface but resolves a region-qualified preference (``ca-ES``) to a
+    language-only supported locale (``ca``) instead of discarding it, so
+    the highest-ranked acceptable language wins.
+    """
+
+    def __init__(self, supported_locales: Iterable[str]) -> None:
+        self.supported_locales = list(supported_locales)
+
+    def __call__(self, conn: HTTPConnection) -> str | None:
+        return negotiate_accept_language(
+            conn.headers.get("accept-language", ""), self.supported_locales
+        )
 
 
 _resolvers: list[tuple[int, int, LocaleResolver]] = []

--- a/vibetuner-py/tests/unit/test_i18n.py
+++ b/vibetuner-py/tests/unit/test_i18n.py
@@ -105,6 +105,68 @@ class TestRegisterLocaleResolver:
             i18n.register_locale_resolver("not a function")  # type: ignore[arg-type]
 
 
+SUPPORTED = ["ca", "es", "eu", "nl", "sv", "en"]
+
+
+class TestNegotiateAcceptLanguage:
+    def test_region_qualified_top_preference_beats_lower_quality_exact(self):
+        # ca-ES (q=1.0) must win over es (q=0.9) via language-only fallback.
+        result = i18n.negotiate_accept_language("ca-ES,es;q=0.9,en;q=0.8", SUPPORTED)
+        assert result == "ca"
+
+    def test_bare_region_tag_falls_back_to_language(self):
+        assert i18n.negotiate_accept_language("ca-ES", SUPPORTED) == "ca"
+
+    def test_unsupported_top_token_defers_to_next_match(self):
+        # zh-TW is unsupported even by language, so the q=0.9 ca-ES wins.
+        result = i18n.negotiate_accept_language("zh-TW,ca-ES;q=0.9,es;q=0.8", SUPPORTED)
+        assert result == "ca"
+
+    def test_exact_region_match_is_preserved(self):
+        supported = ["pt_BR", "pt_PT", "en"]
+        result = i18n.negotiate_accept_language("pt-PT,pt;q=0.9", supported)
+        assert result == "pt_PT"
+
+    def test_language_only_request_maps_to_first_supported_variant(self):
+        supported = ["pt_BR", "pt_PT"]
+        assert i18n.negotiate_accept_language("pt", supported) == "pt_BR"
+
+    def test_q_zero_token_is_skipped(self):
+        # ca is explicitly unacceptable, so es wins despite lower position.
+        assert i18n.negotiate_accept_language("ca;q=0,es", SUPPORTED) == "es"
+
+    def test_wildcard_is_ignored(self):
+        assert i18n.negotiate_accept_language("*", SUPPORTED) is None
+        assert i18n.negotiate_accept_language("*,ca;q=0.5", SUPPORTED) == "ca"
+
+    def test_empty_header_returns_none(self):
+        assert i18n.negotiate_accept_language("", SUPPORTED) is None
+
+    def test_no_match_returns_none(self):
+        assert i18n.negotiate_accept_language("de,fr", SUPPORTED) is None
+
+    def test_matching_is_case_insensitive(self):
+        assert i18n.negotiate_accept_language("CA-es", SUPPORTED) == "ca"
+
+    def test_malformed_quality_defaults_to_one(self):
+        # ca with an unparseable q keeps quality 1.0 and still wins.
+        assert i18n.negotiate_accept_language("ca;q=abc,es;q=0.9", SUPPORTED) == "ca"
+
+
+class TestLocaleFromAcceptLanguage:
+    def test_selector_negotiates_header(self):
+        selector = i18n.LocaleFromAcceptLanguage(SUPPORTED)
+        conn = MagicMock()
+        conn.headers = {"accept-language": "ca-ES,es;q=0.9"}
+        assert selector(conn) == "ca"
+
+    def test_selector_returns_none_without_header(self):
+        selector = i18n.LocaleFromAcceptLanguage(SUPPORTED)
+        conn = MagicMock()
+        conn.headers = {}
+        assert selector(conn) is None
+
+
 class TestSetRequestLanguage:
     def test_updates_request_state_and_babel_contextvar(self):
         request = _fake_request(language="en")

--- a/vibetuner-py/tests/unit/test_locale_selectors.py
+++ b/vibetuner-py/tests/unit/test_locale_selectors.py
@@ -17,8 +17,9 @@ for the same reason. The test validates the logic; integration tests verify the
 actual middleware configuration.
 """
 
-from starlette_babel import LocaleFromCookie, LocaleFromHeader, LocaleFromQuery
+from starlette_babel import LocaleFromCookie, LocaleFromQuery
 from vibetuner.config import LocaleDetectionSettings
+from vibetuner.i18n import LocaleFromAcceptLanguage
 
 
 def locale_selector(conn) -> str | None:
@@ -58,7 +59,9 @@ def build_locale_selectors(
     if config.cookie:
         selectors.append(LocaleFromCookie())
     if config.accept_language:
-        selectors.append(LocaleFromHeader(supported_locales=supported_languages))
+        selectors.append(
+            LocaleFromAcceptLanguage(supported_locales=supported_languages)
+        )
 
     return selectors
 
@@ -118,7 +121,7 @@ class TestBuildLocaleSelectors:
         assert "LocaleFromCookie" not in selector_types
 
     def test_accept_language_disabled(self):
-        """When accept_language is disabled, LocaleFromHeader not included."""
+        """When accept_language is disabled, LocaleFromAcceptLanguage not included."""
         config = LocaleDetectionSettings(accept_language=False)
         supported_languages = {"en", "ca", "es"}
 
@@ -126,7 +129,7 @@ class TestBuildLocaleSelectors:
 
         assert len(selectors) == 4
         selector_types = [type(s).__name__ for s in selectors]
-        assert "LocaleFromHeader" not in selector_types
+        assert "LocaleFromAcceptLanguage" not in selector_types
 
     def test_multiple_selectors_disabled(self):
         """Multiple selectors can be disabled simultaneously."""
@@ -143,7 +146,7 @@ class TestBuildLocaleSelectors:
         assert len(selectors) == 2
         selector_types = [type(s).__name__ for s in selectors]
         assert "LocaleFromQuery" not in selector_types
-        assert "LocaleFromHeader" not in selector_types
+        assert "LocaleFromAcceptLanguage" not in selector_types
 
     def test_all_selectors_disabled(self):
         """When all selectors are disabled, empty list is returned."""
@@ -168,7 +171,7 @@ class TestBuildLocaleSelectors:
         selectors = build_locale_selectors(config, supported_languages)
 
         selector_types = [type(s).__name__ for s in selectors]
-        # Order: LocaleFromQuery, function, function, LocaleFromCookie, LocaleFromHeader
+        # Order: LocaleFromQuery, function, function, LocaleFromCookie, LocaleFromAcceptLanguage
         assert selector_types[0] == "LocaleFromQuery"
         assert selector_types[3] == "LocaleFromCookie"
-        assert selector_types[4] == "LocaleFromHeader"
+        assert selector_types[4] == "LocaleFromAcceptLanguage"


### PR DESCRIPTION
## Summary

Fixes #1973. The Accept-Language locale selector matched each header token against the supported locales by **full identifier only**, so a region-qualified top preference was silently dropped in favor of a lower-ranked exact match. A Catalan browser sending `Accept-Language: ca-ES,es;q=0.9,en;q=0.8` was served Castilian (`es`) instead of Catalan (`ca`), and a bare `ca-ES` resolved to nothing.

The root cause is upstream in `starlette_babel.LocaleFromHeader`, which never falls back to the language-only subtag (`ca_ES` → `ca`) even though the rest of the library (`LocaleMiddleware._find_variant`, `negotiate_locale`) is built around exactly that fallback. We're already on the latest release (1.1.0), so this fixes it framework-side now; the upstream behaviour is being reported separately.

## Change

- Add `negotiate_accept_language(header, supported)` in `vibetuner.i18n`: a pure helper that walks the header's tags highest-to-lowest quality and returns the first that matches a supported locale by full tag, then by language-only subtag. The highest-quality acceptable language wins; `q=0` tags and the `*` wildcard are skipped.
- Add `LocaleFromAcceptLanguage`, the selector wrapper, and use it in `_build_locale_selectors` in place of `LocaleFromHeader`.
- Docs: development guide language-detection section, `llms.txt`, `llms-full.txt`.

## Tests

New unit tests in `tests/unit/test_i18n.py` cover the negotiation (region-qualified top preference beats lower-q exact, bare region fallback, unsupported-top-token defer, exact region preservation, language-only → first supported variant, `q=0` skip, wildcard, empty/no-match, case-insensitivity, malformed `q`) plus the selector wrapper. `test_locale_selectors.py` updated to mirror the new selector. Full unit suite: 960 passed.

Closes #1973