### PR TITLE
fix(release): pin scaffolded @alltuner/vibetuner to ^11 and track it in release-please

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -71,6 +71,11 @@
         {
           "type": "generic",
           "path": "vibetuner-template/pyproject.toml.j2"
+        },
+        {
+          "type": "json",
+          "path": "vibetuner-template/package.json",
+          "jsonpath": "$.devDependencies['@alltuner/vibetuner']"
         }
       ]
     }

--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@alltuner/vibetuner": "^10.22.4"
+    "@alltuner/vibetuner": "11.1.0"
   },
   "dependencies": {},
   "scripts": {


### PR DESCRIPTION
## Problem

`vibetuner-template/package.json` pinned `@alltuner/vibetuner` to `^10.22.4`,
but the framework (`vibetuner-py` and `vibetuner-js`) is at `11.1.0`. Every
newly scaffolded project shipped with the JS package a full major version
behind.

Root cause: `vibetuner-template/package.json` was **not** in the
release-please `extra-files` list (the list tracked
`vibetuner-template/pyproject.toml.j2` but not `package.json`), so the pin
never auto-bumped.

## Fix

**1. Bump the pin** in `vibetuner-template/package.json`:

```diff
-    "@alltuner/vibetuner": "^10.22.4"
+    "@alltuner/vibetuner": "11.1.0"
```

I used the **exact** current release version (`11.1.0`) rather than a
`^11.0.0` caret range. This mirrors the established pattern in this repo: in
PR #1814 `@alltuner/vibetuner-jinja` was deliberately changed from `^10.11.0`
to an exact `10.13.0` because release-please's `Json` updater overwrites the
matched value with the **bare** version on every release (it does not
preserve a caret). Using `^11.0.0` here would be immediately rewritten to
`11.1.0` on the next release, leaving the config and manifest inconsistent.
Exact-pinning also forces bun to re-resolve on update.

**2. Track it in release-please** — added a `json` typed entry to
`.release-please-config.json` `extra-files`, mirroring the existing
`@alltuner/vibetuner-jinja` entry exactly:

```json
{
  "type": "json",
  "path": "vibetuner-template/package.json",
  "jsonpath": "$.devDependencies['@alltuner/vibetuner']"
}
```

(`devDependencies` because the template lists the package there; otherwise
identical syntax to the proven sibling `$.dependencies['@alltuner/vibetuner-jinja']`.)

## Verification

- `vibetuner-template/package.json` is a plain `.json` (not `.json.j2`) and
  contains no copier `{{ }}` placeholders, so release-please can rewrite it safely.
- `.release-please-config.json` parses cleanly:
  `python3 -c "import json; json.load(open('.release-please-config.json'))"`.
- New `json` entry is structurally identical to the existing
  `@alltuner/vibetuner-jinja` entry (same `type`/`path`/`jsonpath` shape,
  same bracket-quoted scoped-package selector), which is confirmed-working
  per PR #1814.

No package versions or release manifest numbers were touched.

Fixes #2016

🤖 Generated with [Claude Code](https://claude.com/claude-code)