### PR TITLE
fix(worker): derive stream_timeout/max_idle_time from idle_timeout to prevent premature connection closure

### DIFF
--- a/vibetuner-docs/docs/background-tasks.md
+++ b/vibetuner-docs/docs/background-tasks.md
@@ -591,10 +591,11 @@ vibetuner run prod worker --workers 4
 | Concurrency | `WORKER_CONCURRENCY` | `16` | Max concurrent tasks per worker |
 | Queue name | — | Project slug | Derived from `REDIS_KEY_PREFIX` |
 | Monitoring port | `--port` flag | `11111` | Port for the worker web UI |
-| Socket timeout | `REDIS_SOCKET_TIMEOUT` | `30` | Seconds before a hung Redis read raises (0 disables) |
+| Idle timeout | `WORKER_IDLE_TIMEOUT` | `60` | Seconds streaq waits for new tasks before re-checking idle tasks |
+| Socket timeout | `REDIS_SOCKET_TIMEOUT` | `30` | Floor for the coredis stream timeout (0 disables) |
 | Connect timeout | `REDIS_SOCKET_CONNECT_TIMEOUT` | `10` | Seconds before a Redis connect attempt gives up (0 disables) |
 | Keepalive | `REDIS_SOCKET_KEEPALIVE` | `true` | Enable TCP keepalive on the Redis connection |
-| Idle recycling | `REDIS_HEALTH_CHECK_INTERVAL` | `30` | Seconds before an idle connection is recycled instead of reused (0 disables) |
+| Idle recycling | `REDIS_HEALTH_CHECK_INTERVAL` | `30` | Floor for idle connection recycling (0 disables) |
 | Watchdog timeout | `WORKER_WATCHDOG_TIMEOUT` | `60` | Seconds of event-loop stall before the process force-exits (0 disables) |
 | Watchdog interval | `WORKER_WATCHDOG_INTERVAL` | `5` | Seconds between watchdog heartbeats/checks |
 
@@ -608,10 +609,15 @@ stays up but stops processing tasks and crons, with no automatic recovery.
 The `REDIS_SOCKET_TIMEOUT`, `REDIS_SOCKET_CONNECT_TIMEOUT`,
 `REDIS_SOCKET_KEEPALIVE`, and `REDIS_HEALTH_CHECK_INTERVAL` settings guard
 against this: a dead connection raises an error instead of hanging, so the
-worker reconnects or exits and is restarted by its `restart` policy. The
-defaults are safe for the worker, whose blocking reads are bounded to well
-under a second. Raise `REDIS_SOCKET_TIMEOUT` if your network has high latency,
-or set it to `0` to disable it entirely.
+worker reconnects or exits and is restarted by its `restart` policy.
+
+The worker's coredis client calls `XREADGROUP BLOCK <idle_timeout>`, which is a
+legitimate blocking read that can last up to `WORKER_IDLE_TIMEOUT` seconds (60 s
+by default). The actual coredis stream timeout and connection idle-recycling
+threshold are therefore derived as `max(REDIS_SOCKET_TIMEOUT, WORKER_IDLE_TIMEOUT
+× 1.5)`, so coredis never interrupts a healthy blocking wait. `REDIS_SOCKET_TIMEOUT`
+acts as a floor — raise it if your network has high latency, or set it to `0` to
+disable stream timeout enforcement entirely.
 
 ### Liveness watchdog
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2594,7 +2594,13 @@ a blocking read that never returns, wedging the worker's event loop
 indefinitely. `REDIS_SOCKET_TIMEOUT` (default 30s, 0 disables),
 `REDIS_SOCKET_CONNECT_TIMEOUT` (default 10s), `REDIS_SOCKET_KEEPALIVE` (default
 true), and `REDIS_HEALTH_CHECK_INTERVAL` (default 30s) make a dead connection
-raise instead of hang, so the worker reconnects or exits and is restarted.
+raise instead of hang, so the worker reconnects or exits and is restarted. The
+worker's coredis client issues `XREADGROUP BLOCK <idle_timeout>`, a legitimate
+blocking wait up to `WORKER_IDLE_TIMEOUT` seconds (default 60s); the actual
+coredis stream timeout and idle-recycling threshold are derived as
+`max(REDIS_SOCKET_TIMEOUT, WORKER_IDLE_TIMEOUT × 1.5)` so coredis never
+interrupts a healthy blocking wait. `WORKER_IDLE_TIMEOUT` must be set here and
+passed to the streaq Worker so the two stay in sync.
 
 Liveness watchdog: as a backstop for any event-loop stall (not just Redis), the
 worker runs a daemon thread that force-exits the process if the loop stops

--- a/vibetuner-py/src/vibetuner/config.py
+++ b/vibetuner-py/src/vibetuner/config.py
@@ -358,6 +358,11 @@ class CoreConfiguration(BaseSettings):
 
     worker_concurrency: int = 16
 
+    # How long (seconds) streaq waits for new tasks before re-checking idle tasks.
+    # Matches streaq's Worker(idle_timeout=...) default so the two stay in sync.
+    # Must be set here so worker_redis_kwargs can derive safe coredis timeouts.
+    worker_idle_timeout: float = 60.0
+
     # Redis connection resilience for long-lived clients (e.g. the streaq worker).
     # Without a socket timeout, a silently-dropped TCP connection leaves a blocking
     # read that never returns, wedging the worker's event loop indefinitely. A
@@ -467,16 +472,25 @@ class CoreConfiguration(BaseSettings):
         ``max_idle_time`` recycles long-idle connections so a stale one is
         never reused. A timeout of 0 is omitted, which coredis treats as no
         timeout.
+
+        Both ``stream_timeout`` and ``max_idle_time`` must safely exceed
+        ``worker_idle_timeout``: streaq calls ``XREADGROUP BLOCK idle_timeout``
+        on the Redis server, and coredis would otherwise time out during that
+        legitimate blocking wait and raise a premature timeout error.
         """
         kwargs: dict[str, Any] = {
             "socket_keepalive": self.redis_socket_keepalive,
         }
+        safe_timeout = max(
+            self.redis_socket_timeout, self.worker_idle_timeout * 1.5
+        )
         if self.redis_socket_timeout > 0:
-            kwargs["stream_timeout"] = self.redis_socket_timeout
+            kwargs["stream_timeout"] = safe_timeout
         if self.redis_socket_connect_timeout > 0:
             kwargs["connect_timeout"] = self.redis_socket_connect_timeout
         if self.redis_health_check_interval > 0:
-            kwargs["max_idle_time"] = int(self.redis_health_check_interval)
+            safe_idle = max(self.redis_health_check_interval, self.worker_idle_timeout * 1.5)
+            kwargs["max_idle_time"] = int(safe_idle)
         return kwargs
 
     @property

--- a/vibetuner-py/src/vibetuner/tasks/worker.py
+++ b/vibetuner-py/src/vibetuner/tasks/worker.py
@@ -13,6 +13,7 @@ worker: Worker | None = (
         queue_name=settings.redis_key_prefix.rstrip(":"),
         lifespan=lifespan,
         concurrency=settings.worker_concurrency,
+        idle_timeout=settings.worker_idle_timeout,
     )
     if settings.workers_available
     else None

--- a/vibetuner-py/tests/unit/test_config.py
+++ b/vibetuner-py/tests/unit/test_config.py
@@ -283,10 +283,28 @@ class TestWorkerRedisKwargs:
         """By default, stream/connect timeouts, keepalive and idle recycling are on."""
         config = CoreConfiguration(project=ProjectConfiguration())
         kwargs = config.worker_redis_kwargs
-        assert kwargs["stream_timeout"] == 30.0
+        assert kwargs["stream_timeout"] == 90.0
         assert kwargs["connect_timeout"] == 10.0
         assert kwargs["socket_keepalive"] is True
-        assert kwargs["max_idle_time"] == 30
+        assert kwargs["max_idle_time"] == 90
+
+    def test_stream_timeout_safely_exceeds_idle_timeout(self):
+        """stream_timeout and max_idle_time must exceed worker_idle_timeout.
+
+        streaq calls XREADGROUP BLOCK <idle_timeout> on the Redis server.
+        coredis enforces stream_timeout during that blocking wait, so if
+        stream_timeout < idle_timeout the worker raises a premature timeout
+        error after stream_timeout seconds (issue #2035).
+        """
+        config = CoreConfiguration(
+            project=ProjectConfiguration(),
+            worker_idle_timeout=60.0,
+            redis_socket_timeout=30.0,
+            redis_health_check_interval=30.0,
+        )
+        kwargs = config.worker_redis_kwargs
+        assert kwargs["stream_timeout"] > config.worker_idle_timeout
+        assert kwargs["max_idle_time"] > config.worker_idle_timeout
 
     def test_kwargs_accepted_by_coredis_connection(self):
         """The kwargs must construct a coredis connection without raising.
@@ -324,7 +342,11 @@ class TestWorkerRedisKwargs:
         assert "max_idle_time" not in config.worker_redis_kwargs
 
     def test_overrides_from_env_vars(self):
-        """REDIS_SOCKET_* and REDIS_HEALTH_CHECK_INTERVAL env vars are honored."""
+        """REDIS_SOCKET_* and REDIS_HEALTH_CHECK_INTERVAL env vars are honored.
+
+        stream_timeout and max_idle_time are derived to safely exceed
+        worker_idle_timeout, so they are not simply the raw env-var values.
+        """
         with patch.dict(
             "os.environ",
             {
@@ -337,10 +359,12 @@ class TestWorkerRedisKwargs:
         ):
             config = CoreConfiguration(project=ProjectConfiguration())
             kwargs = config.worker_redis_kwargs
-            assert kwargs["stream_timeout"] == 5.0
+            # stream_timeout = max(5.0, 60.0 * 1.5) = 90.0
+            assert kwargs["stream_timeout"] == 90.0
             assert kwargs["connect_timeout"] == 2.0
             assert kwargs["socket_keepalive"] is False
-            assert kwargs["max_idle_time"] == 15
+            # max_idle_time = int(max(15.0, 60.0 * 1.5)) = 90
+            assert kwargs["max_idle_time"] == 90
 
 
 class TestRedisClientKwargs:


### PR DESCRIPTION
## Root cause

`Configuration.worker_redis_kwargs` set `stream_timeout` and `max_idle_time` equal to
`redis_socket_timeout` and `redis_health_check_interval` respectively (both defaulting to 30s).

streaq's worker calls `XREADGROUP BLOCK <idle_timeout>` on the Redis server, where `idle_timeout`
defaults to 60s. During that legitimate 60s blocking wait, coredis enforced the 30s `stream_timeout`
and raised a premature timeout error, causing the worker to exit. The same bug class was fixed for the
SSE pub/sub subscriber in #1958/#1965 — this is the analogous fix for the worker's coredis client.

## Fix

- Add `worker_idle_timeout: float = 60.0` to `CoreConfiguration`, mirroring streaq's
  `Worker(idle_timeout=...)` default so the two stay in sync.
- `worker_redis_kwargs` now derives `stream_timeout` and `max_idle_time` as
  `max(configured_value, worker_idle_timeout × 1.5)`, ensuring coredis never interrupts a
  healthy `XREADGROUP` block. `redis_socket_timeout` and `redis_health_check_interval` act as
  floors; zero still disables the respective timeout.
- Pass `idle_timeout=settings.worker_idle_timeout` to the `Worker` constructor in `tasks/worker.py`.
- Update docs in `background-tasks.md` and `llms-full.txt` to describe the new setting and the
  derivation. Also corrected the old misleading claim that worker blocking reads are "bounded to well
  under a second" (they block up to `idle_timeout`, i.e. 60s by default).

## Test plan

- [x] New test `test_stream_timeout_safely_exceeds_idle_timeout` asserts that `stream_timeout`
  and `max_idle_time` are both greater than `worker_idle_timeout`
- [x] `test_defaults_enable_resilience` updated: expects 90.0 / 90 (= max(30, 60×1.5))
- [x] `test_overrides_from_env_vars` updated to reflect derived values
- [x] All 968 unit tests pass
- [x] `just lint-py` and `just type-check-py` pass
- [x] All pre-commit hooks pass

Closes #2035

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTUrgbYEPjmUyFJfQRCfH