### PR TITLE
fix: fast-path worker-health to skip CLI bootstrap (#1974)

### DIFF
--- a/vibetuner-docs/docs/cli-reference.md
+++ b/vibetuner-docs/docs/cli-reference.md
@@ -124,6 +124,9 @@ vibetuner worker-health
 - Checks for a fresh streaq health key in Redis, which the worker renews from
   inside its event loop, so a wedged or stopped worker reads as unhealthy.
 - Used as the `worker` service healthcheck in the scaffolded `compose.prod.yml`.
+- Runs on a fast path that skips the full CLI/app bootstrap (it only loads the
+  config and a Redis client), so it returns well under a second and stays
+  comfortably inside a small healthcheck `timeout`.
 
 ## `vibetuner db`
 

--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 ]
 
 [project.scripts]
-vibetuner = "vibetuner.cli:app"
+vibetuner = "vibetuner.cli:main"
 
 [project.urls]
 Homepage = "https://vibetuner.alltuner.com/"

--- a/vibetuner-py/src/vibetuner/__main__.py
+++ b/vibetuner-py/src/vibetuner/__main__.py
@@ -1,4 +1,6 @@
-from .cli import app
+# ABOUTME: Enables `python -m vibetuner`, sharing the console script entry point.
+# ABOUTME: Routes through main() so the worker-health fast path applies here too.
+from .cli import main
 
 
-app()
+main()

--- a/vibetuner-py/src/vibetuner/cli/__init__.py
+++ b/vibetuner-py/src/vibetuner/cli/__init__.py
@@ -1,215 +1,31 @@
-# ABOUTME: Core CLI setup with AsyncTyper wrapper and base configuration
-# ABOUTME: Provides main CLI entry point and logging configuration
-import importlib.metadata
-import inspect
-from functools import partial, wraps
-
-import asyncer
-import typer
-
-from vibetuner.cli.config import config_app
-from vibetuner.cli.crypto import crypto_app
-from vibetuner.cli.db import db_app
-from vibetuner.cli.debug import debug_app
-from vibetuner.cli.doctor import doctor_app
-from vibetuner.cli.run import run_app
-from vibetuner.cli.scaffold import scaffold_app
-from vibetuner.loader import ConfigurationError, load_app_config
-from vibetuner.logging import LogLevel, logger, setup_logging
+# ABOUTME: CLI console entry point with a fast path for container healthchecks.
+# ABOUTME: Builds the full Typer app lazily so probes skip the heavy bootstrap.
+import sys
 
 
-class AsyncTyper(typer.Typer):
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("no_args_is_help", True)
-        super().__init__(*args, **kwargs)
+def main() -> None:
+    """Console entry point.
 
-    @staticmethod
-    def maybe_run_async(decorator, f):
-        if inspect.iscoroutinefunction(f):
-
-            @wraps(f)
-            def runner(*args, **kwargs):
-                return asyncer.runnify(f)(*args, **kwargs)
-
-            decorator(runner)
-        else:
-            decorator(f)
-        return f
-
-    def callback(self, *args, **kwargs):
-        decorator = super().callback(*args, **kwargs)
-        return partial(self.maybe_run_async, decorator)
-
-    def command(self, *args, **kwargs):
-        decorator = super().command(*args, **kwargs)
-        return partial(self.maybe_run_async, decorator)
-
-
-def _get_app_help():
-    try:
-        from vibetuner.config import settings
-
-        name = settings.project.project_name
-        if name and name != "default_project":
-            return f"{name.title()} CLI"
-    except (RuntimeError, ImportError):
-        pass
-
-    try:
-        from vibetuner.pyproject import get_project_name
-
-        name = get_project_name()
-        if name:
-            return f"{name.replace('_', ' ').title()} CLI"
-    except Exception:  # noqa: S110
-        pass
-
-    return "Vibetuner CLI"
-
-
-app = AsyncTyper(help=_get_app_help())
-
-LOG_LEVEL_OPTION = typer.Option(
-    LogLevel.INFO,
-    "--log-level",
-    "-l",
-    case_sensitive=False,
-    help="Set the logging level",
-)
-
-
-@app.callback()
-def callback(
-    ctx: typer.Context,
-    log_level: LogLevel | None = LOG_LEVEL_OPTION,
-) -> None:
-    """Initialize logging and other global settings."""
-    if ctx.resilient_parsing:
-        return
-    setup_logging(level=log_level)
-
-
-@app.command()
-def version(
-    show_app: bool = typer.Option(
-        False,
-        "--app",
-        "-a",
-        help="Show app settings version even if not in a project directory",
-    ),
-) -> None:
-    """Show version information."""
-    from rich.console import Console
-    from rich.table import Table
-
-    console = Console()
-
-    try:
-        # Get vibetuner package version
-        vibetuner_version = importlib.metadata.version("vibetuner")
-    except importlib.metadata.PackageNotFoundError:
-        vibetuner_version = "unknown"
-
-    # Create table for nice display
-    table = Table(title="Version Information")
-    table.add_column("Component", style="cyan", no_wrap=True)
-    table.add_column("Version", style="green", no_wrap=True)
-
-    # Always show vibetuner package version
-    table.add_row("vibetuner package", vibetuner_version)
-
-    # Show app version if requested or if in a project
-    try:
-        from vibetuner.config import CoreConfiguration
-
-        settings = CoreConfiguration()
-        table.add_row(f"{settings.project.project_name} settings", settings.version)
-    except Exception:
-        if show_app:
-            table.add_row("app settings", "not in project directory")
-        # else: don't show app version if not in project and not requested
-
-    console.print(table)
-
-
-@app.command(name="worker-health")
-async def worker_health() -> None:
-    """Exit 0 if a worker is alive, else exit 1 (for container healthchecks).
-
-    The streaq worker renews a health key in Redis from inside its event loop,
-    so a wedged loop lets the key expire. This checks for a fresh key.
+    Container healthchecks must finish well under their timeout, but building
+    the full Typer app imports every sub-command and the user's tune.py (config,
+    BlobService, rate limiter), which can take several seconds. Dispatch the
+    healthcheck directly before any of that is imported; everything else builds
+    the full app as usual.
     """
-    from vibetuner.config import settings
+    if sys.argv[1:2] == ["worker-health"]:
+        from vibetuner.cli.health import run
 
-    if not settings.workers_available:
-        logger.error("worker-health: REDIS_URL not configured")
-        raise typer.Exit(code=1)
+        run()
+        return
 
-    import redis.asyncio as aioredis
+    from vibetuner.cli.root import app
 
-    queue_name = settings.redis_key_prefix.rstrip(":")
-    pattern = f"streaq:{queue_name}:health:*"
-    client = aioredis.from_url(
-        str(settings.redis_url), socket_timeout=3, socket_connect_timeout=3
-    )
-    found = False
-    try:
-        async for _key in client.scan_iter(match=pattern, count=100):
-            found = True
-            break
-    except Exception as exc:
-        logger.error("worker-health: Redis check failed: {}", exc)
-        raise typer.Exit(code=1) from exc
-    finally:
-        await client.aclose()
-
-    if not found:
-        logger.error("worker-health: no live worker found for queue {}", queue_name)
-        raise typer.Exit(code=1)
+    app()
 
 
-app.add_typer(config_app, name="config")
-app.add_typer(crypto_app, name="crypto")
-app.add_typer(db_app, name="db")
-app.add_typer(debug_app, name="debug")
-app.add_typer(doctor_app, name="doctor")
-app.add_typer(run_app, name="run")
-app.add_typer(scaffold_app, name="scaffold")
+def __getattr__(name: str):
+    if name in ("app", "AsyncTyper"):
+        import vibetuner.cli.root as root
 
-# Add user CLI commands from tune.py
-try:
-    _app_config = load_app_config()
-    if _app_config.cli:
-        _user_cli = _app_config.cli
-        # Determine the user-provided name, if any
-        _user_name = getattr(getattr(_user_cli, "info", None), "name", None)
-        # Collect core command/group names so we can detect shadowing
-        _core_names = {
-            cmd.name
-            for cmd in app.registered_groups + app.registered_commands
-            if hasattr(cmd, "name") and cmd.name
-        }
-        if _user_name and _user_name in _core_names:
-            logger.warning(
-                f"User CLI group name '{_user_name}' shadows a core vibetuner "
-                f"command. Falling back to namespace 'app'."
-            )
-            _user_name = "app"
-        # Guard against self-referencing cycle: if the user re-exported
-        # vibetuner.cli.app instead of creating their own Typer instance,
-        # adding it as a sub-group of itself causes infinite recursion in
-        # typer >=0.23 (eager group hierarchy resolution).
-        if _user_cli is app:
-            logger.warning(
-                "User CLI is the same object as vibetuner's root app. "
-                "Skipping registration to avoid circular reference. "
-                "Create a separate AsyncTyper() or typer.Typer() instance "
-                "for your CLI commands instead of re-exporting vibetuner.cli.app."
-            )
-        else:
-            # Ensure the user CLI is always namespaced to prevent top-level shadowing
-            app.add_typer(_user_cli, name=_user_name or "app")
-            logger.debug("Registered user CLI commands from tune.py")
-except ConfigurationError:
-    # Not in a project directory or tune.py misconfigured, skip user CLI
-    pass
+        return getattr(root, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vibetuner-py/src/vibetuner/cli/health.py
+++ b/vibetuner-py/src/vibetuner/cli/health.py
@@ -1,0 +1,48 @@
+# ABOUTME: Lightweight worker healthcheck for container probes.
+# ABOUTME: Reads only the streaq health key; skips the full CLI/app bootstrap.
+import asyncio
+
+from vibetuner.logging import logger
+
+
+async def check_worker() -> int:
+    """Return 0 if a live worker is found, 1 otherwise.
+
+    The streaq worker renews a health key in Redis from inside its event loop,
+    so a wedged loop lets the key expire. This checks for a fresh key while
+    importing only the config and Redis client, keeping the probe well under a
+    container healthcheck timeout.
+    """
+    from vibetuner.config import settings
+
+    if not settings.workers_available:
+        logger.error("worker-health: REDIS_URL not configured")
+        return 1
+
+    import redis.asyncio as aioredis
+
+    queue_name = settings.redis_key_prefix.rstrip(":")
+    pattern = f"streaq:{queue_name}:health:*"
+    client = aioredis.from_url(
+        str(settings.redis_url), socket_timeout=3, socket_connect_timeout=3
+    )
+    found = False
+    try:
+        async for _key in client.scan_iter(match=pattern, count=100):
+            found = True
+            break
+    except Exception as exc:
+        logger.error("worker-health: Redis check failed: {}", exc)
+        return 1
+    finally:
+        await client.aclose()
+
+    if not found:
+        logger.error("worker-health: no live worker found for queue {}", queue_name)
+        return 1
+    return 0
+
+
+def run() -> None:
+    """Console fast-path entry: run the check and exit with its status."""
+    raise SystemExit(asyncio.run(check_worker()))

--- a/vibetuner-py/src/vibetuner/cli/root.py
+++ b/vibetuner-py/src/vibetuner/cli/root.py
@@ -1,0 +1,193 @@
+# ABOUTME: Builds the full Typer CLI app with all sub-commands and the user CLI.
+# ABOUTME: Imported lazily so lightweight commands can skip the heavy bootstrap.
+import importlib.metadata
+import inspect
+from functools import partial, wraps
+
+import asyncer
+import typer
+
+from vibetuner.cli.config import config_app
+from vibetuner.cli.crypto import crypto_app
+from vibetuner.cli.db import db_app
+from vibetuner.cli.debug import debug_app
+from vibetuner.cli.doctor import doctor_app
+from vibetuner.cli.run import run_app
+from vibetuner.cli.scaffold import scaffold_app
+from vibetuner.loader import ConfigurationError, load_app_config
+from vibetuner.logging import LogLevel, logger, setup_logging
+
+
+class AsyncTyper(typer.Typer):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("no_args_is_help", True)
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def maybe_run_async(decorator, f):
+        if inspect.iscoroutinefunction(f):
+
+            @wraps(f)
+            def runner(*args, **kwargs):
+                return asyncer.runnify(f)(*args, **kwargs)
+
+            decorator(runner)
+        else:
+            decorator(f)
+        return f
+
+    def callback(self, *args, **kwargs):
+        decorator = super().callback(*args, **kwargs)
+        return partial(self.maybe_run_async, decorator)
+
+    def command(self, *args, **kwargs):
+        decorator = super().command(*args, **kwargs)
+        return partial(self.maybe_run_async, decorator)
+
+
+def _get_app_help():
+    try:
+        from vibetuner.config import settings
+
+        name = settings.project.project_name
+        if name and name != "default_project":
+            return f"{name.title()} CLI"
+    except (RuntimeError, ImportError):
+        pass
+
+    try:
+        from vibetuner.pyproject import get_project_name
+
+        name = get_project_name()
+        if name:
+            return f"{name.replace('_', ' ').title()} CLI"
+    except Exception:  # noqa: S110
+        pass
+
+    return "Vibetuner CLI"
+
+
+app = AsyncTyper(help=_get_app_help())
+
+LOG_LEVEL_OPTION = typer.Option(
+    LogLevel.INFO,
+    "--log-level",
+    "-l",
+    case_sensitive=False,
+    help="Set the logging level",
+)
+
+
+@app.callback()
+def callback(
+    ctx: typer.Context,
+    log_level: LogLevel | None = LOG_LEVEL_OPTION,
+) -> None:
+    """Initialize logging and other global settings."""
+    if ctx.resilient_parsing:
+        return
+    setup_logging(level=log_level)
+
+
+@app.command()
+def version(
+    show_app: bool = typer.Option(
+        False,
+        "--app",
+        "-a",
+        help="Show app settings version even if not in a project directory",
+    ),
+) -> None:
+    """Show version information."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+
+    try:
+        # Get vibetuner package version
+        vibetuner_version = importlib.metadata.version("vibetuner")
+    except importlib.metadata.PackageNotFoundError:
+        vibetuner_version = "unknown"
+
+    # Create table for nice display
+    table = Table(title="Version Information")
+    table.add_column("Component", style="cyan", no_wrap=True)
+    table.add_column("Version", style="green", no_wrap=True)
+
+    # Always show vibetuner package version
+    table.add_row("vibetuner package", vibetuner_version)
+
+    # Show app version if requested or if in a project
+    try:
+        from vibetuner.config import CoreConfiguration
+
+        settings = CoreConfiguration()
+        table.add_row(f"{settings.project.project_name} settings", settings.version)
+    except Exception:
+        if show_app:
+            table.add_row("app settings", "not in project directory")
+        # else: don't show app version if not in project and not requested
+
+    console.print(table)
+
+
+@app.command(name="worker-health")
+async def worker_health() -> None:
+    """Exit 0 if a worker is alive, else exit 1 (for container healthchecks).
+
+    The streaq worker renews a health key in Redis from inside its event loop,
+    so a wedged loop lets the key expire. This checks for a fresh key.
+    """
+    from vibetuner.cli.health import check_worker
+
+    code = await check_worker()
+    if code != 0:
+        raise typer.Exit(code=code)
+
+
+app.add_typer(config_app, name="config")
+app.add_typer(crypto_app, name="crypto")
+app.add_typer(db_app, name="db")
+app.add_typer(debug_app, name="debug")
+app.add_typer(doctor_app, name="doctor")
+app.add_typer(run_app, name="run")
+app.add_typer(scaffold_app, name="scaffold")
+
+# Add user CLI commands from tune.py
+try:
+    _app_config = load_app_config()
+    if _app_config.cli:
+        _user_cli = _app_config.cli
+        # Determine the user-provided name, if any
+        _user_name = getattr(getattr(_user_cli, "info", None), "name", None)
+        # Collect core command/group names so we can detect shadowing
+        _core_names = {
+            cmd.name
+            for cmd in app.registered_groups + app.registered_commands
+            if hasattr(cmd, "name") and cmd.name
+        }
+        if _user_name and _user_name in _core_names:
+            logger.warning(
+                f"User CLI group name '{_user_name}' shadows a core vibetuner "
+                f"command. Falling back to namespace 'app'."
+            )
+            _user_name = "app"
+        # Guard against self-referencing cycle: if the user re-exported
+        # vibetuner.cli.app instead of creating their own Typer instance,
+        # adding it as a sub-group of itself causes infinite recursion in
+        # typer >=0.23 (eager group hierarchy resolution).
+        if _user_cli is app:
+            logger.warning(
+                "User CLI is the same object as vibetuner's root app. "
+                "Skipping registration to avoid circular reference. "
+                "Create a separate AsyncTyper() or typer.Typer() instance "
+                "for your CLI commands instead of re-exporting vibetuner.cli.app."
+            )
+        else:
+            # Ensure the user CLI is always namespaced to prevent top-level shadowing
+            app.add_typer(_user_cli, name=_user_name or "app")
+            logger.debug("Registered user CLI commands from tune.py")
+except ConfigurationError:
+    # Not in a project directory or tune.py misconfigured, skip user CLI
+    pass

--- a/vibetuner-py/tests/unit/test_worker_health.py
+++ b/vibetuner-py/tests/unit/test_worker_health.py
@@ -1,6 +1,9 @@
 # ABOUTME: Tests for the `vibetuner worker-health` CLI command.
 # ABOUTME: Verifies exit codes based on the presence of a fresh streaq health key.
-# ruff: noqa: S101
+# ruff: noqa: S101, S603
+import subprocess
+import sys
+import textwrap
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -77,3 +80,44 @@ class TestWorkerHealth:
             result = runner.invoke(app, ["worker-health"])
         assert result.exit_code == 1
         assert fake.closed is True
+
+
+class TestWorkerHealthFastPath:
+    """The healthcheck must skip the full CLI/app bootstrap so it finishes
+    well under a container healthcheck timeout."""
+
+    def test_main_dispatches_without_building_full_app(self):
+        # Run in a fresh interpreter: module import state is process-global,
+        # and other tests import vibetuner.cli.root (the heavy Typer app).
+        script = textwrap.dedent(
+            """
+            import sys
+            sys.argv = ["vibetuner", "worker-health"]
+
+            import vibetuner.cli as cli
+            import vibetuner.cli.health as health
+
+            async def fake_check():
+                return 0
+
+            health.check_worker = fake_check
+
+            try:
+                cli.main()
+            except SystemExit as exc:
+                assert exc.code == 0, exc.code
+
+            # The fast path must not import the heavy command tree, which is
+            # what pulls in the user's tune.py via load_app_config().
+            assert "vibetuner.cli.root" not in sys.modules
+            assert "vibetuner.cli.scaffold" not in sys.modules
+            print("OK")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout

--- a/vibetuner-template/pyproject.toml.j2
+++ b/vibetuner-template/pyproject.toml.j2
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.scripts]
-vibetuner = "vibetuner.cli:app"
+vibetuner = "vibetuner.cli:main"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

Fixes #1974. `vibetuner worker-health` paid the full CLI/app bootstrap before it ever read the streaq health key. The console script was `vibetuner.cli:app`, so importing the CLI package eagerly imported every sub-command **and** ran `load_app_config()`, which imports the user's entire `tune.py` (config, `BlobService`, rate limiter). On a real deploy that bootstrap takes ~5s, so every probe was killed at the scaffolded healthcheck's `timeout: 5s` (ExitCode -1) before the check logic ran, and a healthy worker flapped to permanently `unhealthy`.

## Fix

This is the issue's suggested fix #1 (lightweight fast path), done at the root cause — the entry point.

- The console entry is now `vibetuner.cli:main`. `main()` dispatches `worker-health` straight to a lightweight check **before** the heavy Typer app is imported.
- New `vibetuner/cli/health.py` holds the check: it imports only `vibetuner.config` and a Redis client, then reads the `streaq:{queue}:health:*` key. Same exit-code contract as before.
- The full Typer app (every command + the user CLI via `load_app_config()`) moved to `vibetuner/cli/root.py`, built lazily. `vibetuner.cli.__init__` stays tiny and re-exposes `app`/`AsyncTyper` lazily via `__getattr__` for existing importers.
- `python -m vibetuner` now routes through `main()` too, so the fast path applies there as well.
- Template `pyproject.toml.j2` entry point bumped to `vibetuner.cli:main` so new scaffolds get the fast path.

The healthcheck now returns in well under a second, comfortably inside the existing 5s timeout — no timeout bump needed (issue suggestion #2 left untouched).

## Verification

- `uv run vibetuner worker-health` and `python -m vibetuner worker-health` complete in ~0.4s; the fast path does **not** import `vibetuner.cli.root`, `scaffold`, or `copier` (verified via a fresh-interpreter regression test).
- `version` and all other commands still build the full app unchanged.
- Full unit suite green (961 passed), including the existing 4 worker-health tests plus a new fast-path regression test.

## Docs

- `cli-reference.md` notes the fast-path behavior for ops users tuning healthcheck timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)