### PR TITLE
feat: add TEST_REDIS_URL test-only Redis DSN to mirror TEST_MONGODB_URL

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -2184,6 +2184,31 @@ The test is skipped when neither variable is set.
 - If a test crashes mid-run, the next test re-truncates on setup so
   state is self-healing.
 
+#### `TEST_REDIS_URL` — Isolating the Test Redis
+
+A session-scoped autouse fixture points every Redis consumer (the rate
+limiter, response cache, pub/sub, and the shared Redis client) at the
+test Redis for the whole run. By default that is `REDIS_URL`, so if your
+`.env` points at a remote or production Redis, every request through
+`vibetuner_client` pays the full round-trip latency on rate-limit and
+cache lookups. Set `TEST_REDIS_URL` to keep the suite on a local Redis
+while `REDIS_URL` stays pointed at your app's instance:
+
+```bash
+# .env (or .env.local)
+REDIS_URL=redis://prod-cache.internal:6379/0
+TEST_REDIS_URL=redis://localhost:6379/0
+```
+
+```bash
+# Or stand up a throwaway local Redis just for the suite
+docker run -d --rm -p 6379:6379 redis:7
+TEST_REDIS_URL=redis://localhost:6379/0 pytest
+```
+
+When `TEST_REDIS_URL` is unset the fixtures fall back to `REDIS_URL`, so
+existing behavior is unchanged. This mirrors `TEST_MONGODB_URL` for Mongo.
+
 #### `mock_auth` — Authentication Mocking
 
 Patches the auth backend so requests appear authenticated without real

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2061,6 +2061,7 @@ auto-discovered.
 | `vibetuner_client` | Async HTTP test client with full middleware |
 | `vibetuner_app` | The FastAPI app instance (override for custom apps) |
 | `vibetuner_db` | Session-scoped MongoDB DB on `TEST_MONGODB_URL` (falls back to `MONGODB_URL`); collections truncated per test |
+| _(autouse)_ | Session-scoped fixture points Redis (rate limiter, cache, pub/sub) at `TEST_REDIS_URL` (falls back to `REDIS_URL`) |
 | `mock_auth` | Mock authentication without real sessions |
 | `mock_tasks` | Mock background tasks without Redis |
 | `override_config` | Override RuntimeConfig values with auto-cleanup |
@@ -2118,6 +2119,28 @@ TEST_MONGODB_URL=mongodb://localhost:27017/ pytest
 The session start logs the resolved server and throwaway database name, so it is
 always obvious where the test database is being created. The suite is skipped
 entirely when neither `TEST_MONGODB_URL` nor `MONGODB_URL` is set.
+
+**Running tests against a local Redis:**
+
+Redis follows the same precedent. A session-scoped autouse fixture overrides
+`settings.redis_url` with `TEST_REDIS_URL` when set, so the rate limiter,
+response cache, pub/sub, and the shared Redis client all target the test Redis.
+Without `TEST_REDIS_URL` they fall back to `REDIS_URL`, leaving existing behavior
+unchanged. Pointing `REDIS_URL` at a remote/production Redis makes every request
+through `vibetuner_client` pay round-trip latency on rate-limit and cache lookups,
+so set `TEST_REDIS_URL` to a local Redis to keep the suite fast and off prod:
+
+```bash
+# .env (or .env.local) — prod stays for the app, tests use local Redis
+REDIS_URL=redis://prod-cache.internal:6379/0
+TEST_REDIS_URL=redis://localhost:6379/0
+```
+
+```bash
+# Or spin up a throwaway local Redis just for the suite
+docker run -d --rm -p 6379:6379 redis:7
+TEST_REDIS_URL=redis://localhost:6379/0 pytest
+```
 
 ### Default Language Configuration
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -196,7 +196,8 @@ Important notes:
   entry, with a worker/frontend restart reminder
 - **Testing Fixtures**: `vibetuner_client`, `mock_auth`, `mock_tasks`,
   `override_config`, `vibetuner_db` pytest fixtures. Set `TEST_MONGODB_URL` to
-  run the suite against a local Mongo while `MONGODB_URL` stays pointed at prod
+  run the suite against a local Mongo while `MONGODB_URL` stays pointed at prod;
+  `TEST_REDIS_URL` does the same for Redis (rate limiter, cache, pub/sub)
 - **Error Messages**: Actionable error messages with env var examples, Docker
   commands, and documentation links
 - **Docker Builds**: Production Docker image builds (linux/amd64) via

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -311,6 +311,11 @@ class CoreConfiguration(BaseSettings):
     # remote/production cluster can still run its suite against a local Mongo.
     test_mongodb_url: MongoDsn | None = None
 
+    # Optional test-only Redis DSN. When set, the pytest fixtures target this
+    # server instead of ``redis_url`` so a project whose ``.env`` points at a
+    # remote/production Redis can still run its suite against a local Redis.
+    test_redis_url: RedisDsn | None = None
+
     # Mail provider settings (MAIL_* env vars)
     mail: MailSettings = Field(default_factory=MailSettings)
 
@@ -510,6 +515,16 @@ class CoreConfiguration(BaseSettings):
         to ``mongodb_url`` otherwise.
         """
         return self.test_mongodb_url or self.mongodb_url
+
+    @property
+    def resolved_test_redis_url(self) -> RedisDsn | None:
+        """Redis server the test fixtures target.
+
+        Prefers ``test_redis_url`` (``TEST_REDIS_URL``) when set so a
+        prod-pointing ``redis_url`` stays out of the test path, falling back
+        to ``redis_url`` otherwise.
+        """
+        return self.test_redis_url or self.redis_url
 
     @cached_property
     def mongo_dbname(self) -> str:

--- a/vibetuner-py/src/vibetuner/testing.py
+++ b/vibetuner-py/src/vibetuner/testing.py
@@ -188,6 +188,38 @@ async def vibetuner_db(_vibetuner_db_session: str) -> AsyncGenerator[str, None]:
 
 
 # ---------------------------------------------------------------------------
+# Redis test server
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
+async def _vibetuner_redis_session() -> AsyncGenerator[None, None]:
+    """Point every Redis consumer at the test Redis for the whole session.
+
+    Overrides ``settings.redis_url`` with ``resolved_test_redis_url`` so the
+    rate limiter, response cache, pub/sub, and the shared Redis client all
+    target ``TEST_REDIS_URL`` when set. Falling back to ``redis_url`` when
+    ``TEST_REDIS_URL`` is unset keeps existing behavior unchanged, exactly as
+    ``TEST_MONGODB_URL`` does for Mongo.
+
+    Pointing ``TEST_REDIS_URL`` at a local Redis keeps the suite off a
+    prod-pointing ``redis_url`` so requests through ``vibetuner_client`` don't
+    pay remote round-trip latency on every rate-limit and cache lookup.
+    """
+    from vibetuner.config import settings
+    from vibetuner.redis import close_redis_client
+
+    original_url = settings.redis_url
+    settings.redis_url = settings.resolved_test_redis_url
+    await close_redis_client()
+    try:
+        yield
+    finally:
+        await close_redis_client()
+        settings.redis_url = original_url
+
+
+# ---------------------------------------------------------------------------
 # Authentication mocking
 # ---------------------------------------------------------------------------
 

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -223,6 +223,38 @@ class TestResolvedTestMongodbUrl:
             assert str(config.resolved_test_mongodb_url) == "mongodb://localhost:27018/"
 
 
+class TestResolvedTestRedisUrl:
+    """Test resolved_test_redis_url fallback for the test fixtures."""
+
+    def test_falls_back_to_redis_url_when_test_url_unset(self):
+        """Without TEST_REDIS_URL, tests target the production redis_url."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(),
+            redis_url="redis://prod-host:6379/0",
+        )
+        assert str(config.resolved_test_redis_url) == "redis://prod-host:6379/0"
+
+    def test_prefers_test_url_when_set(self):
+        """TEST_REDIS_URL wins over redis_url so a prod .env stays isolated."""
+        config = CoreConfiguration(
+            project=ProjectConfiguration(),
+            redis_url="redis://prod-host:6379/0",
+            test_redis_url="redis://localhost:6380/0",
+        )
+        assert str(config.resolved_test_redis_url) == "redis://localhost:6380/0"
+
+    def test_is_none_when_neither_set(self):
+        """Resolves to None when no Redis URL is configured at all."""
+        config = CoreConfiguration(project=ProjectConfiguration())
+        assert config.resolved_test_redis_url is None
+
+    def test_test_url_from_env_var(self):
+        """test_redis_url is read from the TEST_REDIS_URL env var."""
+        with patch.dict("os.environ", {"TEST_REDIS_URL": "redis://localhost:6380/0"}):
+            config = CoreConfiguration(project=ProjectConfiguration())
+            assert str(config.resolved_test_redis_url) == "redis://localhost:6380/0"
+
+
 class TestLoadProjectConfig:
     """Test _load_project_config behavior outside a project directory."""
 

--- a/vibetuner-py/tests/unit/test_vibetuner_redis_fixture.py
+++ b/vibetuner-py/tests/unit/test_vibetuner_redis_fixture.py
@@ -1,0 +1,59 @@
+# ABOUTME: Tests that the session-scoped _vibetuner_redis_session fixture overrides
+# ABOUTME: settings.redis_url with resolved_test_redis_url and restores it on teardown.
+# ruff: noqa: S101
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from vibetuner.config import settings
+
+
+async def _run_session_fixture():
+    """Drive the autouse ``_vibetuner_redis_session`` body directly.
+
+    Bypasses the pytest fixture decorator so the test exercises the exact
+    setup/teardown path and can assert on ``settings.redis_url`` while the
+    fixture is "active".
+    """
+    from vibetuner.testing import _vibetuner_redis_session
+
+    gen = _vibetuner_redis_session.__wrapped__()
+    await gen.__anext__()
+    active_url = settings.redis_url
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()
+    return active_url
+
+
+@pytest.mark.unit
+class TestVibetunerRedisSessionFixture:
+    """The session-scoped Redis fixture must:
+
+    - Point ``settings.redis_url`` at ``resolved_test_redis_url`` while active.
+    - Close the shared client on setup and teardown so it reconnects to the
+      test Redis.
+    - Restore the original ``redis_url`` on teardown.
+    """
+
+    async def test_prefers_test_redis_url_and_restores(self):
+        close_mock = AsyncMock()
+        with (
+            patch.object(settings, "redis_url", "redis://prod-host:6379/0"),
+            patch.object(settings, "test_redis_url", "redis://localhost:6380/0"),
+            patch("vibetuner.redis.close_redis_client", close_mock),
+        ):
+            active_url = await _run_session_fixture()
+
+            assert str(active_url) == "redis://localhost:6380/0"
+            assert close_mock.await_count == 2  # setup + teardown
+            # Original restored after teardown.
+            assert str(settings.redis_url) == "redis://prod-host:6379/0"
+
+    async def test_falls_back_to_redis_url_when_test_unset(self):
+        with (
+            patch.object(settings, "redis_url", "redis://prod-host:6379/0"),
+            patch.object(settings, "test_redis_url", None),
+            patch("vibetuner.redis.close_redis_client", AsyncMock()),
+        ):
+            active_url = await _run_session_fixture()
+
+            assert str(active_url) == "redis://prod-host:6379/0"

--- a/vibetuner-template/.claude/rules/testing.md
+++ b/vibetuner-template/.claude/rules/testing.md
@@ -26,5 +26,11 @@ remote/prod cluster, set `TEST_MONGODB_URL=mongodb://localhost:27017/`
 so the suite runs locally instead of reaching prod. The session start
 logs the resolved server + DB name.
 
+Redis works the same way: the fixtures point every Redis consumer (rate
+limiter, response cache, pub/sub, shared client) at `REDIS_URL` unless
+`TEST_REDIS_URL` is set. If `.env` points `REDIS_URL` at a remote/prod
+Redis, set `TEST_REDIS_URL=redis://localhost:6379/0` so the suite isn't
+paying remote round-trip latency on every rate-limit and cache lookup.
+
 Dev server must be running (`just local-all`). Playwright MCP available
 at `http://localhost:8000`.


### PR DESCRIPTION
## Summary

Closes #2000.

`Settings` already has a test-only MongoDB DSN (`test_mongodb_url` / `TEST_MONGODB_URL`, via `resolved_test_mongodb_url`) so a project whose `.env` points `MONGODB_URL` at a remote/prod cluster can still run its suite against a local Mongo. There was no equivalent for Redis, so the suite drove all Redis traffic (rate limiter, response cache, pub/sub) through the production `REDIS_URL`, paying remote round-trip latency on every request made through `vibetuner_client`.

This adds the symmetric `test_redis_url` / `TEST_REDIS_URL` setting.

## Changes

- **`config.py`**: `test_redis_url: RedisDsn | None` field + `resolved_test_redis_url` property (prefers `test_redis_url`, falls back to `redis_url`), mirroring the Mongo precedent.
- **`testing.py`**: a session-scoped autouse fixture overrides `settings.redis_url` with `resolved_test_redis_url` for the whole session, so `get_redis_url()`, the rate limiter storage, the response cache, pub/sub, and the shared Redis client all target the test Redis. The shared client is closed on setup and teardown; the original URL is restored on teardown.
- **Tests**: `TestResolvedTestRedisUrl` in `test_config.py` and a new `test_vibetuner_redis_fixture.py` driving the fixture body directly.
- **Docs**: `development-guide.md`, `llms.txt`, `llms-full.txt`, and the template's `.claude/rules/testing.md`.

When `TEST_REDIS_URL` is unset the fixtures fall back to `REDIS_URL`, so existing behavior is unchanged.

## Testing

- `uv run python -m pytest tests/unit/` → 967 passed
- `just type-check-py` → clean
- `ruff format` / `ruff check` → clean
- `rumdl` on changed markdown → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)