### PR TITLE
feat(api): export sse_endpoint, broadcast, create_crud_routes, require_htmx from the top-level package

### DIFF
--- a/vibetuner-docs/docs/architecture.md
+++ b/vibetuner-docs/docs/architecture.md
@@ -346,7 +346,7 @@ Generate a full set of list/create/read/update/delete routes from a Beanie
 Document model with one function call:
 
 ```python
-from vibetuner.crud import create_crud_routes
+from vibetuner import create_crud_routes
 from app.models import Post
 
 router = create_crud_routes(
@@ -375,7 +375,7 @@ Features:
 Real-time streaming over HTTP with HTMX integration:
 
 ```python
-from vibetuner.sse import sse_endpoint, broadcast
+from vibetuner import sse_endpoint, broadcast
 
 # Subscribe clients to a channel
 @sse_endpoint("/events/notifications", channel="notifications", router=router)

--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -390,7 +390,7 @@ Server-Sent Events. This is useful for progress indicators, live feeds, and
 notifications.
 
 ```python
-from vibetuner.sse import broadcast
+from vibetuner import broadcast
 from vibetuner.tasks.worker import get_worker
 
 worker = get_worker()
@@ -443,7 +443,7 @@ connecting element via its `hx-swap`:
 With a corresponding SSE endpoint:
 
 ```python
-from vibetuner.sse import sse_endpoint
+from vibetuner import sse_endpoint
 
 @sse_endpoint("/events/upload/{user_id}", router=router)
 async def upload_stream(request: Request, user_id: str):

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -1158,7 +1158,7 @@ Use the `require_htmx` dependency to reject non-HTMX requests with a 400 error:
 
 ```python
 from fastapi import Depends
-from vibetuner.frontend.deps import require_htmx
+from vibetuner import require_htmx
 
 @router.post("/items/create", dependencies=[Depends(require_htmx)])
 async def create_item(request: Request):
@@ -1586,7 +1586,7 @@ Generate complete REST API endpoints from Beanie Document models with a single f
 ### Basic Usage
 
 ```python
-from vibetuner.crud import create_crud_routes
+from vibetuner import create_crud_routes
 from app.models.post import Post
 
 post_routes = create_crud_routes(Post, prefix="/posts", tags=["posts"])
@@ -1693,7 +1693,8 @@ post_routes = create_crud_routes(
 Only generate the endpoints you need:
 
 ```python
-from vibetuner.crud import create_crud_routes, Operation
+from vibetuner import create_crud_routes
+from vibetuner.crud import Operation
 
 # Read-only API
 post_routes = create_crud_routes(
@@ -1725,7 +1726,7 @@ designed for use with HTMX.
 Subscribe clients to a named channel and broadcast updates from anywhere:
 
 ```python
-from vibetuner.sse import sse_endpoint, broadcast
+from vibetuner import sse_endpoint, broadcast
 
 router = APIRouter()
 
@@ -1743,7 +1744,7 @@ async def notifications_stream(request: Request):
 Broadcast from any route or background task:
 
 ```python
-from vibetuner.sse import broadcast
+from vibetuner import broadcast
 
 @router.post("/posts")
 async def create_post(request: Request):

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -679,7 +679,7 @@ Properties: `bool(request.state.htmx)`, `.boosted`, `.target`, `.trigger`,
 `.trigger_name`, `.current_url`, `.prompt`.
 
 HTMX-only routes — use the `require_htmx` dependency from
-`vibetuner.frontend.deps` to reject non-HTMX requests with a 400.
+`vibetuner` to reject non-HTMX requests with a 400.
 
 ### Architecture
 
@@ -1118,7 +1118,8 @@ Vibetuner includes a CRUD route factory that generates list, create, read, updat
 and delete endpoints for Beanie Document models with one function call.
 
 ```python
-from vibetuner.crud import create_crud_routes, Operation
+from vibetuner import create_crud_routes
+from vibetuner.crud import Operation
 from app.models import Post
 
 # Generate all CRUD routes
@@ -1218,17 +1219,17 @@ input. If they return `None`, the original data is used.
 ### Server-Sent Events (SSE)
 
 Vibetuner provides SSE helpers for real-time streaming with HTMX. Import from
-`vibetuner.sse` (not `vibetuner.frontend.sse`).
+the top-level `vibetuner` package.
 
 ```python
-from vibetuner.sse import sse_endpoint, broadcast
+from vibetuner import sse_endpoint, broadcast
 ```
 
 **Channel-based endpoint (auto-subscribe):**
 
 ```python
 from fastapi import APIRouter, Request
-from vibetuner.sse import sse_endpoint
+from vibetuner import sse_endpoint
 
 router = APIRouter()
 
@@ -1260,7 +1261,7 @@ async def custom_stream(request: Request):
 **Broadcasting events:**
 
 ```python
-from vibetuner.sse import broadcast
+from vibetuner import broadcast
 
 # Raw data
 await broadcast("notifications", "update", data="<div>New item!</div>")
@@ -2482,7 +2483,7 @@ Cron tasks only execute inside the worker process.
 Broadcast real-time updates from background tasks to connected clients:
 
 ```python
-from vibetuner.sse import broadcast
+from vibetuner import broadcast
 
 @worker.task()
 async def process_upload(file_id: str, user_id: str) -> dict:

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -33,11 +33,11 @@ Important notes:
 - **HTMX Request Detection**: `request.state.htmx` available on every request
   (via `starlette-htmx` middleware). Properties: `.boosted`, `.target`, `.trigger`,
   `.trigger_name`, `.current_url`, `.prompt`. Use `require_htmx` dependency from
-  `vibetuner.frontend.deps` to reject non-HTMX requests with 400
+  `vibetuner` to reject non-HTMX requests with 400
 - **CRUD Factory**: `create_crud_routes()` generates list/create/read/update/delete
   endpoints for Beanie models with pagination, filtering, sorting, and search
 - **SSE Helpers**: `@sse_endpoint()` and `broadcast()` for real-time streaming with
-  HTMX. Import from `vibetuner.sse`. Redis pub/sub for multi-worker support
+  HTMX. Import from `vibetuner`. Redis pub/sub for multi-worker support
 - **`@render` Decorator**: `@render("template.html.jinja")` eliminates
   `render_template()` boilerplate — route returns a dict, decorator handles rendering.
   Returns `Response` objects unchanged (escape hatch). Import from `vibetuner`

--- a/vibetuner-py/src/vibetuner/__init__.py
+++ b/vibetuner-py/src/vibetuner/__init__.py
@@ -1,8 +1,10 @@
 # ABOUTME: Main vibetuner package entry point.
-# ABOUTME: Exports VibetunerApp, AsyncTyper, and core template rendering functions.
+# ABOUTME: Exports VibetunerApp, AsyncTyper, render functions, SSE, CRUD, and HTMX helpers.
 from importlib.metadata import version
 
 from vibetuner.app_config import VibetunerApp
+from vibetuner.crud import create_crud_routes
+from vibetuner.frontend.deps import require_htmx
 from vibetuner.rendering import (
     register_context_provider,
     register_globals,
@@ -13,6 +15,7 @@ from vibetuner.rendering import (
     render_template_stream,
     render_template_string,
 )
+from vibetuner.sse import broadcast, sse_endpoint
 from vibetuner.theming import register_tenant_theme_provider
 
 
@@ -31,6 +34,8 @@ __all__ = [
     "__version__",
     "AsyncTyper",
     "VibetunerApp",
+    "broadcast",
+    "create_crud_routes",
     "register_context_provider",
     "register_globals",
     "register_tenant_theme_provider",
@@ -40,4 +45,6 @@ __all__ = [
     "render_template_blocks",
     "render_template_stream",
     "render_template_string",
+    "require_htmx",
+    "sse_endpoint",
 ]

--- a/vibetuner-py/tests/unit/test_circular_import.py
+++ b/vibetuner-py/tests/unit/test_circular_import.py
@@ -141,3 +141,49 @@ class TestCircularImportPrevention:
             f"Importing render_template_string triggered load_app_config():\n"
             f"stderr: {result.stderr}"
         )
+
+    def test_public_api_importable_from_vibetuner_top_level(self):
+        """SSE, CRUD, and HTMX helpers must be importable from the top-level package.
+
+        These are documented as first-class features, so users should be able to do
+        `from vibetuner import sse_endpoint, broadcast, create_crud_routes, require_htmx`
+        without reaching into submodules and without triggering load_app_config().
+
+        Each re-export must be the same object as its submodule original.
+
+        See: https://github.com/alltuner/vibetuner/issues/2014
+        """
+        code = textwrap.dedent("""\
+            import unittest.mock as mock
+            import vibetuner.loader
+
+            mock.patch.object(
+                vibetuner.loader,
+                "load_app_config",
+                side_effect=RuntimeError("load_app_config called during import"),
+            ).start()
+
+            from vibetuner import sse_endpoint, broadcast, create_crud_routes, require_htmx
+            import vibetuner.sse
+            import vibetuner.crud
+            import vibetuner.frontend.deps
+
+            assert vibetuner.sse.sse_endpoint is sse_endpoint
+            assert vibetuner.sse.broadcast is broadcast
+            assert vibetuner.crud.create_crud_routes is create_crud_routes
+            assert vibetuner.frontend.deps.require_htmx is require_htmx
+
+            print("OK")
+        """)
+
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert "OK" in result.stdout, (
+            f"Importing the public API from vibetuner failed or identities mismatched:\n"
+            f"stderr: {result.stderr}"
+        )


### PR DESCRIPTION
## Summary

The docs present `sse_endpoint`, `broadcast`, `create_crud_routes`, and `require_htmx` as
first-class features, but they were only importable from their submodules
(`vibetuner.sse`, `vibetuner.crud`, `vibetuner.frontend.deps`). This re-exports all four from
the top-level `vibetuner` package and adds them to `__all__`, so users can do
`from vibetuner import ...` consistently.

Docs examples and prose were updated to use the top-level import path. The two
`from vibetuner.crud import create_crud_routes, Operation` examples are split so
`create_crud_routes` comes from `vibetuner` while `Operation` (not a top-level export)
stays on `vibetuner.crud`.

## Symbols exported

- `broadcast`, `sse_endpoint` (from `vibetuner.sse`)
- `create_crud_routes` (from `vibetuner.crud`)
- `require_htmx` (from `vibetuner.frontend.deps`)

## Circular import

No caveat. All four submodules only import `fastapi`, `beanie`, `vibetuner.logging`, and
`vibetuner.rendering` — already in the import chain triggered by the existing top-level
imports. Verified that `from vibetuner import ...` does not trigger `load_app_config()`.

## Testing

- Added `test_public_api_importable_from_vibetuner_top_level` to `tests/unit/test_circular_import.py`
  asserting the imports work and each re-export is identical (`is`) to its submodule original.
- `uv run python -m pytest tests/`: 968 passed (3 integration errors are Docker-unavailable in
  this environment, unrelated to this change).
- `uv run ty check .`: All checks passed.

Fixes #2014

🤖 Generated with [Claude Code](https://claude.com/claude-code)