### PR TITLE
feat: targeted cache invalidation for vary'd keys and O(variants) pattern invalidation

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -1066,9 +1066,29 @@ await invalidate("/api/stats")
 # Invalidate a specific query variant
 await invalidate("/api/stats", query_params="page=1")
 
-# Invalidate all matching paths (uses Redis SCAN)
+# Invalidate the entry cached for one vary_on value (e.g. one user)
+await invalidate("/dashboard", vary=str(user.id))
+
+# Invalidate every cached variant of a path (all queries and vary values)
+await invalidate_pattern("/dashboard")
+
+# Invalidate all matching paths with a glob pattern
 await invalidate_pattern("/api/*")
 ```
+
+`invalidate()` deletes one exact entry: the combination of path, sorted
+query string, and `vary` value. For routes cached with `vary_on`, pass the
+same value the `vary_on` callable returns to target that variant.
+
+`invalidate_pattern()` works off per-path key registries that `@cache`
+maintains at write time, so its cost is proportional to the number of
+cached variants — it never runs a full-keyspace Redis `SCAN`, which could
+block a request handler for minutes on a large or remote Redis. A bare
+path (no glob characters) removes every cached variant of that path; a
+glob pattern is matched against the `path?query|vary:value` portion of
+each registered key. Only entries written through `@cache` are tracked —
+entries written by older framework versions are not in the registry and
+simply expire via their own TTL.
 
 ### Cache Control Headers (Browser-Side)
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1361,8 +1361,21 @@ from vibetuner.cache import invalidate, invalidate_pattern
 
 await invalidate("/api/stats")
 await invalidate("/api/stats", query_params="page=1")
-await invalidate_pattern("/api/*")
+await invalidate("/dashboard", vary=str(user.id))  # one vary_on variant
+await invalidate_pattern("/dashboard")  # every variant of one path
+await invalidate_pattern("/api/*")  # glob across paths
 ```
+
+`invalidate()` deletes one exact entry (path + sorted query string +
+`vary` value). For routes cached with `vary_on`, pass the value the
+`vary_on` callable returns to target that variant.
+
+`invalidate_pattern()` resolves matches from per-path key registries
+maintained at cache-write time, so cost is proportional to the number of
+cached variants — never a full-keyspace Redis `SCAN` (which could block a
+request for minutes). A bare path removes every cached variant of that
+path; a glob is matched against the `path?query|vary:value` portion of
+registered keys. Only entries written through `@cache` are tracked.
 
 ### Template Context Providers
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -54,8 +54,10 @@ Important notes:
   Key derived from path + query params. Use `vary_on=lambda r: str(r.state.user.id)`
   for request-dependent keys (per-user, per-tenant). Disabled in debug mode
   (override with `force_caching=True`). No-op if Redis unavailable.
-  `invalidate(path)` and `invalidate_pattern(path)` for cache busting.
-  Import from `vibetuner.cache`
+  `invalidate(path, query_params=..., vary=...)` deletes one exact entry
+  (pass `vary` to hit a `vary_on` variant); `invalidate_pattern(path)` removes
+  every variant of a path (or a glob match) via per-path key registries —
+  no keyspace SCAN. Import from `vibetuner.cache`
 - **`@cache_control` Decorator**: `@cache_control(max_age=300, public=True)` sets
   `Cache-Control` headers declaratively. Supports `public`, `private`, `no_cache`,
   `no_store`, `max_age`, `s_maxage`, `must_revalidate`, `stale_while_revalidate`,

--- a/vibetuner-py/src/vibetuner/cache.py
+++ b/vibetuner-py/src/vibetuner/cache.py
@@ -1,5 +1,6 @@
 # ABOUTME: Response caching decorator backed by Redis.
 # ABOUTME: Provides @cache for server-side route caching and invalidate() for cache busting.
+import fnmatch
 import functools
 import hashlib
 import inspect
@@ -8,6 +9,9 @@ from collections.abc import Callable
 from typing import Any
 
 from vibetuner.logging import logger
+
+
+_GLOB_CHARS = frozenset("*?[")
 
 
 def _build_cache_key(
@@ -19,6 +23,20 @@ def _build_cache_key(
         raw = f"{raw}|vary:{vary_value}"
     key_hash = hashlib.sha256(raw.encode()).hexdigest()[:16]
     return f"{prefix}cache:{key_hash}:{raw}"
+
+
+def _registry_key(prefix: str, path: str) -> str:
+    """Redis SET holding every cache key written for a route path."""
+    return f"{prefix}cache-index:{path}"
+
+
+def _paths_key(prefix: str) -> str:
+    """Redis SET holding every route path with a key registry."""
+    return f"{prefix}cache-paths"
+
+
+def _as_str(value: bytes | str) -> str:
+    return value.decode() if isinstance(value, bytes) else value
 
 
 def cache(
@@ -129,6 +147,9 @@ async def _cached_call(
         serialized = _serialize_response(response)
         if serialized is not None:
             await client.set(cache_key, serialized, ex=expire)
+            await _register_cache_key(
+                client, settings.redis_key_prefix, request.url.path, cache_key, expire
+            )
 
         return response
 
@@ -141,12 +162,18 @@ async def _cached_call(
         return await _call_handler(func, *args, **kwargs)
 
 
-async def invalidate(path: str, *, query_params: str = "") -> bool:
+async def invalidate(
+    path: str, *, query_params: str = "", vary: str | None = None
+) -> bool:
     """Remove a cached response by route path.
 
     Args:
         path: The URL path to invalidate (e.g. ``"/api/stats"``).
         query_params: Optional sorted query string to target a specific variant.
+        vary: Optional vary value to target the entry written for a route
+            cached with ``vary_on`` (e.g. the user id returned by the
+            ``vary_on`` callable). Without it, only the non-vary'd entry
+            for the path can be hit.
 
     Returns:
         ``True`` if a cached entry was deleted, ``False`` otherwise.
@@ -159,7 +186,9 @@ async def invalidate(path: str, *, query_params: str = "") -> bool:
         if client is None:
             return False
 
-        cache_key = _build_cache_key(settings.redis_key_prefix, path, query_params)
+        cache_key = _build_cache_key(
+            settings.redis_key_prefix, path, query_params, vary
+        )
         deleted = await client.delete(cache_key)
         return deleted > 0
     except (ConnectionError, OSError, TimeoutError):
@@ -171,16 +200,28 @@ async def invalidate(path: str, *, query_params: str = "") -> bool:
 
 
 async def invalidate_pattern(pattern: str) -> int:
-    """Remove all cached responses matching a key pattern.
+    """Remove cached responses for a route path or glob pattern.
 
-    Uses Redis ``SCAN`` to find matching keys without blocking.
+    Works off the per-path key registries maintained at cache-write time,
+    so cost is proportional to the number of cached variants — never a
+    full-keyspace ``SCAN``. A full keyspace scan against a large or remote
+    Redis can block for minutes and must never run in the request path;
+    this function intentionally has no such fallback.
+
+    A bare path (no ``*``, ``?``, or ``[`` glob characters) removes **every**
+    cached variant of that path: all query-string and ``vary_on`` variants,
+    plus the registry itself. A glob pattern is matched against the raw
+    ``path?query|vary:value`` portion of each registered key.
+
+    Only entries written through ``@cache`` are registered; anything else
+    is untouched and expires via its own TTL.
 
     Args:
-        pattern: Glob pattern relative to the cache namespace
-            (e.g. ``"/api/*"``).
+        pattern: Route path or glob pattern relative to the cache namespace
+            (e.g. ``"/dashboard"`` or ``"/api/*"``).
 
     Returns:
-        Number of keys deleted.
+        Number of cache entries deleted.
     """
     try:
         from vibetuner.config import settings
@@ -190,11 +231,25 @@ async def invalidate_pattern(pattern: str) -> int:
         if client is None:
             return 0
 
-        full_pattern = f"{settings.redis_key_prefix}cache:*:{pattern}"
+        prefix = settings.redis_key_prefix
+        if not _GLOB_CHARS & set(pattern):
+            return await _invalidate_path(client, prefix, pattern)
+
+        full_pattern = f"{prefix}cache:*:{pattern}"
+        paths = [_as_str(p) for p in await client.smembers(_paths_key(prefix))]
         deleted = 0
-        async for key in client.scan_iter(match=full_pattern, count=100):
-            await client.delete(key)
-            deleted += 1
+        for path in paths:
+            registry = _registry_key(prefix, path)
+            keys = [_as_str(m) for m in await client.smembers(registry)]
+            matching = [k for k in keys if fnmatch.fnmatchcase(k, full_pattern)]
+            if not matching:
+                continue
+            deleted += await client.unlink(*matching)
+            if len(matching) == len(keys):
+                await client.unlink(registry)
+                await client.srem(_paths_key(prefix), path)
+            else:
+                await client.srem(registry, *matching)
         return deleted
     except (ConnectionError, OSError, TimeoutError):
         logger.debug("Redis unavailable during pattern invalidation")
@@ -204,7 +259,45 @@ async def invalidate_pattern(pattern: str) -> int:
         return 0
 
 
+async def _invalidate_path(client: Any, prefix: str, path: str) -> int:
+    """Delete every registered cache entry for a path plus its registry."""
+    registry = _registry_key(prefix, path)
+    keys = [_as_str(m) for m in await client.smembers(registry)]
+    deleted = await client.unlink(*keys) if keys else 0
+    await client.unlink(registry)
+    await client.srem(_paths_key(prefix), path)
+    return deleted
+
+
 # ── Internal helpers ────────────────────────────────────────────────
+
+
+async def _register_cache_key(
+    client: Any, prefix: str, path: str, cache_key: str, expire: int
+) -> None:
+    """Record a written cache key in the per-path registry sets.
+
+    The registry set and the path index get their TTL bumped to at least
+    ``expire`` (``EXPIRE NX`` seeds a TTL, ``EXPIRE GT`` only ever extends
+    it), so a registry always outlives the longest-lived entry it tracks
+    and expired-entry bookkeeping cannot accumulate forever.
+
+    Failures are swallowed: the response is already cached and registry
+    bookkeeping must not affect the request.
+    """
+    try:
+        registry = _registry_key(prefix, path)
+        paths = _paths_key(prefix)
+        pipe = client.pipeline(transaction=False)
+        pipe.sadd(registry, cache_key)
+        pipe.expire(registry, expire, nx=True)
+        pipe.expire(registry, expire, gt=True)
+        pipe.sadd(paths, path)
+        pipe.expire(paths, expire, nx=True)
+        pipe.expire(paths, expire, gt=True)
+        await pipe.execute()
+    except Exception:
+        logger.debug("Cache key registry update failed")
 
 
 async def _call_handler(func: Callable, *args: Any, **kwargs: Any) -> Any:

--- a/vibetuner-py/tests/unit/test_cache.py
+++ b/vibetuner-py/tests/unit/test_cache.py
@@ -12,6 +12,8 @@ from vibetuner.cache import (
     _restore_response,
     _serialize_response,
     cache,
+    invalidate,
+    invalidate_pattern,
 )
 
 
@@ -46,6 +48,15 @@ def _mock_settings(
     mock.redis_url = redis_url
     mock.redis_key_prefix = redis_key_prefix
     return mock
+
+
+def _mock_redis_client():
+    """Mock Redis client whose pipeline() queues commands synchronously."""
+    client = AsyncMock()
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    client.pipeline = MagicMock(return_value=pipe)
+    return client, pipe
 
 
 class TestBuildCacheKey:
@@ -131,7 +142,7 @@ class TestCacheDecorator:
     async def test_force_caching_in_debug(self):
         """force_caching=True enables caching even in debug mode."""
         call_count = 0
-        mock_client = AsyncMock()
+        mock_client, _ = _mock_redis_client()
         mock_client.get = AsyncMock(return_value=None)
         mock_client.set = AsyncMock()
 
@@ -217,7 +228,7 @@ class TestCacheDecorator:
             }
         ).encode()
 
-        mock_client = AsyncMock()
+        mock_client, _ = _mock_redis_client()
         mock_client.get = AsyncMock(return_value=cached_data)
         mock_client.set = AsyncMock()
 
@@ -311,7 +322,7 @@ class TestVaryOn:
     @pytest.mark.asyncio
     async def test_vary_on_produces_different_keys(self):
         """Different vary_on values produce different cache keys."""
-        mock_client = AsyncMock()
+        mock_client, _ = _mock_redis_client()
         mock_client.get = AsyncMock(return_value=None)
         mock_client.set = AsyncMock()
 
@@ -410,3 +421,271 @@ class TestVaryOn:
             await handler(request=request)
 
         assert call_count == 2
+
+
+class TestInvalidate:
+    """Test exact-key invalidation, including vary'd variants."""
+
+    @pytest.mark.asyncio
+    async def test_invalidate_deletes_path_key(self):
+        client, _ = _mock_redis_client()
+        client.delete = AsyncMock(return_value=1)
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            result = await invalidate("/api/stats")
+
+        assert result is True
+        expected = _build_cache_key("test:", "/api/stats", "")
+        client.delete.assert_awaited_once_with(expected)
+
+    @pytest.mark.asyncio
+    async def test_invalidate_with_vary_targets_varied_key(self):
+        """invalidate(path, vary=...) deletes the key written for that variant."""
+        client, _ = _mock_redis_client()
+        client.delete = AsyncMock(return_value=1)
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            result = await invalidate("/dashboard", vary="user-123")
+
+        assert result is True
+        expected = _build_cache_key("test:", "/dashboard", "", "user-123")
+        client.delete.assert_awaited_once_with(expected)
+
+    @pytest.mark.asyncio
+    async def test_invalidate_with_query_and_vary(self):
+        client, _ = _mock_redis_client()
+        client.delete = AsyncMock(return_value=0)
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            result = await invalidate(
+                "/reports", query_params="page=1", vary="tenant-a"
+            )
+
+        assert result is False
+        expected = _build_cache_key("test:", "/reports", "page=1", "tenant-a")
+        client.delete.assert_awaited_once_with(expected)
+
+
+class TestKeyRegistry:
+    """Cache writes register their key in a per-path Redis set."""
+
+    @pytest.mark.asyncio
+    async def test_write_registers_key_with_ttl_floor(self):
+        """A cache write SADDs the key and bumps registry TTLs via NX then GT."""
+        client, pipe = _mock_redis_client()
+        client.get = AsyncMock(return_value=None)
+        client.set = AsyncMock()
+
+        @cache(expire=120)
+        async def handler(request: Request):
+            return JSONResponse({"ok": True})
+
+        request = _make_request(path="/api/stats")
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+            patch(_RESET_CLIENT_PATH),
+        ):
+            await handler(request=request)
+
+        cache_key = _build_cache_key("test:", "/api/stats", "")
+        registry = "test:cache-index:/api/stats"
+        paths_index = "test:cache-paths"
+
+        pipe.sadd.assert_any_call(registry, cache_key)
+        pipe.sadd.assert_any_call(paths_index, "/api/stats")
+        pipe.expire.assert_any_call(registry, 120, nx=True)
+        pipe.expire.assert_any_call(registry, 120, gt=True)
+        pipe.expire.assert_any_call(paths_index, 120, nx=True)
+        pipe.expire.assert_any_call(paths_index, 120, gt=True)
+        pipe.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_varied_writes_register_in_same_path_registry(self):
+        """Vary'd variants of a path land in the same per-path registry set."""
+        client, pipe = _mock_redis_client()
+        client.get = AsyncMock(return_value=None)
+        client.set = AsyncMock()
+
+        @cache(expire=60, vary_on=lambda r: r.headers.get("x-tenant", ""))
+        async def handler(request: Request):
+            return JSONResponse({"ok": True})
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+            patch(_RESET_CLIENT_PATH),
+        ):
+            await handler(request=_make_request(headers={"x-tenant": "a"}))
+            await handler(request=_make_request(headers={"x-tenant": "b"}))
+
+        registry = "test:cache-index:/test"
+        key_a = _build_cache_key("test:", "/test", "", "a")
+        key_b = _build_cache_key("test:", "/test", "", "b")
+        pipe.sadd.assert_any_call(registry, key_a)
+        pipe.sadd.assert_any_call(registry, key_b)
+
+    @pytest.mark.asyncio
+    async def test_registry_failure_does_not_rerun_handler(self):
+        """A failed registry write must not re-execute the handler."""
+        client, pipe = _mock_redis_client()
+        client.get = AsyncMock(return_value=None)
+        client.set = AsyncMock()
+        pipe.execute = AsyncMock(side_effect=ConnectionError("refused"))
+        call_count = 0
+
+        @cache(expire=60)
+        async def handler(request: Request):
+            nonlocal call_count
+            call_count += 1
+            return JSONResponse({"ok": True})
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+            patch(_RESET_CLIENT_PATH),
+        ):
+            result = await handler(request=_make_request())
+
+        assert call_count == 1
+        assert json.loads(result.body) == {"ok": True}
+
+
+class TestInvalidatePattern:
+    """Pattern invalidation works off the key registry, never a keyspace SCAN."""
+
+    @staticmethod
+    def _client_with_sets(sets: dict[str, set]):
+        client, _ = _mock_redis_client()
+
+        async def smembers(key):
+            return sets.get(key, set())
+
+        client.smembers = AsyncMock(side_effect=smembers)
+        client.unlink = AsyncMock(side_effect=lambda *keys: len(keys))
+        client.srem = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_exact_path_deletes_all_variants(self):
+        """A bare path removes every registered variant plus the registry set."""
+        key_plain = _build_cache_key("test:", "/dashboard", "")
+        key_u1 = _build_cache_key("test:", "/dashboard", "", "u1")
+        key_u2 = _build_cache_key("test:", "/dashboard", "", "u2")
+        client = self._client_with_sets(
+            {"test:cache-index:/dashboard": {key_plain, key_u1, key_u2}}
+        )
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            deleted = await invalidate_pattern("/dashboard")
+
+        assert deleted == 3
+        unlinked = {k for call_ in client.unlink.await_args_list for k in call_.args}
+        assert {key_plain, key_u1, key_u2} <= unlinked
+        assert "test:cache-index:/dashboard" in unlinked
+        client.srem.assert_awaited_once_with("test:cache-paths", "/dashboard")
+        client.scan_iter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_glob_pattern_deletes_matching_variants(self):
+        """A glob pattern matches registered keys across paths, without SCAN."""
+        key_stats = _build_cache_key("test:", "/api/stats", "page=1")
+        key_users = _build_cache_key("test:", "/api/users", "", "u1")
+        key_home = _build_cache_key("test:", "/home", "")
+        client = self._client_with_sets(
+            {
+                "test:cache-paths": {"/api/stats", "/api/users", "/home"},
+                "test:cache-index:/api/stats": {key_stats},
+                "test:cache-index:/api/users": {key_users},
+                "test:cache-index:/home": {key_home},
+            }
+        )
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            deleted = await invalidate_pattern("/api/*")
+
+        assert deleted == 2
+        unlinked = {k for call_ in client.unlink.await_args_list for k in call_.args}
+        assert key_stats in unlinked
+        assert key_users in unlinked
+        assert key_home not in unlinked
+        client.scan_iter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_glob_partial_match_keeps_registry(self):
+        """Unmatched variants stay registered; matched ones are SREM'd."""
+        key_p1 = _build_cache_key("test:", "/api/stats", "page=1")
+        key_bare = _build_cache_key("test:", "/api/stats", "")
+        client = self._client_with_sets(
+            {
+                "test:cache-paths": {"/api/stats"},
+                "test:cache-index:/api/stats": {key_p1, key_bare},
+            }
+        )
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            deleted = await invalidate_pattern("/api/stats[?]page=*")
+
+        assert deleted == 1
+        unlinked = {k for call_ in client.unlink.await_args_list for k in call_.args}
+        assert key_p1 in unlinked
+        assert key_bare not in unlinked
+        assert "test:cache-index:/api/stats" not in unlinked
+        client.srem.assert_awaited_once_with("test:cache-index:/api/stats", key_p1)
+
+    @pytest.mark.asyncio
+    async def test_bytes_members_are_decoded(self):
+        """Registry members stored as bytes are handled transparently."""
+        key = _build_cache_key("test:", "/api/stats", "")
+        client = self._client_with_sets({"test:cache-index:/api/stats": {key.encode()}})
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            deleted = await invalidate_pattern("/api/stats")
+
+        assert deleted == 1
+        unlinked = {k for call_ in client.unlink.await_args_list for k in call_.args}
+        assert key in unlinked
+
+    @pytest.mark.asyncio
+    async def test_no_entries_returns_zero(self):
+        client = self._client_with_sets({})
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            assert await invalidate_pattern("/nothing") == 0
+            assert await invalidate_pattern("/nothing/*") == 0
+
+    @pytest.mark.asyncio
+    async def test_redis_unavailable_returns_zero(self):
+        client, _ = _mock_redis_client()
+        client.smembers = AsyncMock(side_effect=ConnectionError("refused"))
+
+        with (
+            patch(_SETTINGS_PATH, _mock_settings()),
+            patch(_GET_CLIENT_PATH, AsyncMock(return_value=client)),
+        ):
+            assert await invalidate_pattern("/api/*") == 0

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -212,6 +212,11 @@ for handlers on dynamically-inserted elements. Full reference:
 `vary_on=lambda r: str(r.state.user.id)` for per-user/tenant keys.
 Disabled in debug mode (`force_caching=True` to override).
 No-op without Redis.
+`invalidate(path, query_params=..., vary=...)` deletes one exact
+entry — pass `vary` to hit a `vary_on` variant.
+`invalidate_pattern(path)` removes every variant of a path (or a
+glob match like `"/api/*"`) via per-path key registries, never a
+keyspace SCAN.
 
 ## Cache Control (Browser-Side)
 


### PR DESCRIPTION
## Summary

Fixes #2005.

Two gaps in `vibetuner-py/src/vibetuner/cache.py`:

1. `invalidate(path)` could not target entries written for routes cached with `vary_on` — the stored
   key carries a `|vary:<value>` suffix that the public API could never hit, forcing downstream apps
   to import the private `_build_cache_key`.
2. `invalidate_pattern()` ran a full-keyspace `SCAN` (count=100) plus one `DELETE` round trip per
   match, inline in the request path. Against a large/remote Redis this blocked handlers for minutes.

## Design

**`invalidate(path, *, query_params="", vary=None)`** — the new `vary` keyword is passed into the
key builder, so the exact per-variant entry (path + sorted query string + vary value) can be deleted
through the public API.

**Key registry** — every cache write now records its key in a per-path Redis SET
(`{prefix}cache-index:{path}`) and records the path in a path index (`{prefix}cache-paths`), batched
into the same write via a single pipeline. `invalidate_pattern()` resolves matches from these sets:

- A bare path (no `*?[` glob chars) is `SMEMBERS` of that path's registry + `UNLINK` of the members,
  the registry, and the path-index entry — removing every query-string and `vary_on` variant of the
  path in O(variants of that path).
- A glob pattern iterates the path index and `fnmatch`es registered keys against
  `{prefix}cache:*:{pattern}` (the same glob semantics the old SCAN used), unlinking matches and
  pruning emptied registries. Cost is O(cached variants), never O(keyspace).

There is intentionally **no SCAN fallback**: a full-keyspace scan must never run in the request
path (documented in the docstring and docs). Entries written by older framework versions are not in
the registry and simply expire via their own TTL.

**TTL strategy** — registry sets must outlive the entries they track without accumulating forever.
Each write bumps the registry and path-index TTL with `EXPIRE NX` (seed a TTL on a fresh set)
followed by `EXPIRE GT` (only ever extend), so a registry's TTL is always >= the longest entry TTL
written to it and everything self-expires once writes stop. Stale members (entries that expired
before invalidation) are tolerated: `UNLINK` of a missing key is a no-op. Registry bookkeeping
failures are swallowed (debug-logged) so they can never re-execute a handler or fail a request.

**Behavior note** — a bare path passed to `invalidate_pattern()` now removes *all* variants of that
path (previously it only matched the no-query, no-vary entry, which `invalidate(path)` already
covers). Glob patterns keep their previous matching semantics. Key format is unchanged.

## Testing

- TDD: new unit tests for `invalidate(..., vary=...)`, write-time registration + NX/GT TTL bumps,
  exact-path and glob pattern invalidation (asserting `scan_iter` is never called), partial-match
  registry pruning, bytes member decoding, and graceful degradation.
- Full vibetuner-py suite: 979 passed (3 pre-existing integration errors require a Docker daemon,
  unavailable locally; unrelated to this change).
- Smoke-tested end-to-end against a real local Redis (write → registry TTLs → vary invalidate →
  exact-path and glob pattern invalidation) to validate the redis-py pipeline/`EXPIRE NX|GT`/`UNLINK`
  calls.
- `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)