### PR TITLE
fix(cli): preserve scaffold error tracebacks and surface template-task execution

### DIFF
--- a/vibetuner-py/src/vibetuner/cli/scaffold.py
+++ b/vibetuner-py/src/vibetuner/cli/scaffold.py
@@ -1,5 +1,6 @@
 # ABOUTME: Scaffolding commands for creating new projects from the vibetuner template
 # ABOUTME: Uses Copier to generate FastAPI+MongoDB+HTMX projects with interactive prompts
+import os
 import tomllib
 from pathlib import Path
 from typing import Annotated, Any
@@ -11,6 +12,23 @@ def _console():
     from rich.console import Console
 
     return Console()
+
+
+def _is_debug_mode() -> bool:
+    """Return True when the DEBUG environment variable is set to a truthy value."""
+    return os.environ.get("DEBUG", "").lower() in ("1", "true", "yes")
+
+
+def _handle_scaffold_error(e: Exception, action: str) -> None:
+    """Print friendly error message; in debug mode also print the full traceback.
+
+    Must be called from within an except block so sys.exc_info() is populated
+    for Rich's print_exception().
+    """
+    console = _console()
+    console.print(f"[red]Error {action}: {e}[/red]")
+    if _is_debug_mode():
+        console.print_exception()
 
 
 def _get_git_config(key: str, cwd: Path) -> str | None:
@@ -221,6 +239,12 @@ def new(
 ) -> None:
     """Create a new project from the vibetuner template.
 
+    Note: Template tasks defined in the vibetuner template are executed during project
+    creation (copier unsafe mode). Review the template source at
+    https://github.com/alltuner/vibetuner before running in untrusted environments.
+
+    Set DEBUG=1 in the environment to print full tracebacks on failure.
+
     Examples:
 
         # Interactive mode (prompts for all values)
@@ -285,8 +309,8 @@ def new(
         _console().print("  just dev")
 
     except Exception as e:
-        _console().print(f"[red]Error creating project: {e}[/red]")
-        raise typer.Exit(code=1) from None
+        _handle_scaffold_error(e, "creating project")
+        raise typer.Exit(code=1) from e
 
 
 @scaffold_app.command(name="update")
@@ -318,6 +342,12 @@ def update(
 
     This will update the project's files to match the latest template version,
     while preserving your answers to the original questions.
+
+    Note: Template tasks defined in the vibetuner template are executed during the update
+    (copier unsafe mode). Review the template source at
+    https://github.com/alltuner/vibetuner before running in untrusted environments.
+
+    Set DEBUG=1 in the environment to print full tracebacks on failure.
 
     Examples:
 
@@ -373,8 +403,8 @@ def update(
         _console().print("\n[green]✓ Project updated successfully![/green]")
 
     except Exception as e:
-        _console().print(f"[red]Error updating project: {e}[/red]")
-        raise typer.Exit(code=1) from None
+        _handle_scaffold_error(e, "updating project")
+        raise typer.Exit(code=1) from e
 
 
 @scaffold_app.command(name="copy-core-templates", hidden=True)
@@ -420,6 +450,12 @@ def adopt(
     This command allows projects that already have vibetuner installed as a
     dependency to adopt the full scaffolding infrastructure, enabling future
     `scaffold update` commands.
+
+    Note: Template tasks defined in the vibetuner template are executed during adoption
+    (copier unsafe mode). Review the template source at
+    https://github.com/alltuner/vibetuner before running in untrusted environments.
+
+    Set DEBUG=1 in the environment to print full tracebacks on failure.
 
     The command will:
     1. Infer template variables from existing project files (pyproject.toml, etc.)
@@ -499,5 +535,5 @@ def adopt(
         )
 
     except Exception as e:
-        _console().print(f"[red]Error adopting scaffolding: {e}[/red]")
-        raise typer.Exit(code=1) from None
+        _handle_scaffold_error(e, "adopting scaffolding")
+        raise typer.Exit(code=1) from e

--- a/vibetuner-py/tests/unit/test_scaffold_error_handling.py
+++ b/vibetuner-py/tests/unit/test_scaffold_error_handling.py
@@ -1,0 +1,149 @@
+# ABOUTME: Tests for scaffold command error handling helpers
+# ABOUTME: Verifies exception chain preservation and debug traceback printing
+# ruff: noqa: S101
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from vibetuner.cli.scaffold import (
+    _handle_scaffold_error,
+    _is_debug_mode,
+    adopt,
+    new,
+    update,
+)
+
+
+class TestIsDebugMode:
+    """Test the _is_debug_mode helper."""
+
+    def test_false_when_debug_not_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert _is_debug_mode() is False
+
+    def test_true_when_debug_is_1(self):
+        with patch.dict(os.environ, {"DEBUG": "1"}):
+            assert _is_debug_mode() is True
+
+    def test_true_when_debug_is_true(self):
+        with patch.dict(os.environ, {"DEBUG": "true"}):
+            assert _is_debug_mode() is True
+
+    def test_true_when_debug_is_yes(self):
+        with patch.dict(os.environ, {"DEBUG": "yes"}):
+            assert _is_debug_mode() is True
+
+    def test_true_when_debug_is_uppercase(self):
+        with patch.dict(os.environ, {"DEBUG": "TRUE"}):
+            assert _is_debug_mode() is True
+
+    def test_false_when_debug_is_0(self):
+        with patch.dict(os.environ, {"DEBUG": "0"}):
+            assert _is_debug_mode() is False
+
+    def test_false_when_debug_is_empty(self):
+        with patch.dict(os.environ, {"DEBUG": ""}):
+            assert _is_debug_mode() is False
+
+
+class TestHandleScaffoldError:
+    """Test the _handle_scaffold_error helper."""
+
+    def test_prints_friendly_message(self):
+        """The one-line error message is always printed."""
+        mock_console = MagicMock()
+        e = RuntimeError("copier exploded")
+
+        try:
+            raise e
+        except RuntimeError:
+            with patch("vibetuner.cli.scaffold._console", return_value=mock_console):
+                with patch.dict(os.environ, {}, clear=True):
+                    _handle_scaffold_error(e, "creating project")
+
+        mock_console.print.assert_called_once_with(
+            "[red]Error creating project: copier exploded[/red]"
+        )
+
+    def test_no_traceback_without_debug(self):
+        """print_exception is NOT called when DEBUG is not set."""
+        mock_console = MagicMock()
+        e = RuntimeError("something failed")
+
+        try:
+            raise e
+        except RuntimeError:
+            with patch("vibetuner.cli.scaffold._console", return_value=mock_console):
+                with patch.dict(os.environ, {}, clear=True):
+                    _handle_scaffold_error(e, "updating project")
+
+        mock_console.print_exception.assert_not_called()
+
+    def test_prints_traceback_in_debug_mode(self):
+        """print_exception IS called when DEBUG=1."""
+        mock_console = MagicMock()
+        e = RuntimeError("copier task failed")
+
+        try:
+            raise e
+        except RuntimeError:
+            with patch("vibetuner.cli.scaffold._console", return_value=mock_console):
+                with patch.dict(os.environ, {"DEBUG": "1"}):
+                    _handle_scaffold_error(e, "adopting scaffolding")
+
+        mock_console.print_exception.assert_called_once()
+
+
+class TestExceptionChainPreservation:
+    """Verify that raise ... from e preserves the original cause."""
+
+    def test_new_command_preserves_cause(self, tmp_path: Path):
+        """scaffold new: the Exit's __cause__ is the original copier exception."""
+        original = RuntimeError("network timeout")
+
+        with patch("copier.run_copy", side_effect=original):
+            with patch.dict(os.environ, {}, clear=True):
+                with pytest.raises(typer.Exit) as exc_info:
+                    new(destination=tmp_path / "proj")
+
+        assert exc_info.value.__cause__ is original
+
+    def test_update_command_preserves_cause(self, tmp_path: Path):
+        """scaffold update: the Exit's __cause__ is the original copier exception."""
+        # Create .copier-answers.yml so validation passes
+        (tmp_path / ".copier-answers.yml").write_text("project_slug: test\n")
+        original = RuntimeError("git ref not found")
+
+        with patch("copier.run_update", side_effect=original):
+            with patch.dict(os.environ, {}, clear=True):
+                with pytest.raises(typer.Exit) as exc_info:
+                    update(path=tmp_path)
+
+        assert exc_info.value.__cause__ is original
+
+    def test_adopt_command_preserves_cause(self, tmp_path: Path):
+        """scaffold adopt: the Exit's __cause__ is the original copier exception."""
+        # Set up a valid project directory so validation passes
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "test"\ndependencies = ["vibetuner"]\n'
+        )
+        original = RuntimeError("template parse error")
+
+        with patch("copier.run_copy", side_effect=original):
+            with patch.dict(os.environ, {}, clear=True):
+                with pytest.raises(typer.Exit) as exc_info:
+                    adopt(path=tmp_path)
+
+        assert exc_info.value.__cause__ is original
+
+    def test_new_exit_code_is_1_on_failure(self, tmp_path: Path):
+        """scaffold new: exit code is 1 when copier fails."""
+        with patch("copier.run_copy", side_effect=RuntimeError("oops")):
+            with patch.dict(os.environ, {}, clear=True):
+                with pytest.raises(typer.Exit) as exc_info:
+                    new(destination=tmp_path / "proj")
+
+        assert exc_info.value.exit_code == 1


### PR DESCRIPTION
## Summary

- Replaces `raise typer.Exit(1) from None` with `raise typer.Exit(1) from e` in all
  three scaffold commands (`new`, `update`, `adopt`), preserving the original exception
  chain for debuggability.
- Factors a `_handle_scaffold_error` helper that prints the friendly one-line message
  by default, and calls Rich's `console.print_exception()` when `DEBUG=1` is set in the
  environment — full traceback without changing the default user experience.
- Adds a visible note in each command's `--help` text that template tasks execute during
  scaffolding (`copier unsafe=True`) and that users should review the template source
  before running in untrusted environments.

## Test plan

- [ ] 14 new unit tests in `vibetuner-py/tests/unit/test_scaffold_error_handling.py`
  covering `_is_debug_mode`, `_handle_scaffold_error` (friendly message, no traceback,
  traceback in DEBUG mode), and `__cause__` preservation for all three commands
- [ ] All 981 unit tests pass (`uv run python -m pytest tests/unit/`)
- [ ] `just lint-py` and `just type-check-py` pass with no new issues
- [ ] Manually verify: `DEBUG=1 vibetuner scaffold new /nonexistent` should print full
  traceback; without `DEBUG` only the one-line error appears

Closes #2027

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTUrgbYEPjmUyFJfQRCfH