### PR TITLE
chore(deps): sync vibetuner-py/uv.lock with bumped pytest floor

### DIFF
--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2254,7 +2254,7 @@ zstd = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2263,9 +2263,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -3241,7 +3241,7 @@ requires-dist = [
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
     { name = "pydantic-extra-types", extras = ["pycountry"], specifier = ">=2.11.1" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "redis", extras = ["hiredis"], specifier = ">=8.0.0" },


### PR DESCRIPTION
## What

#2047 raised `vibetuner-py` pytest to `>=9.1.1` in `pyproject.toml` and regenerated the root `uv.lock`, but left `vibetuner-py/uv.lock` recording `pytest>=9.1.1`'s *old* state (`>=9.0.3`, resolved `9.1.0`). This regenerates `vibetuner-py/uv.lock` so it matches its own `pyproject.toml`.

## Why

After the bot PRs merged, `uv lock --check` failed on `vibetuner-py/uv.lock` (pyproject floor `pytest>=9.1.1` vs lock-recorded `>=9.0.3`). Any `uv lock --locked` / pre-commit run would flag it. Root lock was already consistent.

## Verification

- `uv lock --check` passes on both `uv.lock` and `vibetuner-py/uv.lock`
- `pytest tests/ --ignore=tests/integration` → 967 passed
- `just type-check-py` → All checks passed

Diff is pytest-only (specifier `>=9.0.3`→`>=9.1.1`, resolved `9.1.0`→`9.1.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)