### PR TITLE
feat(htmx)!: htmx 4 server-side support — own request detection, drop dead response helpers

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2857,18 +2857,6 @@ wheels = [
 ]
 
 [[package]]
-name = "starlette-htmx"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/16/dcb7da6006564a0af5f0dccb5c8710ca9b6da665a86d1c41473744a74c38/starlette_htmx-0.1.1.tar.gz", hash = "sha256:686b507eae5492d3e78963fa5783ecfb4bbaa06fe43a858d4676a2c76f7a83ac", size = 2881, upload-time = "2022-01-22T17:10:48.941Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/ea/da6b4aecca60cac91643b6e2733969d64a658bac79aa35df551b9e97e879/starlette_htmx-0.1.1-py2.py3-none-any.whl", hash = "sha256:f81e0ab89c02ede60203b458c3a9a088e87d47c7583a7e9fd7f11b92e27cef99", size = 2767, upload-time = "2022-01-22T17:10:47.645Z" },
-]
-
-[[package]]
 name = "streaq"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3190,7 +3178,6 @@ dependencies = [
     { name = "sqlmodel" },
     { name = "starlette-babel" },
     { name = "starlette-context" },
-    { name = "starlette-htmx" },
     { name = "streaq", extra = ["web"] },
     { name = "typer" },
 ]
@@ -3254,7 +3241,6 @@ requires-dist = [
     { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "starlette-babel", specifier = ">=1.1.0" },
     { name = "starlette-context", specifier = ">=0.5.1" },
-    { name = "starlette-htmx", specifier = ">=0.1.1" },
     { name = "streaq", extras = ["web"], specifier = ">=7.0.0,<8.0.0" },
     { name = "taplo", marker = "extra == 'dev'", specifier = ">=0.9.3" },
     { name = "testcontainers", extras = ["mongodb"], marker = "extra == 'dev'", specifier = ">=4.14.2" },

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -944,8 +944,8 @@ async def list_posts(page: int = 1):
 
 ### HTMX Request Detection
 
-Every request has `request.state.htmx` available (provided by the `starlette-htmx`
-middleware). Use it to serve different responses for HTMX vs regular requests:
+Every request has `request.state.htmx` available (provided by the framework's
+HTMX middleware). Use it to serve different responses for HTMX vs regular requests:
 
 ```python
 from fastapi import Request
@@ -972,11 +972,12 @@ async def list_items(request: Request):
 |----------|-------------|
 | `bool(request.state.htmx)` | `True` if this is an HTMX request |
 | `.boosted` | `True` if request came via `hx-boost` |
-| `.target` | ID of the target element (`hx-target`) |
-| `.trigger` | ID of the element that triggered the request |
-| `.trigger_name` | Name attribute of the triggering element |
+| `.target` | Target element as `tag#id` (`hx-target`) |
+| `.source` | Triggering element as `tag#id` (`HX-Source`; was `HX-Trigger` in htmx 2) |
+| `.request_type` | `"full"` or `"partial"` (`HX-Request-Type`) |
 | `.current_url` | Browser's current URL when request was made |
-| `.prompt` | User response from `hx-prompt` |
+| `.history_restore_request` | `True` if this is a history-restore request |
+| `.prompt` | User reply from the `hx-prompt` extension (when loaded) |
 
 ### HTMX Response Headers
 
@@ -998,8 +999,7 @@ return response
 ```
 
 Available helpers: `hx_redirect`, `hx_location`, `hx_trigger`,
-`hx_trigger_after_settle`, `hx_trigger_after_swap`, `hx_push_url`,
-`hx_replace_url`, `hx_reswap`, `hx_retarget`, `hx_refresh`.
+`hx_push_url`, `hx_replace_url`, `hx_reswap`, `hx_retarget`, `hx_refresh`.
 
 JSON serialization is handled internally — you never need to call `json.dumps()`.
 

--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -2,7 +2,7 @@
 
 This guide covers the breaking changes when upgrading from htmx v2 to v4
 in Vibetuner projects. It also documents what changed between htmx 4
-pre-release versions (alpha → beta1 → beta3 → beta4), so users on
+pre-release versions (alpha → beta1 → beta3 → beta4 → beta5), so users on
 any pre-release can migrate.
 
 ## Quick Start
@@ -484,6 +484,12 @@ CSS transition rules per the
     extension. Use it as you did in htmx 2 to mark the element whose
     inner HTML is captured for history snapshots.
 
+!!! note
+    `hx-prompt` was **restored in beta5** as an opt-in `hx-prompt`
+    extension (it sends the answer in the `HX-Prompt` request header,
+    like htmx 2). Vibetuner does not ship it by default — see
+    [Beta4 to Beta5 Changes](#beta4-to-beta5-changes).
+
 ## New Attributes
 
 | Attribute | Purpose |
@@ -494,6 +500,8 @@ CSS transition rules per the
 | `hx-config` | Per-element request config (replaces `hx-request`) |
 | `hx-ignore` | Disable htmx processing (replaces `hx-disable`) |
 | `hx-validate` | Control form validation behavior |
+| `hx-morph-skip` | Skip morphing for the matching element (beta5) |
+| `hx-morph-skip-children` | Morph the element but leave its children untouched (beta5) |
 
 ## New Extensions
 
@@ -512,6 +520,7 @@ htmx 4 ships with these core extensions. All auto-register when imported.
 | `htmx-2-compat` | Backward compatibility layer for htmx 2.x code |
 | `csp` | CSP nonce-based protection for inline scripts and `eval`-style code paths (beta3, renamed from `nonce` in beta4) |
 | `live` | DOM-reactivity via `hx-live` and richer `hx-on` helpers: `q()`, `toggle()`, `debounce()` (beta3) |
+| `hx-prompt` | Restores htmx 2's `hx-prompt` attribute: prompts before the request and sends the answer in the `HX-Prompt` header (beta5, opt-in) |
 
 htmx also provides an `htmax` bundle (`htmax.min.js`) that includes htmx
 plus the most popular extensions (SSE, WebSockets, preload,
@@ -714,6 +723,103 @@ migration here.
 The `hx-trigger="..." queue:..."` modifier (a no-op since 4.0) was
 also hard-removed in beta4; use `hx-sync="this:queue all"` instead.
 Vibetuner templates do not use the `queue:` modifier either.
+
+## Beta4 to Beta5 Changes
+
+Beta5 is another small follow-up to the 4.0 release candidate. Nothing in it
+breaks a clean htmx 4 codebase, and Vibetuner's templates need no changes. The
+notable additions are a restored `hx-prompt`, a formalized config grammar
+(HCON), and an SSE-friendly empty-swap default.
+
+### Upgrade Recipe
+
+For most projects this is a two-step bump:
+
+1. Bump `@alltuner/vibetuner` in `package.json` to a release that ships
+   `htmx.org@4.0.0-beta5` (or run `just deps-scaffolding-pr` /
+   `just deps-scaffolding`).
+2. Run `bun install` to refresh `node_modules` and `bun.lock`.
+
+Run `just lint` and `just dev` to confirm the build still passes; no template
+changes are required.
+
+### HCON: the config-attribute grammar is formalized
+
+htmx 4's config attributes (`hx-trigger`, `hx-swap`, `hx-vals`, `hx-config`,
+`hx-headers`, and the `<meta name="htmx-config">` tag) now parse through a
+single documented mini-language, **HCON**. It is a backward-compatible
+superset of what beta4 accepted:
+
+- A value starting with `{` is still parsed as JSON, so JSON `hx-vals` and
+  `<meta>` config keep working unchanged.
+- Space- or comma-separated `key:value` pairs work as before, plus flag-style
+  booleans (`key` alone means `true`), dotted nesting (`sse.reconnect:true`),
+  and single- or double-quoted values for spaces/commas.
+- The `js:` prefix on `hx-vals` / `hx-confirm` is unaffected — it is still
+  evaluated as JavaScript, not parsed as HCON.
+
+No action required: Vibetuner's templates don't use these config attributes, and
+any existing JSON or modifier strings parse identically.
+
+### `hx-prompt` restored as an opt-in extension
+
+Beta5 adds an `hx-prompt` extension that brings back htmx 2's `hx-prompt`
+attribute: it prompts the user before the request and sends the answer in the
+`HX-Prompt` request header (read it via `request.state.htmx.prompt`). Vibetuner
+does **not** load it by default; add it to your `config.js` if you want it:
+
+```javascript
+import "htmx.org/dist/ext/hx-prompt.js";
+```
+
+### `swapEmpty` and the SSE empty-response default
+
+A new `swapEmpty` swap modifier and `htmx.config.defaultSwapEmpty` control
+whether an empty response still swaps. **SSE now defaults to not swapping empty
+responses**, which is the behavior Vibetuner's streams already want — empty
+keepalive frames no longer blank out the connected element. Override per element
+with `hx-swap="innerHTML swapEmpty:true"` if you need the old behavior.
+
+### Morph skip attributes
+
+`hx-morph-skip` and `hx-morph-skip-children` mark elements the morph swap should
+leave alone (the whole element, or just its children). They default to the
+`[hx-morph-skip]` / `[hx-morph-skip-children]` selectors. Only relevant if you
+use a `morph` swap.
+
+### `hx-live` expansion
+
+The `hx-live` extension gained declarative bindings, a reactive engine, a JSON
+data proxy, and xpath + Alpine conflict handling. One behavior change: the
+`take` helper now defaults to **sibling** scope. Vibetuner's documented
+`hx-live` patterns (see [Live Reactivity](#live-reactivity-with-hx-live)) are
+unaffected, but review any custom `htmx.live.take(...)` calls that relied on the
+previous default scope.
+
+### Other beta5 changes (no action required)
+
+- `ctx` (the request context) is now passed to `hx-confirm`, `hx-vals`, and
+  `hx-headers` JavaScript expressions.
+- Download links (`<a download>`) are no longer boosted.
+- `hx-encode` falls back to the enclosing form's `enctype`.
+- The `hx-csp` extension's nonce rewriting now handles unquoted `nonce`
+  attributes — relevant to Vibetuner's default-on CSP, and a pure improvement.
+- Click modifiers pass through only on links; `hx-preload` uses passive event
+  listeners; the `optimistic` extension supports live content.
+
+### Framework-side changes in Vibetuner
+
+Landing on beta5, Vibetuner also brought its server-side htmx surface in line
+with htmx 4:
+
+- `request.state.htmx` now exposes the htmx 4 request headers — `.source`
+  (`HX-Source`, the renamed request-side `HX-Trigger`) and `.request_type`
+  (`HX-Request-Type`). The htmx 2 `.trigger` / `.trigger_name` properties are
+  gone.
+- The `hx_trigger_after_settle` and `hx_trigger_after_swap` response helpers
+  were removed — htmx 4 dropped the `HX-Trigger-After-Settle` /
+  `HX-Trigger-After-Swap` headers they set. Use `hx_trigger` (the `HX-Trigger`
+  response header is unchanged).
 
 ## Live Reactivity with `hx-live`
 
@@ -969,3 +1075,21 @@ that beta4 requires:
   4.0), migrate to `hx-sync="this:queue all"` — removed in beta4
 - [ ] No template changes required — `hx-nonce="{{ csp_nonce }}"`
   attributes keep working
+
+## Beta4 to Beta5 Checklist
+
+If you are already on htmx 4.0.0-beta4, this is the only work beta5 requires:
+
+- [ ] Bump `@alltuner/vibetuner` in `package.json` to a release that ships
+  `htmx.org@4.0.0-beta5`
+- [ ] Run `bun install`
+- [ ] No template changes required — HCON parses existing `hx-*` config
+  attributes identically, and Vibetuner's templates don't use them anyway
+- [ ] If your server reads the request-side trigger, switch from the htmx 2
+  `HX-Trigger` / `request.state.htmx.trigger` to `HX-Source` /
+  `request.state.htmx.source`
+- [ ] If you set the `HX-Trigger-After-Settle` / `HX-Trigger-After-Swap`
+  response headers (or used the removed `hx_trigger_after_settle` /
+  `hx_trigger_after_swap` helpers), move to `HX-Trigger` / `hx_trigger`
+- [ ] (Optional) Add `import "htmx.org/dist/ext/hx-prompt.js";` to `config.js`
+  if you want the restored `hx-prompt` attribute

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -658,7 +658,7 @@ async def list_posts(page: int = 1):
 
 #### HTMX Request Detection
 
-Every request has `request.state.htmx` available (via `starlette-htmx` middleware).
+Every request has `request.state.htmx` available.
 Use it to serve different responses for HTMX vs regular requests:
 
 ```python
@@ -678,8 +678,10 @@ async def list_items(request: Request):
     return render_template("items/list.html.jinja", request, ctx)
 ```
 
-Properties: `bool(request.state.htmx)`, `.boosted`, `.target`, `.trigger`,
-`.trigger_name`, `.current_url`, `.prompt`.
+Properties: `bool(request.state.htmx)`, `.boosted`, `.target` (`tag#id`),
+`.source` (`HX-Source`; the htmx 2 request `HX-Trigger`), `.request_type`
+(`"full"`/`"partial"`), `.current_url`, `.history_restore_request`, `.prompt`
+(via the `hx-prompt` extension).
 
 HTMX-only routes — use the `require_htmx` dependency from
 `vibetuner` to reject non-HTMX requests with a 400.
@@ -2962,8 +2964,34 @@ relevant to vibetuner projects:
   swap from downgrading origin enforcement
 - **`hx-on::` shorthand fixed** — works in beta1+ (was broken in alpha8)
 
+#### Beta5 Additions
+
+htmx 4.0.0-beta5 is a small follow-up; nothing breaks a clean htmx 4 codebase
+and vibetuner templates need no changes:
+
+- **HCON config grammar formalized** — `hx-trigger`, `hx-swap`, `hx-vals`,
+  `hx-config`, `hx-headers`, and `<meta name="htmx-config">` parse through one
+  documented mini-language. Backward compatible: `{`-prefixed values are still
+  JSON and the `js:` prefix still evaluates as JavaScript
+- **`hx-prompt` extension** — opt-in, restores htmx 2's `hx-prompt` attribute
+  and the `HX-Prompt` request header (read via `request.state.htmx.prompt`).
+  Not loaded by default; add `import "htmx.org/dist/ext/hx-prompt.js";`
+- **`swapEmpty` / `htmx.config.defaultSwapEmpty`** — SSE now defaults to not
+  swapping empty responses, so keepalive frames no longer blank the element
+- **`hx-morph-skip` / `hx-morph-skip-children`** — skip morphing for matching
+  elements (only relevant with a `morph` swap)
+- **`hx-live` expansion** — declarative bindings + reactive engine; the `take`
+  helper now defaults to sibling scope
+- **`ctx` passed to `hx-confirm` / `hx-vals` / `hx-headers` JS**, download links
+  no longer boosted, `hx-encode` falls back to the form `enctype`, and `hx-csp`
+  handles unquoted nonce attributes
+- **Vibetuner server-side**: `request.state.htmx` exposes `.source`
+  (`HX-Source`) and `.request_type` (`HX-Request-Type`); the htmx 2 `.trigger` /
+  `.trigger_name` props and the `hx_trigger_after_settle` / `hx_trigger_after_swap`
+  response helpers were removed
+
 See [HTMX v2 to v4 Migration Guide](https://vibetuner.alltuner.com/htmx-migration/)
-for the full list and the dedicated "Beta1 to Beta3 Changes" section.
+for the full list and the dedicated "Beta4 to Beta5 Changes" section.
 
 ### Import Ordering in tune.py
 

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -31,10 +31,11 @@ Important notes:
 
 ## Features
 
-- **HTMX Request Detection**: `request.state.htmx` available on every request
-  (via `starlette-htmx` middleware). Properties: `.boosted`, `.target`, `.trigger`,
-  `.trigger_name`, `.current_url`, `.prompt`. Use `require_htmx` dependency from
-  `vibetuner` to reject non-HTMX requests with 400
+- **HTMX Request Detection**: `request.state.htmx` available on every request.
+  Properties: `.boosted`, `.target` (`tag#id`), `.source` (`HX-Source`; the htmx 2
+  request `HX-Trigger`), `.request_type` (`"full"`/`"partial"`), `.current_url`,
+  `.history_restore_request`, `.prompt` (via the `hx-prompt` extension). Use
+  `require_htmx` dependency from `vibetuner` to reject non-HTMX requests with 400
 - **CRUD Factory**: `create_crud_routes()` generates list/create/read/update/delete
   endpoints for Beanie models with pagination, filtering, sorting, and search
 - **SSE Helpers**: `@sse_endpoint()` and `broadcast()` for real-time streaming with
@@ -65,8 +66,8 @@ Important notes:
   `immutable`. Import from `vibetuner.decorators`
 - **HTMX Response Helpers**: `hx_redirect()`, `hx_location()`, `hx_trigger()`,
   `hx_push_url()`, `hx_reswap()`, `hx_retarget()`, `hx_refresh()`,
-  `hx_replace_url()`, `hx_trigger_after_settle()`, `hx_trigger_after_swap()`.
-  Handles JSON serialization internally. Import from `vibetuner.htmx`
+  `hx_replace_url()`. Handles JSON serialization internally. Import from
+  `vibetuner.htmx`
 - **Built-in Template Globals**: `request`, `language`, `DEBUG`, `now`
   (UTC datetime), `today` (ISO date string), `project` (`settings.project`),
   `brand` (`settings.brand`), `csp_nonce`, and `hotreload` are available

--- a/vibetuner-docs/docs/upgrading-to-v12.md
+++ b/vibetuner-docs/docs/upgrading-to-v12.md
@@ -171,6 +171,14 @@ the sixth returns `429 Too Many Requests`. After raising
   [Development Guide](development-guide.md).
 - **Pick up template improvements**: run `vibetuner scaffold update` to pull
   in template and tooling updates (for example the new `dprint.json`).
+- **htmx bumped to 4.0.0-beta5 and the server-side surface aligned with htmx
+  4**: `request.state.htmx` now exposes `.source` (`HX-Source`) and
+  `.request_type` (`HX-Request-Type`) instead of the htmx 2 `.trigger` /
+  `.trigger_name`, and the `hx_trigger_after_settle` / `hx_trigger_after_swap`
+  response helpers were removed (htmx 4 dropped the headers they set — use
+  `hx_trigger`). Only act if your project reads those request props or calls
+  those helpers. See the
+  [htmx migration guide](htmx-migration.md#beta4-to-beta5-changes).
 
 ## Migration Checklist
 

--- a/vibetuner-py/pyproject.toml
+++ b/vibetuner-py/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
   "slowapi>=0.1.9",
   "starlette-babel>=1.1.0",
   "starlette-context>=0.5.1",
-  "starlette-htmx>=0.1.1",
   "streaq[web]>=7.0.0,<8.0.0",
   "typer>=0.26.7",
   "deprecated>=1.3.1",

--- a/vibetuner-py/src/vibetuner/frontend/middleware.py
+++ b/vibetuner-py/src/vibetuner/frontend/middleware.py
@@ -20,10 +20,10 @@ from starlette_babel import (
 )
 from starlette_context.middleware import RawContextMiddleware
 from starlette_context.plugins import RequestIdPlugin
-from starlette_htmx.middleware import HtmxDetails
 
 from vibetuner.config import settings
 from vibetuner.context import ctx
+from vibetuner.htmx import HtmxDetails
 from vibetuner.logging import logger
 from vibetuner.paths import locales as locales_path, package_locales
 
@@ -84,16 +84,13 @@ if locales_path is not None and locales_path.exists() and locales_path.is_dir():
 
 
 class HtmxMiddleware:
-    """Pure ASGI replacement for starlette_htmx.middleware.HtmxMiddleware.
+    """Attach htmx request details to ``request.state.htmx``.
 
-    The upstream starlette-htmx uses BaseHTTPMiddleware, which adds an extra
-    empty sentinel body chunk on response completion. This triggers a bug in
-    slowapi's SlowAPIASGIMiddleware where http.response.start is re-sent on
-    every body chunk, causing "ASGI flow error: Response already started".
-    See: https://github.com/laurentS/slowapi/issues/XXX
-
-    This pure ASGI version avoids the issue. Can be removed once slowapi
-    fixes SlowAPIASGIMiddleware upstream.
+    Implemented as pure ASGI rather than BaseHTTPMiddleware: the base-class
+    variant adds an extra empty sentinel body chunk on response completion,
+    which trips slowapi's SlowAPIASGIMiddleware into re-sending
+    http.response.start on every body chunk ("ASGI flow error: Response
+    already started"). See: https://github.com/laurentS/slowapi/issues/XXX
     """
 
     def __init__(self, app: ASGIApp):

--- a/vibetuner-py/src/vibetuner/htmx.py
+++ b/vibetuner-py/src/vibetuner/htmx.py
@@ -1,9 +1,71 @@
-# ABOUTME: Helper functions for setting HTMX response headers.
-# ABOUTME: Reduces boilerplate when building interactive HTMX flows.
+# ABOUTME: htmx 4 request detection (HtmxDetails) and response-header helpers.
+# ABOUTME: Reduces boilerplate when building interactive htmx flows.
 import json
+from functools import cached_property
 from typing import Any
+from urllib.parse import unquote
 
+from starlette.requests import Request
 from starlette.responses import HTMLResponse, Response
+
+
+class HtmxDetails:
+    """htmx request metadata read from the ``HX-*`` request headers.
+
+    Wired onto ``request.state.htmx`` by ``HtmxMiddleware``. Truthiness tells
+    whether the request originated from htmx::
+
+        if request.state.htmx:
+            ...  # htmx-driven request
+
+    Only the headers htmx 4 sends are exposed. The htmx 2 request ``HX-Trigger``
+    was renamed to ``HX-Source`` (read it via :attr:`source`) and
+    ``HX-Trigger-Name`` was dropped, so neither has an attribute here.
+    """
+
+    def __init__(self, request: Request) -> None:
+        self.request = request
+
+    def _header(self, name: str) -> str | None:
+        value = self.request.headers.get(name) or None
+        if value and self.request.headers.get(f"{name}-URI-AutoEncoded") == "true":
+            value = unquote(value)
+        return value
+
+    def __bool__(self) -> bool:
+        return self._header("HX-Request") == "true"
+
+    @cached_property
+    def boosted(self) -> bool:
+        return self._header("HX-Boosted") == "true"
+
+    @cached_property
+    def current_url(self) -> str | None:
+        return self._header("HX-Current-URL")
+
+    @cached_property
+    def history_restore_request(self) -> bool:
+        return self._header("HX-History-Restore-Request") == "true"
+
+    @cached_property
+    def prompt(self) -> str | None:
+        """User reply captured by the ``hx-prompt`` extension (``HX-Prompt``)."""
+        return self._header("HX-Prompt")
+
+    @cached_property
+    def target(self) -> str | None:
+        """Target element as ``tag#id`` (``HX-Target``)."""
+        return self._header("HX-Target")
+
+    @cached_property
+    def source(self) -> str | None:
+        """Triggering element as ``tag#id`` (``HX-Source``; the htmx 2 request ``HX-Trigger``)."""
+        return self._header("HX-Source")
+
+    @cached_property
+    def request_type(self) -> str | None:
+        """``"full"`` or ``"partial"`` (``HX-Request-Type``)."""
+        return self._header("HX-Request-Type")
 
 
 def hx_redirect(url: str) -> HTMLResponse:
@@ -120,42 +182,6 @@ def hx_trigger(
         response.headers["HX-Trigger"] = json.dumps({event: detail})
     else:
         response.headers["HX-Trigger"] = event
-    return response
-
-
-def hx_trigger_after_settle(
-    response: Response,
-    event: str | dict[str, Any],
-    detail: dict[str, Any] | None = None,
-) -> Response:
-    """Set the ``HX-Trigger-After-Settle`` header on a response.
-
-    Same as :func:`hx_trigger` but fires after the settle phase.
-    """
-    if isinstance(event, dict):
-        response.headers["HX-Trigger-After-Settle"] = json.dumps(event)
-    elif detail is not None:
-        response.headers["HX-Trigger-After-Settle"] = json.dumps({event: detail})
-    else:
-        response.headers["HX-Trigger-After-Settle"] = event
-    return response
-
-
-def hx_trigger_after_swap(
-    response: Response,
-    event: str | dict[str, Any],
-    detail: dict[str, Any] | None = None,
-) -> Response:
-    """Set the ``HX-Trigger-After-Swap`` header on a response.
-
-    Same as :func:`hx_trigger` but fires after the swap phase.
-    """
-    if isinstance(event, dict):
-        response.headers["HX-Trigger-After-Swap"] = json.dumps(event)
-    elif detail is not None:
-        response.headers["HX-Trigger-After-Swap"] = json.dumps({event: detail})
-    else:
-        response.headers["HX-Trigger-After-Swap"] = event
     return response
 
 

--- a/vibetuner-py/tests/unit/test_htmx_helpers.py
+++ b/vibetuner-py/tests/unit/test_htmx_helpers.py
@@ -1,10 +1,12 @@
 # ruff: noqa: S101
-"""Tests for HTMX response header helpers."""
+"""Tests for htmx request detection and response header helpers."""
 
 import json
 
+from starlette.requests import Request
 from starlette.responses import HTMLResponse
 from vibetuner.htmx import (
+    HtmxDetails,
     hx_location,
     hx_push_url,
     hx_redirect,
@@ -13,9 +15,63 @@ from vibetuner.htmx import (
     hx_reswap,
     hx_retarget,
     hx_trigger,
-    hx_trigger_after_settle,
-    hx_trigger_after_swap,
 )
+
+
+def _request(headers: dict[str, str]) -> Request:
+    raw = [(key.lower().encode(), value.encode()) for key, value in headers.items()]
+    return Request({"type": "http", "headers": raw})
+
+
+class TestHtmxDetails:
+    def test_bool_true_for_htmx_request(self):
+        assert bool(HtmxDetails(_request({"HX-Request": "true"})))
+
+    def test_bool_false_without_header(self):
+        assert not bool(HtmxDetails(_request({})))
+
+    def test_source_reads_hx_source(self):
+        details = HtmxDetails(_request({"HX-Source": "button#save"}))
+        assert details.source == "button#save"
+
+    def test_request_type(self):
+        assert (
+            HtmxDetails(_request({"HX-Request-Type": "partial"})).request_type
+            == "partial"
+        )
+
+    def test_target_boosted_and_current_url(self):
+        details = HtmxDetails(
+            _request(
+                {
+                    "HX-Target": "div#main",
+                    "HX-Boosted": "true",
+                    "HX-Current-URL": "/dashboard",
+                }
+            )
+        )
+        assert details.target == "div#main"
+        assert details.boosted is True
+        assert details.current_url == "/dashboard"
+
+    def test_prompt(self):
+        assert HtmxDetails(_request({"HX-Prompt": "Bob"})).prompt == "Bob"
+
+    def test_uri_autoencoded_value_is_decoded(self):
+        details = HtmxDetails(
+            _request(
+                {
+                    "HX-Current-URL": "%2Ffoo%20bar",
+                    "HX-Current-URL-URI-AutoEncoded": "true",
+                }
+            )
+        )
+        assert details.current_url == "/foo bar"
+
+    def test_no_legacy_htmx2_request_attributes(self):
+        details = HtmxDetails(_request({"HX-Request": "true"}))
+        assert not hasattr(details, "trigger")
+        assert not hasattr(details, "trigger_name")
 
 
 class TestHxRedirect:
@@ -70,26 +126,6 @@ class TestHxTrigger:
         response = HTMLResponse("<html>ok</html>")
         result = hx_trigger(response, "test")
         assert result is response
-
-
-class TestHxTriggerAfterSettle:
-    def test_sets_header(self):
-        response = HTMLResponse("<html>ok</html>")
-        hx_trigger_after_settle(response, "settled")
-        assert response.headers["HX-Trigger-After-Settle"] == "settled"
-
-    def test_with_detail(self):
-        response = HTMLResponse("<html>ok</html>")
-        hx_trigger_after_settle(response, "done", {"count": 5})
-        parsed = json.loads(response.headers["HX-Trigger-After-Settle"])
-        assert parsed == {"done": {"count": 5}}
-
-
-class TestHxTriggerAfterSwap:
-    def test_sets_header(self):
-        response = HTMLResponse("<html>ok</html>")
-        hx_trigger_after_swap(response, "swapped")
-        assert response.headers["HX-Trigger-After-Swap"] == "swapped"
 
 
 class TestHxPushUrl:

--- a/vibetuner-py/uv.lock
+++ b/vibetuner-py/uv.lock
@@ -2857,18 +2857,6 @@ wheels = [
 ]
 
 [[package]]
-name = "starlette-htmx"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/16/dcb7da6006564a0af5f0dccb5c8710ca9b6da665a86d1c41473744a74c38/starlette_htmx-0.1.1.tar.gz", hash = "sha256:686b507eae5492d3e78963fa5783ecfb4bbaa06fe43a858d4676a2c76f7a83ac", size = 2881, upload-time = "2022-01-22T17:10:48.941Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/ea/da6b4aecca60cac91643b6e2733969d64a658bac79aa35df551b9e97e879/starlette_htmx-0.1.1-py2.py3-none-any.whl", hash = "sha256:f81e0ab89c02ede60203b458c3a9a088e87d47c7583a7e9fd7f11b92e27cef99", size = 2767, upload-time = "2022-01-22T17:10:47.645Z" },
-]
-
-[[package]]
 name = "streaq"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3190,7 +3178,6 @@ dependencies = [
     { name = "sqlmodel" },
     { name = "starlette-babel" },
     { name = "starlette-context" },
-    { name = "starlette-htmx" },
     { name = "streaq", extra = ["web"] },
     { name = "typer" },
 ]
@@ -3254,7 +3241,6 @@ requires-dist = [
     { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "starlette-babel", specifier = ">=1.1.0" },
     { name = "starlette-context", specifier = ">=0.5.1" },
-    { name = "starlette-htmx", specifier = ">=0.1.1" },
     { name = "streaq", extras = ["web"], specifier = ">=7.0.0,<8.0.0" },
     { name = "taplo", marker = "extra == 'dev'", specifier = ">=0.9.3" },
     { name = "testcontainers", extras = ["mongodb"], marker = "extra == 'dev'", specifier = ">=4.14.2" },

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -95,15 +95,15 @@ async def notifications_stream(request: Request): pass
 From `vibetuner.htmx`: `hx_redirect(url)`,
 `hx_location(path, target=, swap=)`,
 `hx_trigger(response, event, detail)`, `hx_push_url`,
-`hx_replace_url`, `hx_reswap`, `hx_retarget`, `hx_refresh`,
-`hx_trigger_after_settle`, `hx_trigger_after_swap`.
+`hx_replace_url`, `hx_reswap`, `hx_retarget`, `hx_refresh`.
 
 ## HTMX 4 Event Handling
 
 htmx 4 changed event handling significantly. Key differences:
 
 **Event names** use colon-separated format (not camelCase):
-`htmx:after:request`, `htmx:before:swap`, `htmx:after:settle`.
+`htmx:after:request`, `htmx:before:swap`, `htmx:after:swap` (the htmx 2
+settle phase folded into swap, so there is no `htmx:after:settle`).
 
 **`hx-on` attributes** — the `hx-on::` shorthand works in beta1+
 (it was broken in alpha8). Both forms are valid:
@@ -234,5 +234,7 @@ request, ctx)` — renders a single `{% block %}`.
 ## HTMX Request Detection
 
 `request.state.htmx` — truthy for HTMX requests. Properties:
-`.boosted`, `.target`, `.trigger`, `.trigger_name`, `.current_url`,
-`.prompt`. Use `Depends(require_htmx)` for HTMX-only routes.
+`.boosted`, `.target` (`tag#id`), `.source` (`HX-Source`; the htmx 2 request
+`HX-Trigger`), `.request_type` (`"full"`/`"partial"`), `.current_url`,
+`.history_restore_request`, `.prompt` (via the `hx-prompt` extension).
+Use `Depends(require_htmx)` for HTMX-only routes.


### PR DESCRIPTION
## What

Brings vibetuner's server-side htmx surface and docs fully in line with htmx 4 (the client bumped to `htmx.org@4.0.0-beta5` separately in #2062). Audited templates, JS, the Python layer, and all docs/agent instructions against the htmx 4 model.

### Framework code (breaking)

- **Own htmx request detection.** Replaces the third-party `starlette_htmx.HtmxDetails` (which reads htmx 2 request headers) with a vibetuner-owned `HtmxDetails` in `vibetuner.htmx`, exposing htmx 4's surface: `.source` (`HX-Source`, the renamed request-side `HX-Trigger`) and `.request_type` (`HX-Request-Type`), alongside the still-valid `__bool__`/`.boosted`/`.current_url`/`.history_restore_request`/`.target`/`.prompt`. The htmx 2 `.trigger` / `.trigger_name` props are gone. Drops the `starlette-htmx` dependency.
- **Remove dead response helpers.** `hx_trigger_after_settle` / `hx_trigger_after_swap` set `HX-Trigger-After-Settle` / `HX-Trigger-After-Swap`, both removed in htmx 4 (the client silently ignores them). Use `hx_trigger` (the `HX-Trigger` response header is unchanged).

### Docs / instructions

- New **"Beta4 to Beta5 Changes"** section + checklist in the htmx migration guide: HCON config grammar (backward-compatible), the restored `hx-prompt` extension, `swapEmpty`/`defaultSwapEmpty` (SSE empty-response default), morph-skip attributes, the `hx-live` expansion, and the framework-side changes above. New-extensions/new-attributes tables updated; beta5 highlights mirrored in `llms-full.txt`.
- Corrected the stale request-detection props and response-helper lists in `development-guide.md`, `llms.txt`, `llms-full.txt`, and the template's `.claude/rules/frontend.md`; fixed a bad `htmx:after:settle` event example.
- Linked the htmx 4 changes from the v11→v12 upgrade guide.

## Audit result

Templates and JS were already htmx-4-clean (correct idioms, valid extension paths, no removed attrs/events, no inheritance to migrate; `hx-vals`/`hx-trigger`/`hx-headers` unused, so beta5's HCON parser change is a non-issue). The only gaps were the Python helpers/detection and docs, all addressed here.

## Verification

- `pytest tests/unit` → **1039 passed** (new `HtmxDetails` tests; dead-helper tests removed)
- `just type-check-py` → All checks passed
- `just docs-build` → builds clean (new `#beta4-to-beta5-changes` anchor + v12 cross-link resolve)
- Both `uv.lock` files consistent; `starlette-htmx` removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)