### PR TITLE
fix(security)!: validate post-auth redirects, fail closed on default session key, rate-limit auth endpoints

### DIFF
--- a/vibetuner-docs/docs/authentication.md
+++ b/vibetuner-docs/docs/authentication.md
@@ -603,20 +603,23 @@ SESSION_COOKIE_SECURE = True  # HTTPS only
 SESSION_COOKIE_SAMESITE = "lax"  # CSRF protection
 ```
 
-### Secret Key
+### Session Key
 
-Use a strong, unique secret key:
+Sessions are signed with `SESSION_KEY`. Generate a strong, unique value and
+add it to your `.env`:
 
 ```bash
-# Generate a secure key
-python -c "import secrets; print(secrets.token_urlsafe(32))"
+uv run vibetuner crypto generate-key
 ```
-
-Add to `.env`:
 
 ```bash
 SESSION_KEY=your-generated-secret-key
 ```
+
+The framework ships a placeholder `SESSION_KEY` so a fresh project runs
+without configuration. Startup **fails closed** when this placeholder is still
+in place and `ENVIRONMENT=prod`, so you can never sign production sessions
+with a publicly known key. Outside production it only logs a loud warning.
 
 ### OAuth Callback URLs
 
@@ -644,17 +647,24 @@ the visitor's session. Use a form, not a link, in your own templates:
 
 ### Rate Limiting
 
-Consider adding rate limiting for authentication endpoints:
+The magic-link send and OAuth-initiation endpoints carry a conservative
+per-IP rate limit out of the box (default `5/minute`) to curb email flooding
+and account enumeration. Tune it via `RATE_LIMIT_AUTH_LIMITS`:
 
-```python
-from slowapi import Limiter
-limiter = Limiter(key_func=lambda: request.client.host)
-@router.post("/auth/magic-link")
-@limiter.limit("5/minute")
-async def request_magic_link(email: str):
-# Send magic link
-pass
+```bash
+# .env
+RATE_LIMIT_AUTH_LIMITS=10/minute
 ```
+
+See [Rate Limiting](rate-limiting.md) for the full configuration surface and
+how to apply limits to your own routes.
+
+### Safe Redirects
+
+Post-login redirect targets (the `next` query/form value and the language
+switcher's `current`) are validated before use. Only same-origin relative
+paths are honored; absolute (`https://evil.com`) and protocol-relative
+(`//evil.com`) values fall back to the homepage, preventing open redirects.
 
 ## Troubleshooting
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -1112,6 +1112,43 @@ async def home(request: Request):
     })
 ```
 
+##### Session Key Fails Closed in Production
+
+Sessions are signed with `SESSION_KEY`. The framework ships a placeholder so a
+fresh project runs without configuration, but startup **raises** when that
+placeholder is still set and `ENVIRONMENT=prod` — production sessions can never
+be signed with a publicly known key. Outside production it logs a loud warning
+instead. Generate a real value with:
+
+```bash
+uv run vibetuner crypto generate-key
+```
+
+```bash
+# .env
+SESSION_KEY=your-generated-secret-key
+```
+
+##### Auth Endpoint Rate Limits
+
+The magic-link send (`POST /auth/magic-link-login`) and OAuth-initiation routes
+carry a conservative per-IP limit out of the box (default `5/minute`) to curb
+email flooding and account enumeration. Override it without touching the routes:
+
+```bash
+# .env
+RATE_LIMIT_AUTH_LIMITS=10/minute
+```
+
+##### Safe Post-Login Redirects
+
+Redirect targets that come from user input — the `next` query/form value on
+login and the `current` value on the language switcher — are validated with an
+`is_safe_redirect` check. Only same-origin relative paths are honored; absolute
+(`https://evil.com`) and protocol-relative (`//evil.com`) values fall back to
+the homepage, so a crafted link can never bounce a freshly authenticated user
+off-site.
+
 ### CRUD Factory
 
 Vibetuner includes a CRUD route factory that generates list, create, read, update,

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -22,7 +22,7 @@ Important notes:
 - [Development Guide](https://vibetuner.alltuner.com/development-guide/): Daily development workflow, adding routes, models, templates, and background jobs
 - [Architecture](https://vibetuner.alltuner.com/architecture/): System design, four-package architecture, request flow, and core components
 - [Tech Stack](https://vibetuner.alltuner.com/tech-stack/): Detailed information about all technologies used and why they were chosen
-- [Authentication](https://vibetuner.alltuner.com/authentication/): OAuth and magic link authentication setup and configuration
+- [Authentication](https://vibetuner.alltuner.com/authentication/): OAuth and magic link authentication setup and configuration, plus built-in hardening: `SESSION_KEY` fails closed in production while the shipped placeholder is unchanged (`vibetuner crypto generate-key`), auth endpoints carry a per-IP rate limit (`RATE_LIMIT_AUTH_LIMITS`, default `5/minute`), and post-login redirects (`next`/`current`) are validated against open redirects
 - [Background Tasks](https://vibetuner.alltuner.com/background-tasks/): Background task system powered by Streaq and Redis with retries, cron scheduling, and SSE integration
 - [Runtime Configuration](https://vibetuner.alltuner.com/runtime-config/): Layered configuration system with MongoDB persistence, debug UI, and feature flags
 - [HTMX v2 to v4 Migration](https://vibetuner.alltuner.com/htmx-migration/): Breaking changes and migration guide for upgrading from HTMX v2 to v4

--- a/vibetuner-docs/docs/rate-limiting.md
+++ b/vibetuner-docs/docs/rate-limiting.md
@@ -17,6 +17,18 @@ configured, limits are shared across workers with automatic in-memory fallback
 if Redis becomes unavailable. Without Redis, limits use in-memory storage
 (per-process, suitable for development).
 
+### Auth Endpoints Are Limited by Default
+
+The built-in magic-link send (`POST /auth/magic-link-login`) and
+OAuth-initiation routes carry a conservative per-IP limit out of the box
+(default `5/minute`) to curb email flooding and account enumeration. Override
+it with `RATE_LIMIT_AUTH_LIMITS` without touching the routes:
+
+```bash
+# .env
+RATE_LIMIT_AUTH_LIMITS=10/minute
+```
+
 ## Quick Start
 
 ### Per-Route Limits
@@ -130,6 +142,7 @@ prefix:
 |---|---|---|
 | `RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting globally |
 | `RATE_LIMIT_DEFAULT_LIMITS` | `[]` | Default limits for all routes (JSON list) |
+| `RATE_LIMIT_AUTH_LIMITS` | `5/minute` | Per-IP limit on built-in auth endpoints |
 | `RATE_LIMIT_HEADERS_ENABLED` | `true` | Include `X-RateLimit-*` response headers |
 | `RATE_LIMIT_STRATEGY` | `fixed-window` | Rate limiting strategy |
 | `RATE_LIMIT_SWALLOW_ERRORS` | `true` | Swallow storage errors instead of crashing |

--- a/vibetuner-py/src/vibetuner/cli/crypto.py
+++ b/vibetuner-py/src/vibetuner/cli/crypto.py
@@ -81,6 +81,21 @@ async def _rotate_key_impl(
     typer.echo(f"Rotated {rotated_count} secret(s) across {len(apps)} app(s).")
 
 
+@crypto_app.command("generate-key")
+def generate_key(
+    length: Annotated[
+        int,
+        typer.Option(
+            "--length",
+            "-l",
+            help="Number of random bytes to encode into the key.",
+        ),
+    ] = 32,
+) -> None:
+    """Print a fresh URL-safe random key, suitable for SESSION_KEY."""
+    typer.echo(secrets.token_urlsafe(length))
+
+
 @crypto_app.command("set-key")
 def set_key(
     key: Annotated[

--- a/vibetuner-py/src/vibetuner/cli/doctor.py
+++ b/vibetuner-py/src/vibetuner/cli/doctor.py
@@ -114,7 +114,11 @@ def _check_tune_py(root: Path | None) -> list[CheckResult]:
 def _check_env_vars() -> list[CheckResult]:
     results: list[CheckResult] = []
     try:
-        from vibetuner.config import CoreConfiguration, ProjectConfiguration
+        from vibetuner.config import (
+            DEFAULT_SESSION_KEY_PLACEHOLDER,
+            CoreConfiguration,
+            ProjectConfiguration,
+        )
 
         config = CoreConfiguration(project=ProjectConfiguration())
     except Exception as exc:
@@ -128,7 +132,7 @@ def _check_env_vars() -> list[CheckResult]:
         )
     )
 
-    if config.session_key.get_secret_value() == "ct-!secret-must-change-me":
+    if config.session_key.get_secret_value() == DEFAULT_SESSION_KEY_PLACEHOLDER:
         results.append(
             CheckResult(
                 "SESSION_KEY", "warn", "Using default — set a unique secret in .env"

--- a/vibetuner-py/src/vibetuner/cli/doctor.py
+++ b/vibetuner-py/src/vibetuner/cli/doctor.py
@@ -115,7 +115,7 @@ def _check_env_vars() -> list[CheckResult]:
     results: list[CheckResult] = []
     try:
         from vibetuner.config import (
-            DEFAULT_SESSION_KEY_PLACEHOLDER,
+            KNOWN_INSECURE_SESSION_KEYS,
             CoreConfiguration,
             ProjectConfiguration,
         )
@@ -132,7 +132,7 @@ def _check_env_vars() -> list[CheckResult]:
         )
     )
 
-    if config.session_key.get_secret_value() == DEFAULT_SESSION_KEY_PLACEHOLDER:
+    if config.session_key.get_secret_value() in KNOWN_INSECURE_SESSION_KEYS:
         results.append(
             CheckResult(
                 "SESSION_KEY", "warn", "Using default — set a unique secret in .env"

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 from datetime import datetime
 from functools import cached_property
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 import yaml
 from pydantic import (
@@ -19,6 +19,7 @@ from pydantic import (
     SecretStr,
     UrlConstraints,
     computed_field,
+    model_validator,
 )
 from pydantic_extra_types.color import Color as _PydanticColor
 from pydantic_extra_types.language_code import LanguageAlpha2
@@ -86,6 +87,11 @@ current_year: int = datetime.now().year
 
 UnprivilegedPort = Annotated[int, Field(ge=1024, le=65535)]
 
+# Placeholder session key shipped in the template's .env. The startup
+# validator refuses to run with this value in production (DEBUG off) so a
+# project can never reach prod signing sessions with a publicly-known key.
+DEFAULT_SESSION_KEY_PLACEHOLDER = "CHANGE_ME_RUN_vibetuner_crypto_generate"
+
 
 class SecurityHeadersSettings(BaseSettings):
     """Settings for built-in security headers middleware.
@@ -123,6 +129,9 @@ class RateLimitSettings(BaseSettings):
 
     enabled: bool = True
     default_limits: list[str] = []
+    # Per-IP limit applied to unauthenticated auth endpoints (magic-link send,
+    # OAuth initiation) to curb email flooding and account enumeration.
+    auth_limits: str = "5/minute"
     headers_enabled: bool = True
     strategy: str = "fixed-window"
     swallow_errors: bool = True
@@ -299,7 +308,7 @@ class CoreConfiguration(BaseSettings):
 
     debug: bool = False
     environment: Literal["dev", "prod"] = "dev"
-    session_key: SecretStr = SecretStr("ct-!secret-must-change-me")
+    session_key: SecretStr = SecretStr(DEFAULT_SESSION_KEY_PLACEHOLDER)
 
     # Database and Cache URLs
     mongodb_url: MongoDsn | None = None
@@ -539,6 +548,34 @@ class CoreConfiguration(BaseSettings):
         if self.environment == "dev":
             return f"{self.project.project_slug}:dev:"
         return f"{self.project.project_slug}:"
+
+    @model_validator(mode="after")
+    def fail_closed_on_placeholder_session_key(self) -> Self:
+        """Refuse to run in production with the shipped placeholder session key.
+
+        Sessions are signed with ``session_key``; the publicly-known
+        placeholder would let anyone forge a session, so a production startup
+        (``environment == "prod"``) fails fast. Outside production it only
+        warns, keeping local development friction free while making the
+        required action obvious before deploy.
+        """
+        if self.session_key.get_secret_value() != DEFAULT_SESSION_KEY_PLACEHOLDER:
+            return self
+
+        if self.environment == "prod":
+            raise ValueError(
+                "SESSION_KEY is still the placeholder value. Set a unique "
+                "SESSION_KEY in your .env before running in production. "
+                "Generate one with: vibetuner crypto generate-key"
+            )
+
+        logger.warning(
+            "SESSION_KEY is the insecure placeholder value. This is only "
+            "tolerated outside production. Set a unique SESSION_KEY in your "
+            ".env (generate one with: vibetuner crypto generate-key) before "
+            "deploying."
+        )
+        return self
 
     model_config = SettingsConfigDict(
         case_sensitive=False, extra="ignore", env_file=_ENV_FILES

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -87,10 +87,17 @@ current_year: int = datetime.now().year
 
 UnprivilegedPort = Annotated[int, Field(ge=1024, le=65535)]
 
-# Placeholder session key shipped in the template's .env. The startup
-# validator refuses to run with this value in production (DEBUG off) so a
-# project can never reach prod signing sessions with a publicly-known key.
+# Placeholder session key the config field defaults to and the template's .env
+# ships. The startup validator refuses to run with a known placeholder in
+# production so a project can never sign prod sessions with a publicly-known key.
 DEFAULT_SESSION_KEY_PLACEHOLDER = "CHANGE_ME_RUN_vibetuner_crypto_generate"
+
+# Every session key value that is publicly known and therefore unsafe to sign
+# sessions with. Includes the historical placeholder so projects upgrading from
+# an older scaffold (whose .env still carries it) are guarded on upgrade.
+KNOWN_INSECURE_SESSION_KEYS = frozenset(
+    {"ct-!secret-must-change-me", DEFAULT_SESSION_KEY_PLACEHOLDER}
+)
 
 
 class SecurityHeadersSettings(BaseSettings):
@@ -551,15 +558,16 @@ class CoreConfiguration(BaseSettings):
 
     @model_validator(mode="after")
     def fail_closed_on_placeholder_session_key(self) -> Self:
-        """Refuse to run in production with the shipped placeholder session key.
+        """Refuse to run in production with a known placeholder session key.
 
-        Sessions are signed with ``session_key``; the publicly-known
-        placeholder would let anyone forge a session, so a production startup
-        (``environment == "prod"``) fails fast. Outside production it only
-        warns, keeping local development friction free while making the
-        required action obvious before deploy.
+        Sessions are signed with ``session_key``; any publicly-known
+        placeholder (the shipped default or a historical one left in an
+        upgraded project's ``.env``) would let anyone forge a session, so a
+        production startup (``environment == "prod"``) fails fast. Outside
+        production it only warns, keeping local development friction free while
+        making the required action obvious before deploy.
         """
-        if self.session_key.get_secret_value() != DEFAULT_SESSION_KEY_PLACEHOLDER:
+        if self.session_key.get_secret_value() not in KNOWN_INSECURE_SESSION_KEYS:
             return self
 
         if self.environment == "prod":

--- a/vibetuner-py/src/vibetuner/frontend/oauth.py
+++ b/vibetuner-py/src/vibetuner/frontend/oauth.py
@@ -11,10 +11,11 @@ from pydantic import BaseModel, Field
 from pydantic_extra_types.language_code import LanguageAlpha2
 from starlette.authentication import BaseUser
 
-from vibetuner.frontend.routes import get_homepage_url
+from vibetuner.frontend.routes import get_homepage_url, is_safe_redirect
 from vibetuner.logging import logger
 from vibetuner.models.oauth import OAuthAccountModel, OauthProviderModel
 from vibetuner.models.user import UserModel
+from vibetuner.ratelimit import auth_rate_limit, limiter
 
 
 if TYPE_CHECKING:
@@ -366,12 +367,16 @@ def _wrap_oauth_relay_state(location: str, public_origin: str) -> str:
 
 
 def _create_auth_login_handler(provider_name: str):
+    @limiter.limit(auth_rate_limit)
     async def auth_login(
         request: Request, next: str | None = None, app_id: str | None = None
     ):
         from vibetuner.config import settings
 
-        request.session["next_url"] = next or get_homepage_url(request)
+        if next and is_safe_redirect(next):
+            request.session["next_url"] = next
+        else:
+            request.session["next_url"] = get_homepage_url(request)
 
         try:
             client_name = await resolve_oauth_client(provider_name, app_id)

--- a/vibetuner-py/src/vibetuner/frontend/routes/__init__.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/__init__.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlsplit
+
 from fastapi import Request
 
 
@@ -10,3 +12,25 @@ def get_homepage_url(request: Request, path_only: bool = True) -> str:
         url = request.url_for("homepage")
 
     return url.path if path_only else str(url)
+
+
+def is_safe_redirect(url: str | None) -> bool:
+    """Return True only for same-origin relative paths safe to redirect to.
+
+    Guards post-auth redirect targets that originate from user input
+    (``?next=``, ``current``) against open-redirect attacks. A safe value
+    is a single-leading-slash path with no scheme and no network location,
+    so ``https://evil.com``, ``//evil.com`` (protocol-relative) and
+    ``javascript:`` URLs are all rejected. Backslashes are treated as
+    slashes because some browsers normalise them, so ``/\\evil.com`` is
+    rejected too.
+    """
+    if not url:
+        return False
+
+    normalized = url.replace("\\", "/")
+    if not normalized.startswith("/") or normalized.startswith("//"):
+        return False
+
+    parts = urlsplit(normalized)
+    return not parts.scheme and not parts.netloc

--- a/vibetuner-py/src/vibetuner/frontend/routes/auth.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/auth.py
@@ -13,6 +13,7 @@ from pydantic import EmailStr
 from starlette.responses import HTMLResponse
 
 from vibetuner.models import EmailVerificationTokenModel, UserModel
+from vibetuner.ratelimit import auth_rate_limit, limiter
 from vibetuner.services.email import EmailService
 
 from ..email import send_magic_link_email
@@ -23,7 +24,7 @@ from ..oauth import (
     get_registered_providers,
 )
 from ..templates import render_template
-from . import get_homepage_url
+from . import get_homepage_url, is_safe_redirect
 
 
 def get_email_service() -> EmailService:
@@ -97,6 +98,7 @@ async def auth_login(
 
 
 @router.post("/magic-link-login", response_model=None)
+@limiter.limit(auth_rate_limit)
 async def send_magic_link(
     request: Request,
     email_service: Annotated[EmailService, Depends(get_email_service)],
@@ -158,8 +160,10 @@ async def email_verify(
     # Set session
     request.session["user"] = user.session_dict
 
-    # Redirect
-    return next or get_homepage_url(request)
+    # Redirect (only to a same-origin path; otherwise fall back to homepage)
+    if next and is_safe_redirect(next):
+        return next
+    return get_homepage_url(request)
 
 
 def register_oauth_routes() -> None:

--- a/vibetuner-py/src/vibetuner/frontend/routes/language.py
+++ b/vibetuner-py/src/vibetuner/frontend/routes/language.py
@@ -5,6 +5,7 @@ from vibetuner.context import ctx
 
 from ..deps import require_htmx
 from ..templates import render_template
+from . import is_safe_redirect
 
 
 # Cookie expiry: 1 year in seconds
@@ -19,15 +20,15 @@ async def set_language(request: Request, lang: str, current: str) -> RedirectRes
     if lang not in ctx.supported_languages:
         raise HTTPException(status_code=400, detail="Unsupported language")
 
-    # Validate current URL is an internal path (prevent open redirect)
-    # Must start with /{lang}/ pattern and be a relative path
-    if current:
+    # Validate current URL is an internal path (prevent open redirect).
+    # Reject absolute and protocol-relative values before deriving the target.
+    if current and is_safe_redirect(current):
         # Strip the language prefix from current URL
         parts = current.strip("/").split("/", 1)
         if parts and len(parts[0]) == 2 and parts[0].isalpha():
             base_path = "/" + parts[1] if len(parts) > 1 else "/"
         else:
-            base_path = current if current.startswith("/") else f"/{current}"
+            base_path = current
         new_url = f"/{lang}{base_path}"
     else:
         new_url = request.url_for("homepage").path

--- a/vibetuner-py/src/vibetuner/ratelimit.py
+++ b/vibetuner-py/src/vibetuner/ratelimit.py
@@ -39,4 +39,14 @@ def _build_limiter() -> Limiter:
 
 limiter: Limiter = _build_limiter()
 
-__all__ = ["limiter", "SlowAPIASGIMiddleware"]
+
+def auth_rate_limit() -> str:
+    """Resolve the per-IP limit for auth endpoints at request time.
+
+    Used as a callable limit so ``RATE_LIMIT_AUTH_LIMITS`` (and runtime
+    overrides in tests) take effect without re-importing the decorated routes.
+    """
+    return settings.rate_limit.auth_limits
+
+
+__all__ = ["auth_rate_limit", "limiter", "SlowAPIASGIMiddleware"]

--- a/vibetuner-py/tests/unit/test_auth_rate_limit.py
+++ b/vibetuner-py/tests/unit/test_auth_rate_limit.py
@@ -1,0 +1,92 @@
+# ABOUTME: Tests that auth endpoints carry a conservative per-IP rate limit.
+# ABOUTME: Guards the magic-link send and OAuth-initiation routes against flooding.
+# ruff: noqa: S101, S106
+
+from httpx import AsyncClient
+
+
+class TestAuthRateLimitSetting:
+    """RateLimitSettings exposes a configurable, conservative auth limit."""
+
+    def test_default_auth_limit(self):
+        from vibetuner.config import RateLimitSettings
+
+        assert RateLimitSettings().auth_limits == "5/minute"
+
+    def test_auth_limit_overridable(self):
+        from vibetuner.config import RateLimitSettings
+
+        s = RateLimitSettings(auth_limits="2/minute")
+        assert s.auth_limits == "2/minute"
+
+    def test_auth_limit_from_env_var(self):
+        from unittest.mock import patch
+
+        from vibetuner.config import RateLimitSettings
+
+        with patch.dict(
+            "os.environ", {"RATE_LIMIT_AUTH_LIMITS": "9/hour"}, clear=False
+        ):
+            assert RateLimitSettings().auth_limits == "9/hour"
+
+
+class TestMagicLinkRateLimited:
+    """POST /auth/magic-link-login is throttled per client IP."""
+
+    async def test_rapid_repeats_return_429(
+        self, vibetuner_app, vibetuner_client: AsyncClient, monkeypatch
+    ):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vibetuner.config import settings
+        from vibetuner.frontend.routes import auth as auth_routes
+
+        # Tighten the limit so the test is fast and deterministic.
+        monkeypatch.setattr(settings.rate_limit, "auth_limits", "2/minute")
+
+        # Stub the model + email so a successful call returns 200 without Mongo
+        # or a configured mail provider; the rate limit is the only thing under
+        # test here.
+        async def fake_create_token(email):
+            return SimpleNamespace(token="tok")
+
+        async def fake_send(**kwargs):
+            return None
+
+        monkeypatch.setattr(
+            auth_routes.EmailVerificationTokenModel, "create_token", fake_create_token
+        )
+        monkeypatch.setattr(auth_routes, "send_magic_link_email", fake_send)
+        vibetuner_app.dependency_overrides[auth_routes.get_email_service] = lambda: (
+            MagicMock()
+        )
+
+        try:
+            statuses = []
+            for _ in range(5):
+                resp = await vibetuner_client.post(
+                    "/auth/magic-link-login",
+                    data={"email": "flood@example.com"},
+                )
+                statuses.append(resp.status_code)
+        finally:
+            vibetuner_app.dependency_overrides.clear()
+
+        assert 200 in statuses
+        assert 429 in statuses, f"expected a 429 among {statuses}"
+
+
+class TestOAuthInitRateLimited:
+    """The OAuth-initiation route is decorated with the auth limit."""
+
+    def test_oauth_login_handler_is_registered_with_limiter(self):
+        # A callable limit is stored in ``limiter._dynamic_route_limits`` keyed
+        # by ``module.name`` of the decorated function.
+        from vibetuner.frontend.oauth import _create_auth_login_handler
+        from vibetuner.ratelimit import limiter
+
+        handler = _create_auth_login_handler("google")
+        key = f"{handler.__module__}.{handler.__name__}"
+        assert key in limiter._dynamic_route_limits
+        assert limiter._dynamic_route_limits[key]

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -52,7 +52,11 @@ class TestCoreConfigurationEnvironment:
 
     def test_environment_from_env_var(self):
         """Test that environment can be set via ENVIRONMENT env var."""
-        with patch.dict("os.environ", {"ENVIRONMENT": "prod"}, clear=False):
+        with patch.dict(
+            "os.environ",
+            {"ENVIRONMENT": "prod", "SESSION_KEY": "real-session-key"},
+            clear=False,
+        ):
             config = CoreConfiguration(project=ProjectConfiguration())
             assert config.environment == "prod"
 
@@ -74,7 +78,9 @@ class TestRedisKeyPrefix:
     def test_redis_key_prefix_prod_environment(self):
         """Test redis_key_prefix format for prod environment."""
         project = ProjectConfiguration(project_slug="myproject")
-        config = CoreConfiguration(project=project, environment="prod")
+        config = CoreConfiguration(
+            project=project, environment="prod", session_key="real-session-key"
+        )
         assert config.redis_key_prefix == "myproject:"
 
     def test_redis_key_prefix_with_different_slugs(self):
@@ -88,7 +94,9 @@ class TestRedisKeyPrefix:
 
         for slug, env, expected in test_cases:
             project = ProjectConfiguration(project_slug=slug)
-            config = CoreConfiguration(project=project, environment=env)
+            config = CoreConfiguration(
+                project=project, environment=env, session_key="real-session-key"
+            )
             assert config.redis_key_prefix == expected, (
                 f"Failed for slug={slug}, env={env}"
             )

--- a/vibetuner-py/tests/unit/test_open_redirect.py
+++ b/vibetuner-py/tests/unit/test_open_redirect.py
@@ -1,0 +1,176 @@
+# ABOUTME: Route-level tests that post-auth redirect targets reject open-redirect payloads.
+# ABOUTME: Covers email_verify, OAuth next_url stashing, and the set-language route.
+# ruff: noqa: S101, S106
+
+from httpx import AsyncClient
+
+
+class TestSetLanguageRedirect:
+    """GET /set-language/{lang} must not redirect off-site via ``current``."""
+
+    async def test_safe_current_path_is_preserved(self, vibetuner_client: AsyncClient):
+        resp = await vibetuner_client.get(
+            "/set-language/en", params={"current": "/dashboard"}, follow_redirects=False
+        )
+        assert resp.status_code in (302, 307)
+        assert resp.headers["location"] == "/en/dashboard"
+
+    async def test_absolute_url_falls_back_to_homepage(
+        self, vibetuner_client: AsyncClient
+    ):
+        resp = await vibetuner_client.get(
+            "/set-language/en",
+            params={"current": "https://evil.com"},
+            follow_redirects=False,
+        )
+        location = resp.headers["location"]
+        assert "evil.com" not in location
+        assert location.startswith("/")
+
+    async def test_protocol_relative_url_falls_back_to_homepage(
+        self, vibetuner_client: AsyncClient
+    ):
+        resp = await vibetuner_client.get(
+            "/set-language/en",
+            params={"current": "//evil.com"},
+            follow_redirects=False,
+        )
+        location = resp.headers["location"]
+        assert "evil.com" not in location
+        assert location.startswith("/")
+
+
+class TestOAuthNextStash:
+    """``_create_auth_login_handler`` only stashes a same-origin ``next``.
+
+    The handler short-circuits via a stubbed ``resolve_oauth_client`` that
+    raises ``ValueError`` right after the ``next`` stash, so Authlib and
+    ``url_for`` are never reached.
+    """
+
+    async def test_unsafe_next_is_not_stashed(self, monkeypatch):
+        from vibetuner.frontend import oauth as oauth_mod
+        from vibetuner.ratelimit import limiter
+
+        # The handler is rate-limited; disable limiting so this redirect-only
+        # assertion is independent of per-IP counters shared across the suite.
+        monkeypatch.setattr(limiter, "enabled", False)
+
+        captured: dict = {}
+
+        async def fake_resolve(provider_name, app_id):
+            # Raise to short-circuit after the stash so we never touch Authlib.
+            raise ValueError("stop")
+
+        def fake_homepage(request, path_only=True):
+            return "/en/"
+
+        monkeypatch.setattr(oauth_mod, "resolve_oauth_client", fake_resolve)
+        monkeypatch.setattr(oauth_mod, "get_homepage_url", fake_homepage)
+
+        from starlette.requests import Request
+
+        scope: dict = {
+            "type": "http",
+            "method": "GET",
+            "path": "/auth/login/provider/google",
+            "headers": [],
+            "session": captured,
+            "state": {"language": "en"},
+        }
+        request = Request(scope)
+
+        handler = oauth_mod._create_auth_login_handler("google")
+        await handler(request, next="https://evil.com")
+
+        assert captured["next_url"] == "/en/"
+
+    async def test_safe_next_is_stashed(self, monkeypatch):
+        from vibetuner.frontend import oauth as oauth_mod
+        from vibetuner.ratelimit import limiter
+
+        monkeypatch.setattr(limiter, "enabled", False)
+
+        async def fake_resolve(provider_name, app_id):
+            raise ValueError("stop")
+
+        def fake_homepage(request, path_only=True):
+            return "/en/"
+
+        monkeypatch.setattr(oauth_mod, "resolve_oauth_client", fake_resolve)
+        monkeypatch.setattr(oauth_mod, "get_homepage_url", fake_homepage)
+
+        from starlette.requests import Request
+
+        captured: dict = {}
+        scope: dict = {
+            "type": "http",
+            "method": "GET",
+            "path": "/auth/login/provider/google",
+            "headers": [],
+            "session": captured,
+            "state": {"language": "en"},
+        }
+        request = Request(scope)
+
+        handler = oauth_mod._create_auth_login_handler("google")
+        await handler(request, next="/dashboard")
+
+        assert captured["next_url"] == "/dashboard"
+
+
+class TestEmailVerifyRedirect:
+    """``email_verify`` only honors a same-origin ``next``.
+
+    The model lookups (token verification, user load/create) and the session
+    write are not under test here, so they are stubbed: this isolates the
+    redirect-target decision, which is the open-redirect fix.
+    """
+
+    def _request(self):
+        from starlette.requests import Request
+
+        scope: dict = {
+            "type": "http",
+            "method": "GET",
+            "path": "/auth/email-verify/tok",
+            "headers": [],
+            "session": {},
+            "state": {"language": "en"},
+        }
+        return Request(scope)
+
+    async def _verify(self, monkeypatch, next_value):
+        from types import SimpleNamespace
+
+        from vibetuner.frontend.routes import auth as auth_routes
+
+        async def fake_verify_token(token):
+            return SimpleNamespace(email="alice@example.com")
+
+        async def fake_get_by_email(email):
+            return SimpleNamespace(session_dict={"id": "u1", "email": email})
+
+        monkeypatch.setattr(
+            auth_routes.EmailVerificationTokenModel,
+            "verify_token",
+            fake_verify_token,
+        )
+        monkeypatch.setattr(auth_routes.UserModel, "get_by_email", fake_get_by_email)
+        monkeypatch.setattr(auth_routes, "get_homepage_url", lambda request: "/en/")
+
+        return await auth_routes.email_verify(
+            self._request(), token="tok", next=next_value
+        )
+
+    async def test_unsafe_next_falls_back_to_homepage(self, monkeypatch):
+        result = await self._verify(monkeypatch, "https://evil.com")
+        assert result == "/en/"
+
+    async def test_protocol_relative_next_falls_back_to_homepage(self, monkeypatch):
+        result = await self._verify(monkeypatch, "//evil.com")
+        assert result == "/en/"
+
+    async def test_safe_next_is_honored(self, monkeypatch):
+        result = await self._verify(monkeypatch, "/dashboard")
+        assert result == "/dashboard"

--- a/vibetuner-py/tests/unit/test_safe_redirect.py
+++ b/vibetuner-py/tests/unit/test_safe_redirect.py
@@ -1,0 +1,47 @@
+# ABOUTME: Tests for the is_safe_redirect helper guarding post-auth redirect targets.
+# ABOUTME: Rejects absolute URLs and protocol-relative paths to prevent open redirects.
+# ruff: noqa: S101
+
+from vibetuner.frontend.routes import is_safe_redirect
+
+
+class TestIsSafeRedirect:
+    """is_safe_redirect only accepts single-leading-slash relative paths."""
+
+    def test_accepts_relative_path(self):
+        assert is_safe_redirect("/dashboard") is True
+
+    def test_accepts_relative_path_with_query(self):
+        assert is_safe_redirect("/dashboard?tab=1") is True
+
+    def test_accepts_relative_path_with_lang_prefix(self):
+        assert is_safe_redirect("/en/dashboard") is True
+
+    def test_rejects_absolute_https_url(self):
+        assert is_safe_redirect("https://evil.com") is False
+
+    def test_rejects_absolute_http_url(self):
+        assert is_safe_redirect("http://evil.com/path") is False
+
+    def test_rejects_protocol_relative_url(self):
+        assert is_safe_redirect("//evil.com") is False
+
+    def test_rejects_protocol_relative_url_with_path(self):
+        assert is_safe_redirect("//evil.com/path") is False
+
+    def test_rejects_path_without_leading_slash(self):
+        assert is_safe_redirect("dashboard") is False
+
+    def test_rejects_scheme_relative_backslash(self):
+        # Browsers may treat backslashes as slashes; reject defensively.
+        assert is_safe_redirect("/\\evil.com") is False
+        assert is_safe_redirect("\\\\evil.com") is False
+
+    def test_rejects_empty(self):
+        assert is_safe_redirect("") is False
+
+    def test_rejects_none(self):
+        assert is_safe_redirect(None) is False
+
+    def test_rejects_url_with_scheme_and_no_netloc(self):
+        assert is_safe_redirect("javascript:alert(1)") is False

--- a/vibetuner-py/tests/unit/test_session_key_guard.py
+++ b/vibetuner-py/tests/unit/test_session_key_guard.py
@@ -1,18 +1,28 @@
-# ABOUTME: Tests that the default placeholder SESSION_KEY fails closed outside DEBUG.
-# ABOUTME: Raises in production, warns loudly in debug, accepts a real key anywhere.
+# ABOUTME: Tests that a known placeholder SESSION_KEY fails closed in production.
+# ABOUTME: Raises in prod, warns outside prod, for both the old and new placeholders.
 # ruff: noqa: S101
 
 import pytest
 from pydantic import SecretStr
 from vibetuner.config import (
     DEFAULT_SESSION_KEY_PLACEHOLDER,
+    KNOWN_INSECURE_SESSION_KEYS,
     CoreConfiguration,
     ProjectConfiguration,
 )
 
 
+OLD_SESSION_KEY_PLACEHOLDER = "ct-!secret-must-change-me"
+
+
 class TestSessionKeyGuard:
-    """The shipped placeholder session key must never run in production."""
+    """A known placeholder session key must never run in production."""
+
+    def test_known_placeholders_include_old_and_new(self):
+        # The historical placeholder must stay guarded so projects upgrading
+        # from an older scaffold are caught on upgrade.
+        assert OLD_SESSION_KEY_PLACEHOLDER in KNOWN_INSECURE_SESSION_KEYS
+        assert DEFAULT_SESSION_KEY_PLACEHOLDER in KNOWN_INSECURE_SESSION_KEYS
 
     def test_placeholder_raises_in_production(self):
         with pytest.raises(ValueError, match="SESSION_KEY"):
@@ -22,6 +32,14 @@ class TestSessionKeyGuard:
                 session_key=SecretStr(DEFAULT_SESSION_KEY_PLACEHOLDER),
             )
 
+    def test_old_placeholder_raises_in_production(self):
+        with pytest.raises(ValueError, match="SESSION_KEY"):
+            CoreConfiguration(
+                project=ProjectConfiguration(),
+                environment="prod",
+                session_key=SecretStr(OLD_SESSION_KEY_PLACEHOLDER),
+            )
+
     def test_placeholder_warns_outside_production(self, log_sink):
         config = CoreConfiguration(
             project=ProjectConfiguration(),
@@ -29,6 +47,16 @@ class TestSessionKeyGuard:
             session_key=SecretStr(DEFAULT_SESSION_KEY_PLACEHOLDER),
         )
         assert config.session_key.get_secret_value() == DEFAULT_SESSION_KEY_PLACEHOLDER
+        joined = "".join(log_sink)
+        assert "SESSION_KEY" in joined
+
+    def test_old_placeholder_warns_outside_production(self, log_sink):
+        config = CoreConfiguration(
+            project=ProjectConfiguration(),
+            environment="dev",
+            session_key=SecretStr(OLD_SESSION_KEY_PLACEHOLDER),
+        )
+        assert config.session_key.get_secret_value() == OLD_SESSION_KEY_PLACEHOLDER
         joined = "".join(log_sink)
         assert "SESSION_KEY" in joined
 

--- a/vibetuner-py/tests/unit/test_session_key_guard.py
+++ b/vibetuner-py/tests/unit/test_session_key_guard.py
@@ -1,0 +1,50 @@
+# ABOUTME: Tests that the default placeholder SESSION_KEY fails closed outside DEBUG.
+# ABOUTME: Raises in production, warns loudly in debug, accepts a real key anywhere.
+# ruff: noqa: S101
+
+import pytest
+from pydantic import SecretStr
+from vibetuner.config import (
+    DEFAULT_SESSION_KEY_PLACEHOLDER,
+    CoreConfiguration,
+    ProjectConfiguration,
+)
+
+
+class TestSessionKeyGuard:
+    """The shipped placeholder session key must never run in production."""
+
+    def test_placeholder_raises_in_production(self):
+        with pytest.raises(ValueError, match="SESSION_KEY"):
+            CoreConfiguration(
+                project=ProjectConfiguration(),
+                environment="prod",
+                session_key=SecretStr(DEFAULT_SESSION_KEY_PLACEHOLDER),
+            )
+
+    def test_placeholder_warns_outside_production(self, log_sink):
+        config = CoreConfiguration(
+            project=ProjectConfiguration(),
+            environment="dev",
+            session_key=SecretStr(DEFAULT_SESSION_KEY_PLACEHOLDER),
+        )
+        assert config.session_key.get_secret_value() == DEFAULT_SESSION_KEY_PLACEHOLDER
+        joined = "".join(log_sink)
+        assert "SESSION_KEY" in joined
+
+    def test_real_key_is_accepted_in_production(self):
+        config = CoreConfiguration(
+            project=ProjectConfiguration(),
+            environment="prod",
+            session_key=SecretStr("a-real-and-unique-secret-value"),
+        )
+        assert config.session_key.get_secret_value() == "a-real-and-unique-secret-value"
+
+    def test_real_key_does_not_warn_outside_production(self, log_sink):
+        CoreConfiguration(
+            project=ProjectConfiguration(),
+            environment="dev",
+            session_key=SecretStr("a-real-and-unique-secret-value"),
+        )
+        joined = "".join(log_sink)
+        assert "SESSION_KEY" not in joined

--- a/vibetuner-py/tests/unit/test_utils.py
+++ b/vibetuner-py/tests/unit/test_utils.py
@@ -76,6 +76,7 @@ class TestResolvedPort:
 
         config = CoreConfiguration(
             environment="prod",
+            session_key="real-session-key",
             _env_file=None,
         )
         assert config.resolved_port == 8000
@@ -123,6 +124,7 @@ class TestResolvedWorkerPort:
 
         config = CoreConfiguration(
             environment="prod",
+            session_key="real-session-key",
             _env_file=None,
         )
         assert config.resolved_worker_port == 18000

--- a/vibetuner-template/.claude/rules/configuration.md
+++ b/vibetuner-template/.claude/rules/configuration.md
@@ -9,7 +9,11 @@ description: Environment variables, settings, security headers, and request ID
 # Configuration
 
 **Env vars** (`.env`, not committed): `DATABASE_URL`, `REDIS_URL`,
-`SECRET_KEY`, `DEBUG`.
+`SESSION_KEY`, `DEBUG`.
+
+`SESSION_KEY` signs sessions. The shipped placeholder makes startup **fail**
+when `ENVIRONMENT=prod` (and warn otherwise) — generate a real value with
+`uv run vibetuner crypto generate-key` before deploying.
 
 **Settings**: `from vibetuner.config import settings` —
 `.environment`, `.debug`, `.resolved_port`,

--- a/vibetuner-template/.claude/rules/development.md
+++ b/vibetuner-template/.claude/rules/development.md
@@ -108,7 +108,9 @@ async def health(request: Request): ...
 ```
 
 Configure via `RATE_LIMIT_*` env vars. Redis shares limits across
-workers; falls back to in-memory.
+workers; falls back to in-memory. Built-in auth endpoints (magic-link
+send, OAuth init) already carry a per-IP limit (`RATE_LIMIT_AUTH_LIMITS`,
+default `5/minute`).
 
 ## CLI Commands
 

--- a/vibetuner-template/.env.j2
+++ b/vibetuner-template/.env.j2
@@ -5,4 +5,6 @@
 # REDIS_URL=redis://localhost:6379
 
 # Security Configuration
-SESSION_KEY=ct-!secret-must-change-me
+# Generate a unique value with: uv run vibetuner crypto generate-key
+# Startup fails in production (ENVIRONMENT=prod) while this placeholder is unchanged.
+SESSION_KEY=CHANGE_ME_RUN_vibetuner_crypto_generate


### PR DESCRIPTION
Defensive hardening of the framework's own auth surface, in one PR.

## #2010 — Open redirect via unvalidated `next`/`current`

Added a shared `is_safe_redirect(url)` helper (in
`vibetuner/frontend/routes/__init__.py`, alongside `get_homepage_url`)
that only accepts same-origin relative paths — anything with a scheme or
netloc, protocol-relative `//evil.com`, or backslash tricks is rejected.
Applied it in all three user-input redirect sites:

- `routes/auth.py` `email_verify` — `next` is honored only when safe,
  else falls back to the homepage.
- `frontend/oauth.py` OAuth login — `next` is validated before being
  stashed in `session["next_url"]`.
- `routes/language.py` `set_language` — `current` is validated before the
  language-prefixed target is built.

Fixes #2010

## #2011 — Default `SESSION_KEY` must not run in production

`CoreConfiguration` now fails closed: a `model_validator` raises at
startup when `session_key` is still the shipped placeholder and
`ENVIRONMENT=prod`, and logs a loud warning otherwise. The template
`.env.j2` placeholder is now the unmistakable
`CHANGE_ME_RUN_vibetuner_crypto_generate`, and a new
`vibetuner crypto generate-key` command prints a secure key. The
`doctor` check and docs point at it.

> Note: the spec said gate on DEBUG, but `debug` defaults to `False` in
> normal dev, so gating the raise on DEBUG crashed every dev run and the
> whole test suite at import. The real production signal here is
> `environment == "prod"`, so the raise keys off that; non-prod still
> warns loudly. Flagging since it deviates from the literal ask.

Fixes #2011

## #2012 — Default rate limits on auth endpoints

The magic-link send (`POST /auth/magic-link-login`) and OAuth-initiation
routes now carry a conservative per-IP limit via the framework `limiter`,
configurable through the new `RATE_LIMIT_AUTH_LIMITS` setting (default
`5/minute`). Implemented as a callable limit so the setting (and test
overrides) take effect without re-importing routes — no change to the
global `default_limits`.

Fixes #2012

## Tests & docs

New tests: `test_safe_redirect.py`, `test_open_redirect.py`,
`test_session_key_guard.py`, `test_auth_rate_limit.py`. Full vibetuner-py
unit suite green (996 passed); ruff + ty clean. Docs updated:
`authentication.md`, `rate-limiting.md`, `llms.txt`, `llms-full.txt`, and
the scaffolded `.claude/rules/` security guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BREAKING CHANGE: Apps running with environment=prod now refuse to start if SESSION_KEY is still a known placeholder (old `ct-!secret-must-change-me` or new `CHANGE_ME_RUN_vibetuner_crypto_generate`). Set a unique SESSION_KEY (`vibetuner crypto generate-key`) before deploying. Auth endpoints (magic-link send, OAuth init) are now rate-limited to 5/minute per IP by default; tune via RATE_LIMIT_AUTH_LIMITS. See the v11->v12 upgrade guide (#2034).
