### PR TITLE
fix(rendering): log and narrow exception handling in date/timeago filters

### DIFF
--- a/vibetuner-py/src/vibetuner/rendering.py
+++ b/vibetuner-py/src/vibetuner/rendering.py
@@ -385,7 +385,8 @@ def timeago(dt, short: bool = False):
         if short:
             return _timeago_short(diff, dt)
         return _timeago_verbose(diff, dt)
-    except Exception:
+    except (TypeError, ValueError, AttributeError) as e:
+        logger.warning(f"timeago filter received invalid value {dt!r}: {e}")
         return ""
 
 
@@ -403,7 +404,8 @@ def format_date(dt):
         return ""
     try:
         return dt.strftime("%B %d, %Y")
-    except Exception:
+    except (TypeError, ValueError, AttributeError) as e:
+        logger.warning(f"format_date filter received invalid value {dt!r}: {e}")
         return ""
 
 
@@ -421,7 +423,8 @@ def format_datetime(dt):
         return ""
     try:
         return dt.strftime("%B %d, %Y at %I:%M %p")
-    except Exception:
+    except (TypeError, ValueError, AttributeError) as e:
+        logger.warning(f"format_datetime filter received invalid value {dt!r}: {e}")
         return ""
 
 

--- a/vibetuner-py/tests/unit/test_timeago.py
+++ b/vibetuner-py/tests/unit/test_timeago.py
@@ -1,11 +1,12 @@
-# ABOUTME: Unit tests for the timeago template filter
+# ABOUTME: Unit tests for the timeago, format_date, and format_datetime template filters
 # ABOUTME: Tests both verbose (default) and short format output for relative time display
 # ruff: noqa: S101
 
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
-from vibetuner.frontend.templates import timeago
+import pytest
+from vibetuner.frontend.templates import format_date, format_datetime, timeago
 
 
 class TestTimeagoVerbose:
@@ -582,3 +583,57 @@ class TestTimeagoEdgeCases:
         assert "7" in result
         assert "day" in result
         assert "week" not in result.lower()
+
+
+class TestFilterErrorHandling:
+    """Test that date/time filters log warnings on invalid input and let unexpected exceptions propagate."""
+
+    def test_timeago_bad_input_logs_warning_and_returns_empty(self, log_sink):
+        """timeago() logs a WARNING when given a non-datetime value."""
+        result = timeago("not a date")
+        assert result == ""
+        assert any("WARNING" in m for m in log_sink)
+
+    def test_timeago_none_logs_warning_and_returns_empty(self, log_sink):
+        """timeago(None) logs a WARNING."""
+        result = timeago(None)
+        assert result == ""
+        assert any("WARNING" in m for m in log_sink)
+
+    def test_format_date_bad_input_logs_warning_and_returns_empty(self, log_sink):
+        """format_date() logs a WARNING when given a non-datetime value."""
+        result = format_date(42)
+        assert result == ""
+        assert any("WARNING" in m for m in log_sink)
+
+    def test_format_datetime_bad_input_logs_warning_and_returns_empty(self, log_sink):
+        """format_datetime() logs a WARNING when given a non-datetime value."""
+        result = format_datetime(42)
+        assert result == ""
+        assert any("WARNING" in m for m in log_sink)
+
+    def test_timeago_unexpected_exception_propagates(self):
+        """timeago() lets unexpected exception types propagate instead of silently returning ''."""
+        with patch("vibetuner.rendering.age_in_timedelta", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                timeago("anything")
+
+    def test_format_date_unexpected_exception_propagates(self):
+        """format_date() lets unexpected exception types propagate instead of silently returning ''."""
+
+        class BadObj:
+            def strftime(self, fmt: str) -> str:
+                raise RuntimeError("unexpected")
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            format_date(BadObj())
+
+    def test_format_datetime_unexpected_exception_propagates(self):
+        """format_datetime() lets unexpected exception types propagate instead of silently returning ''."""
+
+        class BadObj:
+            def strftime(self, fmt: str) -> str:
+                raise RuntimeError("unexpected")
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            format_datetime(BadObj())


### PR DESCRIPTION
## Summary

- `timeago`, `format_date`, and `format_datetime` each had `except Exception: return ""`, which
  silently discarded any error — including real bugs like `NameError` or internal library failures
  — with no log output and no signal to the developer.
- Narrowed the catch to `(TypeError, ValueError, AttributeError)`, the only exception types these
  filter bodies can reasonably encounter with bad input (e.g. passing `None` or a plain string
  where a `datetime` is expected raises `AttributeError` on the missing `.tzinfo` or `.strftime`).
- Added `logger.warning(...)` before each `return ""` so callers can see in the logs which value
  triggered the failure.
- Unexpected exception types (e.g. `RuntimeError` from a failing internal call) now propagate
  instead of being silently swallowed.

## Exception type justification

- **`AttributeError`** — primary expected failure: `None`, strings, ints, and other non-datetime
  objects all raise `AttributeError` when the code accesses `.tzinfo` (in `age_in_timedelta`) or
  calls `.strftime(...)`.
- **`TypeError`** — defensive inclusion: arithmetic like `now() - dt` can raise `TypeError` if
  the operand supports partial attribute access but not datetime subtraction.
- **`ValueError`** — defensive inclusion: timezone or strftime edge cases in third-party code
  may raise `ValueError` on unusual inputs.

## Test plan

- [ ] 7 new tests added to `tests/unit/test_timeago.py` (`TestFilterErrorHandling` class)
- [ ] Each filter is tested for: bad input logs WARNING and returns `""`; unexpected exception
  type (`RuntimeError`) propagates
- [ ] All 7 new tests failed before the fix and pass after
- [ ] Full unit suite: 1041 tests pass

Closes #2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTUrgbYEPjmUyFJfQRCfH