### PR TITLE
docs: warn that backgrounded SSE tabs drop events and document resync

### DIFF
--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -400,17 +400,18 @@ async def process_upload(file_id: str, user_id: str) -> dict:
     """Process an uploaded file and broadcast progress."""
     channel = f"upload:{user_id}"
 
-    await broadcast(channel, "progress", data="Processing started...")
+    # Unnamed messages (event="") are swapped into the connecting element.
+    await broadcast(channel, event="", data="<p>Processing started…</p>")
 
     # ... do work ...
 
-    await broadcast(channel, "progress", data="50% complete...")
+    await broadcast(channel, event="", data="<p>50% complete…</p>")
 
     # ... more work ...
 
     await broadcast(
         channel,
-        "complete",
+        event="",
         data="<div class='alert alert-success'>Upload complete!</div>",
     )
     return {"status": "complete"}
@@ -422,13 +423,22 @@ async def process_upload(file_id: str, user_id: str) -> dict:
     process to the frontend process). Without Redis, broadcasts from
     tasks will not reach connected clients.
 
-On the frontend, subscribe with HTMX:
+On the frontend, subscribe with HTMX. Each unnamed message is swapped into the
+connecting element via its `hx-swap`:
 
 ```html
-<div sse-connect="/events/upload/{{ user.id }}"
-     sse-swap="progress complete">
+<div hx-sse:connect="/events/upload/{{ user.id }}" hx-swap="innerHTML">
+    <!-- each progress message replaces this content -->
 </div>
 ```
+
+!!! warning "Backgrounded tabs drop events"
+    `hx-sse:connect` pauses while the tab is hidden and replays nothing on
+    return, so a message sent during that window (including the final
+    "complete") is lost. For views that must survive a backgrounded tab, use a
+    named event plus a consumer that re-fetches current state on
+    `htmx:after:sse:connection` — see
+    [Backgrounded Tabs Drop Events](development-guide.md#sse--real-time-streaming).
 
 With a corresponding SSE endpoint:
 

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -1795,20 +1795,87 @@ async def clock_stream(request: Request):
 
 ### HTMX Integration
 
-Connect an SSE endpoint to HTMX using the built-in SSE support:
+Connect an SSE endpoint to HTMX using the built-in SSE support. The
+`hx-sse:connect` attribute opens the stream; htmx v4 then handles messages two
+ways depending on whether the broadcast carries an event name:
+
+- **Named events** (the `event` you pass to `broadcast()`) are dispatched as DOM
+  events on the connecting element. You consume them elsewhere with
+  `hx-trigger="<event> from:#<id>"`, typically to re-fetch current state.
+- **Unnamed messages** (an empty event name) are swapped into the connecting
+  element directly using its own `hx-target` / `hx-swap`.
+
+The recommended pattern broadcasts a named event as a *signal* and lets a
+consumer fetch the current state, so the rendered markup always reflects the
+server rather than a fragment that can be missed:
 
 ```html
-<div sse-connect="/events/notifications">
-    <div sse-swap="new-post" hx-swap="beforeend">
-        <!-- new posts appear here -->
-    </div>
+<!-- Opens the stream; carries no visible content itself -->
+<div id="notifications-stream" hx-sse:connect="/events/notifications"></div>
+
+<!-- Re-fetches current state whenever the "new-post" event fires -->
+<div hx-get="/notifications"
+     hx-trigger="new-post from:#notifications-stream">
+    <!-- current notifications render here -->
 </div>
 ```
+
+```python
+# Broadcast the signal; the consumer re-fetches the current state.
+await broadcast("notifications", "new-post")
+```
+
+### Backgrounded Tabs Drop Events — Resync on Reconnect
+
+!!! warning "Live views go stale when the tab is backgrounded"
+    For `hx-sse:connect`, htmx v4 enables `pauseOnBackground` by default: when
+    the tab is hidden it **closes the stream**, and reopens it when the tab is
+    visible again. Any event `broadcast()` during the hidden window is **lost** —
+    there is no automatic replay — so the view stays stuck on its old state until
+    the next event or a manual reload. This is easy to miss in local testing
+    (focused tabs never pause) and most visible with fast transitions, where a
+    status flip lands during a glance away.
+
+Recover by re-fetching current state on every (re)connection, not just on the
+named event. The `htmx:after:sse:connection` event fires on the connecting
+element on each connect and reconnect, so add it to the consumer's trigger:
+
+```html
+<div id="notifications-stream" hx-sse:connect="/events/notifications"></div>
+
+<div hx-get="/notifications"
+     hx-trigger="new-post from:#notifications-stream,
+                 htmx:after:sse:connection from:#notifications-stream">
+    <!-- current notifications; re-fetched on each event and every reconnect -->
+</div>
+```
+
+The reconnect fetch is one idempotent request that returns the view to the
+current server state, picking up anything missed while hidden. Because the
+consumer always renders server state, this stays correct no matter how many
+events were dropped.
+
+To keep a stream live in the background instead (at the cost of holding the
+connection open in hidden tabs), disable the pause per element with `hx-config`:
+
+```html
+<div hx-sse:connect="/events/notifications"
+     hx-config="sse.pauseOnBackground:false"></div>
+```
+
+or globally in your entry point with `htmx.config.sse = {pauseOnBackground: false}`.
 
 ### Multi-Worker Support
 
 When Redis is configured (`REDIS_URL`), broadcasts are relayed across
 all worker processes via Redis pub/sub automatically. No extra setup needed.
+
+`sse_endpoint(buffer_size=...)` enables a per-channel ring buffer so a client
+reconnecting with a `Last-Event-ID` header can replay missed events. Note that
+event IDs are **per-process and monotonic**, so across multiple frontend workers
+a reconnect that lands on a different worker cannot replay reliably. The
+resync-on-reconnect pattern above is the robust answer regardless of worker
+count, and it does not depend on `buffer_size`.
 
 ### Reverse Proxies and CDNs
 

--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -122,7 +122,17 @@ Each `<hx-partial>` specifies its own `hx-target` and `hx-swap` strategy.
 ## SSE: Native Support Replaces Extension
 
 htmx v4 includes Server-Sent Events support in core. The separate `sse` extension
-and `hx-ext="sse"` attribute are no longer needed.
+and `hx-ext="sse"` attribute are no longer needed, but the attributes changed:
+`sse-connect` becomes `hx-sse:connect`, and `sse-swap` is **removed** (there is
+no equivalent — the extension no longer has its own swap system).
+
+In v4, messages are handled by event name:
+
+- **Named events** (the event name in your stream) are dispatched as DOM events
+  on the connecting element. Consume them with `hx-trigger="<event> from:#<id>"`,
+  typically on a `hx-get` element that re-fetches current state.
+- **Unnamed messages** (empty event name) are swapped into the connecting element
+  using its own `hx-target` / `hx-swap`.
 
 **Before (v2):**
 
@@ -135,19 +145,25 @@ and `hx-ext="sse"` attribute are no longer needed.
 **After (v4):**
 
 ```html
-<div sse-connect="/events/notifications" sse-swap="update">
+<div id="notifications-stream" hx-sse:connect="/events/notifications"></div>
+<div hx-get="/notifications" hx-trigger="update from:#notifications-stream">
     <!-- updates appear here -->
 </div>
 ```
 
-The `sse-connect` and `sse-swap` attributes work exactly the same, just remove
-`hx-ext="sse"` from the element.
+!!! warning "Backgrounded tabs drop events"
+    `hx-sse:connect` enables `pauseOnBackground` by default: a hidden tab closes
+    the stream and reopens it on return, with no replay, so events sent while
+    hidden are lost. Add `htmx:after:sse:connection from:#<id>` to the consumer's
+    `hx-trigger` so it re-fetches current state on every reconnect, or disable
+    the pause with `hx-config="sse.pauseOnBackground:false"`. See
+    [SSE / Real-Time Streaming](development-guide.md#sse--real-time-streaming).
 
 !!! warning
     The SSE and WebSocket extensions were significantly rewritten for v4.
     If you use advanced SSE/WS features (custom config, event handling),
     see the upstream upgrade guides:
-    [SSE](https://four.htmx.org/docs/extensions/sse#upgrading-from-htmx-2x),
+    [SSE](https://four.htmx.org/extensions/hx-sse),
     [WS](https://four.htmx.org/docs/extensions/ws#upgrading-from-htmx-2x).
 
 ## Extension Auto-Registration
@@ -275,9 +291,13 @@ import "htmx-ext-sse";
 import "@alltuner/vibetuner/htmx/sse";
 ```
 
-Use `hx-sse:connect="/events"` (and `hx-sse:swap`, `hx-sse:close`) on elements
-that should subscribe to a server-sent events stream. The `hx-ext="sse"`
-attribute is no longer needed — the extension auto-registers on import.
+Use `hx-sse:connect="/events"` on the element that should subscribe to a
+server-sent events stream (`hx-sse:close="<event>"` closes it on a named event).
+There is no `hx-sse:swap` — named events are dispatched as DOM events and unnamed
+messages swap into the connecting element; see
+[SSE: Native Support Replaces Extension](#sse-native-support-replaces-extension).
+The `hx-ext="sse"` attribute is no longer needed — the extension auto-registers
+on import.
 
 ## Event Names Changed from camelCase to Colon-Separated
 
@@ -814,7 +834,9 @@ term hits the server.
 still being loaded, conflicting with htmx v4's built-in SSE support.
 
 **Fix:** Remove both the `hx-ext="sse"` attribute and any `<script>` tag loading
-`htmx-ext-sse`. The `sse-connect` and `sse-swap` attributes work natively in v4.
+`htmx-ext-sse`. Rename `sse-connect` to `hx-sse:connect`; `sse-swap` is removed,
+so replace it per the
+[SSE migration](#sse-native-support-replaces-extension) above.
 
 ### `window.htmx` is undefined in inline scripts
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1277,11 +1277,40 @@ no extra proxy configuration is needed for live updates to work in production.
 
 **HTMX client example:**
 
+`hx-sse:connect` opens the stream. In htmx v4 a **named** event (the `event`
+passed to `broadcast()`) is dispatched as a DOM event on the connecting element;
+consume it with `hx-trigger="<event> from:#<id>"` to re-fetch current state. An
+**unnamed** message (empty event name) is swapped into the connecting element
+via its own `hx-target`/`hx-swap`. The recommended pattern broadcasts a named
+event as a signal and lets a consumer fetch state:
+
 ```html
-<div sse-connect="/events/notifications" sse-swap="update">
-    <!-- Updates appear here -->
+<div id="notifications-stream" hx-sse:connect="/events/notifications"></div>
+
+<div hx-get="/notifications"
+     hx-trigger="update from:#notifications-stream,
+                 htmx:after:sse:connection from:#notifications-stream">
+    <!-- current state; re-fetched on each event and every reconnect -->
 </div>
 ```
+
+```python
+await broadcast("notifications", "update")  # signal; consumer re-fetches
+```
+
+**Backgrounded tabs drop events.** For `hx-sse:connect`, htmx v4 enables
+`pauseOnBackground` by default: a hidden tab closes the stream and reopens it
+when visible, with **no replay**, so events broadcast during the hidden window
+are lost and the view goes stale until the next event or a reload. Recovering is
+why the consumer above also triggers on `htmx:after:sse:connection` (fires on
+every connect/reconnect) — one idempotent re-fetch restores current state. To
+keep a stream live in the background instead, disable the pause per element with
+`hx-config="sse.pauseOnBackground:false"` (or globally via `htmx.config.sse`).
+
+`sse_endpoint(buffer_size=...)` enables `Last-Event-ID` replay, but event IDs are
+per-process and monotonic, so replay is unreliable across multiple frontend
+workers; the resync-on-reconnect trigger is the robust, worker-count-independent
+answer.
 
 ### Response Caching
 
@@ -2658,14 +2687,19 @@ Breaking changes when upgrading from htmx v2 to v4 in Vibetuner projects.
 
 #### SSE: Native Support Replaces Extension
 
-htmx v4 includes SSE in core. Remove `hx-ext="sse"`:
+htmx v4 includes SSE in core. Remove `hx-ext="sse"`, rename `sse-connect` to
+`hx-sse:connect`, and replace `sse-swap` — it is **removed** in v4 (no
+equivalent). Named events are now dispatched as DOM events (consume with
+`hx-trigger`); unnamed messages are swapped into the connecting element via its
+own `hx-target`/`hx-swap`.
 
 ```html
-<!-- Before (v2) -->
+<!-- Before (v2): sse-swap names the event to swap -->
 <div hx-ext="sse" sse-connect="/events/notifications" sse-swap="update">
 
-<!-- After (v4) -->
-<div sse-connect="/events/notifications" sse-swap="update">
+<!-- After (v4): hx-sse:connect opens the stream; a consumer re-fetches state -->
+<div id="notifications-stream" hx-sse:connect="/events/notifications"></div>
+<div hx-get="/notifications" hx-trigger="update from:#notifications-stream"></div>
 ```
 
 #### Extension Auto-Registration

--- a/vibetuner-js/README.md
+++ b/vibetuner-js/README.md
@@ -79,7 +79,7 @@ Vibetuner uses HTMX for dynamic, reactive interfaces without complex JavaScript:
 </form>
 
 <!-- Real-time updates (native SSE in htmx v4) -->
-<div sse-connect="/events" sse-swap="message">
+<div hx-sse:connect="/events" hx-swap="innerHTML">
   Updates will appear here
 </div>
 ```

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -81,7 +81,13 @@ async def notifications_stream(request: Request): pass
 # Dynamic: return channel name from function body
 # Broadcast: await broadcast("channel", "event",
 #   data="<html>" or template=..., ctx=...)
-# HTMX: <div sse-connect="/events/..." sse-swap="event-name">
+# HTMX v4: <div id="s" hx-sse:connect="/events/..."></div>
+#   Named events -> DOM triggers: consume with
+#     hx-trigger="event from:#s" on a hx-get that re-fetches state.
+#   Unnamed (event="") messages swap into the connecting element.
+# pauseOnBackground (default on) drops events while the tab is hidden;
+#   add htmx:after:sse:connection from:#s to the consumer's hx-trigger
+#   to resync on reconnect. See development-guide.md#sse--real-time-streaming
 ```
 
 ## HTMX Response Headers


### PR DESCRIPTION
Closes #1976.

## Problem

`hx-sse:connect` in htmx v4 enables `pauseOnBackground` by default: when a tab
is hidden the extension closes the stream, and `sse_endpoint(...)` has no replay
without `buffer_size`. Any `broadcast()` sent during the hidden window is lost
permanently, so live views silently go stale until the next event or a manual
reload. Nothing in the docs flagged this, and the existing SSE client examples
used `sse-connect`/`sse-swap`, which htmx v4 has **deprecated** (`sse-connect`)
and **removed** (`sse-swap`).

## What changed (docs only)

- **`development-guide.md`** — rewrote the HTMX Integration section to the htmx 4
  model (named events → DOM triggers consumed via `hx-trigger`; unnamed messages
  auto-swap). Added a **"Backgrounded Tabs Drop Events — Resync on Reconnect"**
  section with the `pauseOnBackground` warning, the resync pattern
  (`htmx:after:sse:connection` trigger re-fetches current state on every
  reconnect), the `hx-config="sse.pauseOnBackground:false"` knob, and a
  `buffer_size` multi-worker caveat (per-process monotonic IDs can't replay
  reliably across workers).
- **`htmx-migration.md`** — corrected the SSE migration section, which wrongly
  claimed `sse-connect`/`sse-swap` "work exactly the same" in v4; documented that
  `sse-swap` is removed and there is no `hx-sse:swap`; added the backgrounding
  warning; fixed the troubleshooting note and a dead upstream link.
- **`background-tasks.md`** — updated the upload-progress example to the v4
  unnamed-message auto-swap model and cross-linked the resync guidance.
- **`llms-full.txt`** — mirrored the client example and migration fixes with a
  concise warning.
- **`vibetuner-js/README.md`** and **`vibetuner-template/.claude/rules/frontend.md`**
  — fixed the remaining deprecated `sse-connect`/`sse-swap` snippets.

## Verification

- Confirmed every claim against the bundled htmx 4.0.0-beta4 `hx-sse.js`
  (`pauseOnBackground: isConnect`, `reader.cancel()` on `visibilitychange`,
  named→`htmx.trigger`, unnamed→`htmx.swap`, `htmx:after:sse:connection` on every
  reconnect, `sse-swap` removal warning) and against the upstream htmx 4 SSE docs.
- `rumdl` passes on all touched markdown files (via pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)