### PR TITLE
fix(security)!: enable Jinja autoescape in the static-render template environment

### DIFF
--- a/vibetuner-docs/docs/authentication.md
+++ b/vibetuner-docs/docs/authentication.md
@@ -462,6 +462,13 @@ Edit `templates/email/magic_link.html.jinja`:
 </html>
 ```
 
+These templates are rendered by the framework's static-render engine, which
+**auto-escapes context variables for HTML and XML templates** (`.html.jinja`,
+`.xml.jinja`). Plain-text templates (`.txt.jinja`) are emitted verbatim. So any
+user-derived value (display name, profile field) is safely escaped in the HTML
+email without action on your part. If you need to inject pre-rendered, trusted
+markup, opt out explicitly with Jinja's `| safe` filter.
+
 ## User Model
 
 The built-in User model supports both OAuth and magic link authentication:

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -992,6 +992,16 @@ those headers when a `RateLimitError` is raised.
 4. System validates token and logs user in
 5. Session created
 
+##### Template autoescaping
+
+Magic-link emails (and other static pages) are rendered by the framework's
+static-render engine (`render_static_template` in `vibetuner.templates`). It
+**auto-escapes context for HTML and XML templates** (`.html.jinja`,
+`.xml.jinja`) and leaves plain-text templates (`.txt.jinja`) verbatim, keying
+the decision off the format extension under the `.jinja` wrapper. User-derived
+values (display names, profile fields) are escaped automatically, closing the
+XSS gap. Inject pre-rendered, trusted markup with Jinja's `| safe` filter.
+
 ##### Custom OAuth Providers
 
 Add any OAuth provider using `custom_oauth_providers` in `tune.py`:

--- a/vibetuner-py/src/vibetuner/templates.py
+++ b/vibetuner-py/src/vibetuner/templates.py
@@ -6,6 +6,27 @@ from jinja2 import Environment, FileSystemLoader, TemplateNotFound
 from . import paths
 
 
+# Markup formats whose output must escape interpolated context to prevent
+# injection. Framework templates are named ``<name>.<format>.jinja``, so the
+# autoescape decision keys off the format extension underneath the ``.jinja``
+# wrapper, not the wrapper itself (a ``.txt.jinja`` email stays plain text).
+_AUTOESCAPE_FORMATS = ("html", "xml")
+
+
+def _autoescape_for_template(template_name: str | None) -> bool:
+    """Decide autoescaping for a template, unwrapping the ``.jinja`` suffix.
+
+    Strings rendered without a template name default to escaping (the safe
+    choice for ``Environment.from_string`` callers).
+    """
+    if template_name is None:
+        return True
+    name = template_name
+    if name.endswith(".jinja"):
+        name = name[: -len(".jinja")]
+    return name.rsplit(".", 1)[-1].lower() in _AUTOESCAPE_FORMATS
+
+
 def _get_base_paths_for_namespace(
     namespace: str | None,
     template_path: Path | list[Path] | None,
@@ -141,8 +162,12 @@ def render_static_template(
         )
 
     # Create Jinja environment with search paths
-    env = Environment(  # noqa: S701
+    # The S701 suppression is required because ruff only recognises ``True`` or
+    # ``select_autoescape`` as safe; the callable escapes by markup format under
+    # the ``.jinja`` wrapper, which select_autoescape cannot express here.
+    env = Environment(
         loader=FileSystemLoader(search_paths),
+        autoescape=_autoescape_for_template,  # noqa: S701
         trim_blocks=True,
         lstrip_blocks=True,
     )

--- a/vibetuner-py/tests/unit/test_static_template_autoescape.py
+++ b/vibetuner-py/tests/unit/test_static_template_autoescape.py
@@ -1,0 +1,78 @@
+# ABOUTME: Tests that render_static_template autoescapes HTML so context data can't inject markup.
+# ABOUTME: Also pins that the magic-link email templates still render their expected content.
+# ruff: noqa: S101
+
+from pathlib import Path
+
+from vibetuner.config import HexColor
+from vibetuner.templates import render_static_template
+
+
+def test_html_template_escapes_context_values(tmp_path: Path) -> None:
+    """User-supplied context interpolated into an HTML template is escaped,
+    so a value like ``<script>`` can't break out into live markup."""
+    template = tmp_path / "greeting.html.jinja"
+    template.write_text("<p>Hello {{ name }}</p>")
+
+    out = render_static_template(
+        "greeting.html",
+        template_path=tmp_path,
+        context={"name": "<script>alert(1)</script>"},
+    )
+
+    assert "<script>alert(1)</script>" not in out
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in out
+
+
+def test_non_html_template_does_not_escape(tmp_path: Path) -> None:
+    """A plain-text template (``.txt``) is not HTML, so its content is emitted
+    verbatim without entity escaping."""
+    template = tmp_path / "note.txt.jinja"
+    template.write_text("Hello {{ name }}")
+
+    out = render_static_template(
+        "note.txt",
+        template_path=tmp_path,
+        context={"name": "<tag> & more"},
+    )
+
+    assert out == "Hello <tag> & more"
+
+
+def test_magic_link_html_email_still_renders() -> None:
+    """The magic-link HTML email renders its links, button color, and copy
+    intact under autoescaping (no legitimate content is mangled)."""
+    out = render_static_template(
+        "magic_link.html",
+        namespace="email",
+        lang="en",
+        context={
+            "login_url": "https://example.com/login",
+            "project_name": "TestApp",
+            "button_color": HexColor("#1DB954"),
+        },
+    )
+
+    assert 'href="https://example.com/login"' in out
+    assert "background-color: #1db954" in out
+    assert "Sign In" in out
+    assert "expire in 15 minutes" in out
+
+
+def test_magic_link_text_email_keeps_url_unescaped() -> None:
+    """The plain-text magic-link email is not HTML, so a login URL with query
+    separators stays as literal ``&`` rather than being entity-escaped (which
+    would corrupt the link when pasted into a browser)."""
+    out = render_static_template(
+        "magic_link.txt",
+        namespace="email",
+        lang="en",
+        context={
+            "login_url": "https://example.com/login?token=abc&next=%2Fhome",
+            "project_name": "TestApp",
+        },
+    )
+
+    assert "https://example.com/login?token=abc&next=%2Fhome" in out
+    assert "&amp;" not in out
+    assert "Sign in to TestApp" in out


### PR DESCRIPTION
## Summary

`vibetuner.templates.render_static_template` built its Jinja `Environment` with
autoescaping disabled (suppressed by `# noqa: S701`). Jinja defaults
`autoescape=False`, so any HTML rendered through this static-render path that
interpolated user-derived data (OAuth display names, profile fields) was an XSS
sink. This path is used by magic-link emails and some static pages. (The
`rendering.py` path already autoescapes `.html` via Starlette's
`Jinja2Templates`; this gap was specifically `templates.py`.)

## Change

- Enable autoescaping for the static-render `Environment`.
- The framework names every template `<name>.<format>.jinja`, so the real
  content type is the *inner* extension. A plain `select_autoescape(["html",
  "xml", "jinja"], ...)` would key off the `.jinja` suffix and escape
  `.txt.jinja` emails too, corrupting plain-text magic-link URLs (`&` →
  `&amp;`). Instead, a small `_autoescape_for_template` predicate unwraps the
  `.jinja` wrapper and escapes only `html`/`xml` formats, leaving `.txt`
  verbatim. The `# noqa: S701` is retained because ruff only recognises `True`
  or `select_autoescape` as safe, not a custom callable.

## Template audit

No template rendered through this path emits pre-rendered/trusted HTML:

- `email/magic_link.html.jinja` — interpolates `login_url`, `project_name`,
  `button_color`; all are plain values that should be escaped. No `| safe`
  needed.
- `email/magic_link.txt.jinja` — plain text, not escaped.
- The `markdown` namespace ships only a placeholder (no real templates).

No `| safe` additions were required.

## Tests

New `tests/unit/test_static_template_autoescape.py`:

- HTML template escapes a `<script>` context value.
- `.txt` template is emitted verbatim.
- Magic-link HTML email still renders its link, button color, and copy.
- Magic-link text email keeps a URL with `&` query separators unescaped.

Full unit suite: **971 passed**. No existing test broke due to escaping (the
magic-link render tests in `test_brand_settings.py` still pass; the meta
templates in that file build their own `Environment` and are unaffected). The
3 errors in the full run are Docker-dependent integration tests, unrelated.

Fixes #2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BREAKING CHANGE: Templates rendered through the static-render path (vibetuner.templates / render_static_template) now autoescape HTML output. Projects rendering custom .html/.xml templates that emit trusted pre-rendered HTML must add an explicit `|safe` filter or the markup will render escaped. Plain-text (.txt) templates are unaffected. See the v11->v12 upgrade guide.
