### PR TITLE
fix(security): allow enabled OAuth providers' avatar hosts in default CSP img-src

### DIFF
--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -795,13 +795,20 @@ fall back to the legacy soft mode (where debug emits
 `Content-Security-Policy-Report-Only`), set
 `CSP_ENFORCE_CSP_IN_DEBUG=false`.
 
+**OAuth provider avatars.** When an OAuth provider (Google, GitHub) is enabled and
+has credentials configured, the middleware automatically adds that provider's avatar
+CDN host to `img-src` so profile pictures load without any manual configuration
+(`https://lh3.googleusercontent.com` for Google, `https://avatars.githubusercontent.com`
+for GitHub). Use `CSP_EXTRA_IMG_SRC` only if you need additional image sources beyond
+what the active providers supply.
+
 Configure extra allowed sources via environment variables:
 
 | Variable | Description |
 |----------|-------------|
 | `CSP_EXTRA_SCRIPT_SRC` | Additional script sources |
 | `CSP_EXTRA_STYLE_SRC` | Additional style sources |
-| `CSP_EXTRA_IMG_SRC` | Additional image sources |
+| `CSP_EXTRA_IMG_SRC` | Additional image sources (OAuth provider avatar hosts are added automatically) |
 | `CSP_EXTRA_CONNECT_SRC` | Additional connect sources |
 | `CSP_EXTRA_FONT_SRC` | Additional font sources |
 | `CSP_EXTRA_MEDIA_SRC` | Additional media sources |

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2265,6 +2265,12 @@ instead. Configure extra sources via `CSP_EXTRA_SCRIPT_SRC`,
 `CSP_EXTRA_STYLE_SRC`, `CSP_EXTRA_IMG_SRC`, `CSP_EXTRA_CONNECT_SRC`,
 `CSP_EXTRA_FONT_SRC`, `CSP_EXTRA_MEDIA_SRC` environment variables.
 
+When an OAuth provider (Google, GitHub) is enabled and has credentials
+configured, its avatar CDN host is added to `img-src` automatically
+(`https://lh3.googleusercontent.com` for Google,
+`https://avatars.githubusercontent.com` for GitHub). Use
+`CSP_EXTRA_IMG_SRC` for any additional sources beyond those.
+
 The middleware always sets `X-Content-Type-Options: nosniff`. If a
 response has no `Content-Type` header (e.g. a bare
 `Response(status_code=404)` with no `media_type=`), the middleware fills

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -140,11 +140,13 @@ Important notes:
   environment variables (e.g., `CSP_EXTRA_SCRIPT_SRC`). Set `CSP_STYLE_SRC_STRICT=true`
   to drop `'unsafe-inline'` from `style-src` and require nonces on `<style>` tags
   (opt-in hardening; framework templates already nonce every `<style>`). Requires
-  `vibetuner` ≥ 10.11.0 (older releases silently ignore the env var). The middleware
-  also pairs nosniff with a `text/plain; charset=utf-8` fallback when a response has
-  no `Content-Type` (e.g. a bare `Response(status_code=404)`), so bare responses do
-  not get turned into 0-byte browser downloads (Safari/Firefox) or generic error
-  pages (Chrome)
+  `vibetuner` ≥ 10.11.0 (older releases silently ignore the env var). When an OAuth
+  provider (Google, GitHub) is enabled and has credentials configured, its avatar CDN
+  host is added to `img-src` automatically — no `CSP_EXTRA_IMG_SRC` entry needed for
+  OAuth provider profile pictures. The middleware also pairs nosniff with a
+  `text/plain; charset=utf-8` fallback when a response has no `Content-Type` (e.g. a
+  bare `Response(status_code=404)`), so bare responses do not get turned into 0-byte
+  browser downloads (Safari/Firefox) or generic error pages (Chrome)
 - **htmx CSP Protection (default-on)**: htmx 4.0.0-beta4 ships an `hx-csp` extension
   (renamed from `hx-nonce` in beta3) that gates htmx attribute processing behind the
   page CSP nonce. It is loaded by default from the framework-managed block of

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -124,6 +124,16 @@ _HX_ELEMENT_WITHOUT_NONCE_RE = re.compile(
 )
 
 
+# Avatar CDN hosts for each supported OAuth provider.
+# When a provider is registered and active, its avatar host is automatically
+# included in the CSP img-src directive so profile pictures load without
+# requiring a manual CSP_EXTRA_IMG_SRC entry.
+_PROVIDER_AVATAR_HOSTS: dict[str, str] = {
+    "google": "https://lh3.googleusercontent.com",
+    "github": "https://avatars.githubusercontent.com",
+}
+
+
 class SecurityHeadersMiddleware:
     """Pure ASGI middleware that adds security headers (CSP with nonce, etc.) to responses.
 
@@ -136,6 +146,13 @@ class SecurityHeadersMiddleware:
 
     def __init__(self, app: ASGIApp):
         self.app = app
+        from .oauth import get_oauth_providers
+
+        self._oauth_img_src = " ".join(
+            _PROVIDER_AVATAR_HOSTS[name]
+            for name in get_oauth_providers()
+            if name in _PROVIDER_AVATAR_HOSTS
+        )
 
     def _apply_headers(self, headers: MutableHeaders, nonce: str) -> None:
         config = settings.security_headers
@@ -151,9 +168,9 @@ class SecurityHeadersMiddleware:
         if config.extra_style_src:
             style_src += f" {config.extra_style_src}"
 
-        img_src = "'self' data:"
-        if config.extra_img_src:
-            img_src += f" {config.extra_img_src}"
+        img_src = " ".join(
+            filter(None, ["'self' data:", self._oauth_img_src, config.extra_img_src])
+        )
 
         media_src = "'self' blob:"
         if config.extra_media_src:

--- a/vibetuner-py/tests/unit/test_security_headers_middleware.py
+++ b/vibetuner-py/tests/unit/test_security_headers_middleware.py
@@ -12,6 +12,12 @@ from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 
+_PROVIDER_AVATAR_HOSTS: dict[str, str] = {
+    "google": "https://lh3.googleusercontent.com",
+    "github": "https://avatars.githubusercontent.com",
+}
+
+
 @dataclass
 class _SecurityHeadersConfig:
     enabled: bool = True
@@ -24,6 +30,7 @@ class _SecurityHeadersConfig:
     frame_ancestors: str = "'self'"
     enforce_csp_in_debug: bool = True
     style_src_strict: bool = False
+    oauth_providers: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -55,6 +62,11 @@ class SecurityHeadersMiddleware:
     def __init__(self, app: ASGIApp, settings: _Settings | None = None):
         self.app = app
         self._settings = settings or _Settings()
+        self._oauth_img_src = " ".join(
+            _PROVIDER_AVATAR_HOSTS[name]
+            for name in self._settings.security_headers.oauth_providers
+            if name in _PROVIDER_AVATAR_HOSTS
+        )
 
     def _apply_headers(self, headers: MutableHeaders, nonce: str) -> None:
         config = self._settings.security_headers
@@ -70,9 +82,9 @@ class SecurityHeadersMiddleware:
         if config.extra_style_src:
             style_src += f" {config.extra_style_src}"
 
-        img_src = "'self' data:"
-        if config.extra_img_src:
-            img_src += f" {config.extra_img_src}"
+        img_src = " ".join(
+            filter(None, ["'self' data:", self._oauth_img_src, config.extra_img_src])
+        )
 
         media_src = "'self' blob:"
         if config.extra_media_src:
@@ -612,3 +624,62 @@ class TestBareResponseContentType:
         resp = client.get("/")
         assert resp.status_code == 418
         assert resp.headers["Content-Type"] == "application/json"
+
+
+class TestOAuthAvatarImgSrc:
+    """Test that enabled OAuth providers' avatar hosts appear in CSP img-src."""
+
+    def _img_src(self, csp: str) -> str:
+        return next(d.strip() for d in csp.split(";") if "img-src" in d)
+
+    def test_google_provider_adds_avatar_host(self):
+        """Enabling google adds lh3.googleusercontent.com to img-src."""
+        config = _SecurityHeadersConfig(oauth_providers=["google"])
+        app = _make_app(settings=_Settings(security_headers=config))
+        client = TestClient(app)
+        resp = client.get("/")
+        assert "https://lh3.googleusercontent.com" in self._img_src(
+            resp.headers["Content-Security-Policy"]
+        )
+
+    def test_github_provider_adds_avatar_host(self):
+        """Enabling github adds avatars.githubusercontent.com to img-src."""
+        config = _SecurityHeadersConfig(oauth_providers=["github"])
+        app = _make_app(settings=_Settings(security_headers=config))
+        client = TestClient(app)
+        resp = client.get("/")
+        assert "https://avatars.githubusercontent.com" in self._img_src(
+            resp.headers["Content-Security-Policy"]
+        )
+
+    def test_multiple_providers_add_all_avatar_hosts(self):
+        """Enabling multiple providers adds all their avatar hosts to img-src."""
+        config = _SecurityHeadersConfig(oauth_providers=["google", "github"])
+        app = _make_app(settings=_Settings(security_headers=config))
+        client = TestClient(app)
+        resp = client.get("/")
+        img_src = self._img_src(resp.headers["Content-Security-Policy"])
+        assert "https://lh3.googleusercontent.com" in img_src
+        assert "https://avatars.githubusercontent.com" in img_src
+
+    def test_no_providers_does_not_add_avatar_hosts(self):
+        """No oauth providers means no extra avatar hosts in img-src."""
+        app = _make_app()
+        client = TestClient(app)
+        resp = client.get("/")
+        img_src = self._img_src(resp.headers["Content-Security-Policy"])
+        assert "googleusercontent.com" not in img_src
+        assert "githubusercontent.com" not in img_src
+
+    def test_extra_img_src_additive_with_oauth_hosts(self):
+        """extra_img_src is additive alongside oauth avatar hosts."""
+        config = _SecurityHeadersConfig(
+            oauth_providers=["google"],
+            extra_img_src="https://custom.example.com",
+        )
+        app = _make_app(settings=_Settings(security_headers=config))
+        client = TestClient(app)
+        resp = client.get("/")
+        img_src = self._img_src(resp.headers["Content-Security-Policy"])
+        assert "https://lh3.googleusercontent.com" in img_src
+        assert "https://custom.example.com" in img_src


### PR DESCRIPTION
## Summary

- `SecurityHeadersMiddleware` previously emitted `img-src 'self' data:` as
  the default, which blocked avatar images loaded from OAuth provider CDNs
  (e.g. `lh3.googleusercontent.com` for Google, `avatars.githubusercontent.com`
  for GitHub) in production.
- The middleware now derives the set of active provider avatar hosts at init
  time (from the providers registered with credentials) and merges them into
  the default `img-src`.
- `CSP_EXTRA_IMG_SRC` remains fully additive — nothing changes for apps that
  already set it manually.

## Changes

- `vibetuner-py/src/vibetuner/frontend/middleware.py`: Add `_PROVIDER_AVATAR_HOSTS`
  mapping and compute `_oauth_img_src` in `SecurityHeadersMiddleware.__init__` from
  registered OAuth providers. Include it in `img-src` via `filter()` (which also
  reduced cyclomatic complexity to stay within the ruff C901 threshold).
- `vibetuner-py/tests/unit/test_security_headers_middleware.py`: Mirror the same
  logic in the test's local middleware copy; add `TestOAuthAvatarImgSrc` class with
  5 tests covering Google, GitHub, multiple providers, no providers, and additive
  `extra_img_src`.
- `vibetuner-docs/docs/development-guide.md`, `llms.txt`, `llms-full.txt`: Document
  the automatic OAuth avatar host behaviour and update the `CSP_EXTRA_IMG_SRC`
  description.

## Test plan

- [ ] `cd vibetuner-py && uv sync --extra dev && uv run python -m pytest tests/unit/test_security_headers_middleware.py -v` — all 43 tests pass including 5 new `TestOAuthAvatarImgSrc` tests
- [ ] `just lint-py` — passes (ruff C901 satisfied via `filter()`)
- [ ] `just type-check-py` — passes
- [ ] Manual: enable Google OAuth, log in, confirm avatar appears in production

## Possible follow-up

A programmatic hook on `VibetunerApp` to let apps extend the CSP (e.g. to add
custom `img-src` hosts at middleware-init time) is intentionally out of scope here.

Closes #2031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTUrgbYEPjmUyFJfQRCfH