### PR TITLE
fix: scope dprint yaml linting to non-gitignored project files

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,1 @@
+vibetuner-template/dprint.json

--- a/vibetuner-template/.justfiles/formatting.justfile
+++ b/vibetuner-template/.justfiles/formatting.justfile
@@ -16,7 +16,7 @@ format-jinja:
 # Format YAML files with dprint
 [group('Code quality: formatting')]
 format-yaml:
-    @uvx --from dprint-py dprint fmt --plugins https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm
+    @uvx --from dprint-py dprint fmt --config-discovery=ignore-descendants --plugins https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm
 
 # Format Markdown files with rumdl
 [group('Code quality: formatting')]

--- a/vibetuner-template/.justfiles/linting.justfile
+++ b/vibetuner-template/.justfiles/linting.justfile
@@ -21,7 +21,7 @@ lint-jinja:
 # Lint YAML files with dprint
 [group('Code quality: linting')]
 lint-yaml:
-    @uvx --from dprint-py dprint check --plugins https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm
+    @uvx --from dprint-py dprint check --config-discovery=ignore-descendants --plugins https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm
 
 # Lint PO translation files with lint-po
 [group('Code quality: linting')]

--- a/vibetuner-template/dprint.json
+++ b/vibetuner-template/dprint.json
@@ -1,0 +1,9 @@
+{
+  "excludes": [
+    "**/.claude",
+    "**/.tmp",
+    "**/.venv",
+    "**/node_modules",
+    "**/packages"
+  ]
+}


### PR DESCRIPTION
## Problem

The scaffolded `lint-yaml` / `format-yaml` recipes run dprint with no config, so dprint walks the
entire tree. dprint honors `.gitignore` files but not `.git/info/exclude` or the user's global
excludes file — which is exactly how `.claude/worktrees/` ends up ignored — so stale agent
worktrees (each a full repo copy with its own YAML) made `just lint` fail nondeterministically.
The other linters (rumdl, ruff, taplo) skip ignored paths.

## Fix

- **`vibetuner-template/dprint.json`** (new, scaffolded to projects): minimal config with explicit
  excludes for `**/.claude`, `**/.tmp`, `**/.venv`, `**/node_modules`, `**/packages` (the
  YAML-bearing directories the template's `.gitignore` ignores).
- **Root `dprint.json`**: symlink to the template copy, following the existing `djlint.toml` /
  `opencode.json` / `.rumdl.toml` pattern. The root justfile already imports the template's
  linting/formatting justfiles, so both repos share the same recipes and config.
- **`--config-discovery=ignore-descendants`** added to the `lint-yaml` / `format-yaml` recipes:
  without it, dprint treats `vibetuner-template/` (which now contains its own `dprint.json`) as a
  separate project and silently skips all template YAML when linting from the monorepo root.

## Verification

In a worktree with a badly formatted `broken.yml` placed under `.claude/worktrees/stale-agent/`:

- Without the config, `dprint check` (same uvx invocation as the recipe) flags the gitignored file
  (reproduces the issue).
- With the config, `dprint output-file-paths` lists exactly the tracked YAML (root + template
  workflows, compose files, `copier.yml`, `mkdocs.yml`) and nothing under `.claude/` or `.tmp/`.
- A deliberately mangled tracked `compose.yml` is still flagged.
- `just lint-yaml` passes at the root with the bad gitignored YAML present.

Docs only mention dprint in one-line command listings ("Lint YAML files with dprint"), which remain
accurate, so no docs changes are needed.

Fixes #2006

🤖 Generated with [Claude Code](https://claude.com/claude-code)