### PR TITLE
fix(release): track scaffolded @alltuner/vibetuner pin in release-please extra-files

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -71,6 +71,11 @@
         {
           "type": "generic",
           "path": "vibetuner-template/pyproject.toml.j2"
+        },
+        {
+          "type": "json",
+          "path": "vibetuner-template/package.json",
+          "jsonpath": "$.devDependencies['@alltuner/vibetuner']"
         }
       ]
     }

--- a/vibetuner-template/package.json
+++ b/vibetuner-template/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@alltuner/vibetuner": "^11.1.0"
+    "@alltuner/vibetuner": "11.1.0"
   },
   "dependencies": {},
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds a `json` extra-files entry in `.release-please-config.json` targeting
  `vibetuner-template/package.json` → `$.devDependencies['@alltuner/vibetuner']`,
  so release-please auto-bumps the scaffolded frontend package pin on every release.
- Normalizes the current pin from `^11.1.0` to `11.1.0` (bare exact version).

## Why exact (no caret)?

The only other tracked JSON dep in this repo is `vibetuner-js/package.json` →
`$.dependencies['@alltuner/vibetuner-jinja']`, which is pinned `"11.1.0"` (exact).
Release-please's JSON updater also writes bare versions when it bumps (it strips
any caret), so leaving a caret in place just means the first post-merge release
would produce a noisy diff (`^11.1.0` → `11.2.0` instead of `11.1.0` → `11.2.0`).
Normalizing to exact now keeps both tracked deps consistent and avoids that noise.

## Context

The `@alltuner/vibetuner` pin itself was already brought up to `^11.1.0` on main
(via a previous dependency bump). This PR closes the remaining gap: without the
`extra-files` entry, release-please never touched `vibetuner-template/package.json`,
so every release left scaffolded projects a version behind.

This PR supersedes #2017 (which addressed the same issue but is broader). Recommend
closing #2017 in favour of this minimal fix.

## Test plan

- [x] Both JSON files validate (`python3 -m json.tool`)
- [x] Pre-commit hooks pass (trim whitespace, don't-commit-to-branch, etc.)
- [x] Entry mirrors the proven style of the existing `vibetuner-jinja` tracked dep

Closes #2016

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTUrgbYEPjmUyFJfQRCfH