### PR TITLE
fix(docker): run scaffolded template image as non-root with a HEALTHCHECK

### DIFF
--- a/vibetuner-template/Dockerfile
+++ b/vibetuner-template/Dockerfile
@@ -105,34 +105,38 @@ FROM python:${PYTHON_VERSION}-slim AS runtime
 ARG ENVIRONMENT=dev
 ARG VERSION=0.0.0
 
+# Run as an unprivileged user; create it before copying so files land owned by it
+RUN groupadd --gid 1000 appuser && \
+    useradd --uid 1000 --gid 1000 --create-home appuser
+
 WORKDIR /app
 
 # Copy Python virtual environment with all dependencies and project installed
-COPY --link --from=python-app /app/.venv/ .venv/
+COPY --link --chown=1000:1000 --from=python-app /app/.venv/ .venv/
 
 # Copy application source code (required for editable install)
-COPY --link --from=python-app /app/src/ src/
+COPY --link --chown=1000:1000 --from=python-app /app/src/ src/
 
 # Copy static assets and markdown content (not full frontend source)
-COPY --link assets/statics/ assets/statics/
-COPY --link templates/markdown/ templates/markdown/
+COPY --link --chown=1000:1000 assets/statics/ assets/statics/
+COPY --link --chown=1000:1000 templates/markdown/ templates/markdown/
 
 # Copy compiled localization files (smaller than source .po files)
-COPY --link --from=locales --parents /app/locales/*/LC_MESSAGES/messages.mo /
+COPY --link --chown=1000:1000 --from=locales --parents /app/locales/*/LC_MESSAGES/messages.mo /
 
 # Copy template files
-COPY --link templates/frontend templates/frontend/
-COPY --link templates/email templates/email/
+COPY --link --chown=1000:1000 templates/frontend templates/frontend/
+COPY --link --chown=1000:1000 templates/email templates/email/
 
 # Copy built frontend assets (CSS and JS bundles)
-COPY --link --from=frontend-build /app/assets/statics/css/bundle.css assets/statics/css/bundle.css
-COPY --link --from=frontend-build /app/assets/statics/js/bundle.js assets/statics/js/bundle.js
+COPY --link --chown=1000:1000 --from=frontend-build /app/assets/statics/css/bundle.css assets/statics/css/bundle.css
+COPY --link --chown=1000:1000 --from=frontend-build /app/assets/statics/js/bundle.js assets/statics/js/bundle.js
 
 # Copy configuration files (used as project root marker and for package metadata)
-COPY --link .copier-answers.yml pyproject.toml ./
+COPY --link --chown=1000:1000 .copier-answers.yml pyproject.toml ./
 
 # Copy startup script with executable permissions (--chmod eliminates separate RUN layer)
-COPY --link --chmod=755 start.sh /start.sh
+COPY --link --chmod=755 --chown=1000:1000 start.sh /start.sh
 
 # Configure environment for Python application
 ENV PATH="/app/.venv/bin:$PATH" \
@@ -142,12 +146,21 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 EXPOSE 8000
 
+# Probe the dependency-free liveness endpoint using only the stdlib (no curl in image)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health/ping', timeout=4).status == 200 else 1)"]
+
+USER appuser
+
 ENTRYPOINT ["/start.sh"]
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Stage 8: Dev Runtime (extends runtime with bun + watcher inputs for asset rebuild)
 # ────────────────────────────────────────────────────────────────────────────────
 FROM runtime AS dev-runtime
+
+# Dev containers run as root so bun watchers can write rebuilt assets to /app
+USER root
 
 # Bun binary for tailwind/bundler watchers. oven/bun:1 is debian-glibc, matching
 # python:slim, so the static binary works without extra libs.


### PR DESCRIPTION
## Summary

- Creates `appuser` (uid/gid 1000) in the `runtime` stage before any `COPY`
  so all runtime files land owned by the app user, not root.
- Adds `--chown=1000:1000` to every `COPY` instruction in the `runtime` stage
  (venv, source, assets, locales, templates, bundles, config, start.sh).
- Wires a `HEALTHCHECK` using only the Python stdlib `urllib.request` against
  `/health/ping` — no `curl` or extra packages needed in the image.
- The `dev-runtime` stage explicitly resets `USER root` so bun watchers can
  write rebuilt CSS/JS assets during development without permission errors.

This mirrors the same changes made to the repo's own build `Dockerfile` in
PR #2019, but applied to the `vibetuner-template/Dockerfile` that scaffolded
user projects actually deploy.

## Verification

Performed manual review of the final Dockerfile (hadolint not available in
this environment). Key checks:
- User creation happens before `WORKDIR /app` and all `COPY` instructions in
  the runtime stage — consistent with PR #2019 approach.
- HEALTHCHECK path `/health/ping` confirmed against `vibetuner-py/src/vibetuner/frontend/routes/health.py`
  (the `@router.get("/ping")` liveness endpoint).
- `dev-runtime` stage resets to `USER root` to preserve dev behaviour —
  the compose.dev.yml healthcheck and `docker compose watch` sync continue to work.
- All pre-commit hooks pass.
- No Python, TOML, YAML, or Jinja changes; Dockerfile-only diff.

Closes #2030

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTUrgbYEPjmUyFJfQRCfH