### PR TITLE
fix(docker): run runtime image as non-root and add a HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,26 +81,30 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ────────────────────────────────────────────────────────────────────────────────
 FROM python:${PYTHON_VERSION}-slim AS runtime
 
+# Run as an unprivileged user; create it before copying so files land owned by it
+RUN groupadd --gid 1000 appuser && \
+    useradd --uid 1000 --gid 1000 --create-home appuser
+
 WORKDIR /app
 
 # Copy Python virtual environment with all dependencies and project installed
-COPY --link --from=python-app /app/.venv/ .venv/
+COPY --link --chown=1000:1000 --from=python-app /app/.venv/ .venv/
 
 # Copy static assets
-COPY --link --from=python-app /app/assets/ assets/
+COPY --link --chown=1000:1000 --from=python-app /app/assets/ assets/
 
 # Copy templates
-COPY --link --from=python-app /app/templates/ templates/
+COPY --link --chown=1000:1000 --from=python-app /app/templates/ templates/
 
 # Copy built frontend assets (CSS and JS bundles)
-COPY --link --from=frontend-build /app/assets/statics/css/bundle.css assets/statics/css/bundle.css
-COPY --link --from=frontend-build /app/assets/statics/js/bundle.js assets/statics/js/bundle.js
+COPY --link --chown=1000:1000 --from=frontend-build /app/assets/statics/css/bundle.css assets/statics/css/bundle.css
+COPY --link --chown=1000:1000 --from=frontend-build /app/assets/statics/js/bundle.js assets/statics/js/bundle.js
 
 # Copy configuration file (used as project root marker)
-COPY --link --from=python-app /app/.copier-answers.yml ./
+COPY --link --chown=1000:1000 --from=python-app /app/.copier-answers.yml ./
 
 # Copy startup script
-COPY --link --from=python-app /app/start.sh /start.sh
+COPY --link --chown=1000:1000 --from=python-app /app/start.sh /start.sh
 
 # Configure environment for Python application
 # No PYTHONPATH needed - app is installed in site-packages via non-editable install
@@ -108,5 +112,11 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1
 
 EXPOSE 8000
+
+# Probe the dependency-free liveness endpoint using only the stdlib (no curl in image)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health/ping', timeout=4).status == 200 else 1)"]
+
+USER appuser
 
 ENTRYPOINT ["/start.sh"]

--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,7 @@ services:
   app:
     build: .
     environment:
+      - ENVIRONMENT=prod
       - MONGODB_URL=mongodb://mongo:27017/
       - REDIS_URL=redis://redis:6379/
     depends_on:

--- a/uv-sources.toml
+++ b/uv-sources.toml
@@ -1,3 +1,2 @@
 
-[tool.uv.sources]
 vibetuner = { path = "/vibetuner-py", editable = true }


### PR DESCRIPTION
Fixes #2015

## What

The root test `Dockerfile`'s runtime stage ran as **root** with **no `HEALTHCHECK`**, despite `compose.yml`
defining healthchecks for the `mongo`/`redis` services.

- **Non-root user**: add an unprivileged `appuser` (uid/gid 1000), `--chown=1000:1000` on every `COPY` into
  the runtime stage (numeric ids are required because `COPY --link` resolves ownership before the user DB
  layer is composited), and `USER appuser` before the entrypoint.
- **HEALTHCHECK**: probe `/health/ping` (the dependency-free liveness endpoint) on port 8000 via a stdlib
  `urllib.request` one-liner — no `curl`/`requests` assumed in the `slim` image. This mirrors the pattern the
  scaffolded template's `compose.prod.yml` already uses for its frontend service.
- **compose.yml**: set `ENVIRONMENT=prod` on the `app` service so the container listens on 8000 (the
  `EXPOSE`/healthcheck port). In dev mode the app binds a deterministic auto-port (e.g. 11709), which would
  never match the baked-in healthcheck.

## Incidental build fix (was blocking the build on `main`)

While verifying, the build failed on a pre-existing issue unrelated to the security change: the scaffolded
`pyproject.toml` now ships a `[tool.uv.sources]` header, and stage 4 appended `uv-sources.toml` which **also**
started with that header — producing a duplicate-key TOML parse error. `uv sync` then errored, but the
trailing `|| true` in the `RUN` masked the failure, so `.venv` was never created and the
`COPY --from=python-app /app/.venv/` into the runtime stage failed with `"/app/.venv": not found`. Fixed by
appending only the source key (no duplicate table header). Reproduced cleanly on pristine `origin/main`.

## Verification

Built and ran from the worktree root.

`docker build -t vibetuner-test .` — succeeds.

`docker inspect vibetuner-test`:

```
User=appuser
Healthcheck=["CMD","python","-c","import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health/ping', timeout=4).status == 200 else 1)"]
```

`docker compose up -d --wait` (full stack):

```
Container ...-app-1  Healthy
Health=healthy HealthExitCode=0 User=appuser
```

`id` inside the running container: `uid=1000(appuser) gid=1000(appuser) groups=1000(appuser)`.

The probe also correctly exits non-zero (`ConnectionRefusedError` → exit 1) when nothing is listening,
confirming it is a real check rather than a no-op.

## Note (out of scope)

The scaffolded `vibetuner-template/Dockerfile` (the image users actually deploy) is *also* missing `USER` and
`HEALTHCHECK`. Issue #2015 scopes to the root Dockerfile, so I left the template alone — worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)