### PR TITLE
docs(htmx): document htmx 4 attribute-inheritance removal in migration guide and agent rules

### DIFF
--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -90,6 +90,14 @@ inheritance must be explicitly opted into using the `:inherited` modifier.
 
 Without `:inherited`, each child element must set its own attributes explicitly.
 
+!!! warning "Silent failure: no console error"
+    When a child element has no `hx-target` or `hx-swap` of its own, htmx 4 falls
+    back to its defaults (target: the element itself; swap: `innerHTML`) with no
+    warning. The common `<div hx-target="this" hx-swap="outerHTML">` wrapper pattern
+    is the typical casualty — clicking a child button nests the response *inside* the
+    button instead of replacing the outer fragment. No console error is emitted, and
+    any click handlers on the child stay armed for repeated firing.
+
 Use `:append` to add to an inherited value instead of replacing it:
 
 ```html
@@ -853,16 +861,37 @@ window.htmx = htmx;
 
 ### Attributes no longer inherited by child elements
 
-**Symptom:** Buttons or links inside a container stop working because they relied on
-a parent's `hx-target`, `hx-swap`, or similar attribute.
+**Symptom:** A child element's request silently targets itself with `innerHTML` swap
+instead of using the ancestor's `hx-target`/`hx-swap`. The classic failure is a
+`<div hx-target="this" hx-swap="outerHTML">` wrapper: clicking a child button nests
+the server response *inside* the button rather than replacing the outer fragment.
+No console error is emitted, and click handlers on the child remain armed.
 
-**Cause:** htmx v4 no longer inherits attributes by default.
+**Cause:** htmx v4 no longer inherits attributes from ancestors by default. Every
+element must carry its own `hx-target`, `hx-swap`, `hx-trigger`, etc.
 
-**Fix:** Add `:inherited` to the parent attribute:
+**Fix (each element carries its own attributes):**
 
 ```html
-<!-- Before: <div hx-target="#results"> -->
-<div hx-target:inherited="#results">
+<!-- v2: child inherits hx-target/hx-swap from parent -->
+<div hx-target="this" hx-swap="outerHTML">
+    <button hx-get="/fragment">Refresh</button>
+</div>
+
+<!-- v4: child declares its own attributes -->
+<div>
+    <button hx-get="/fragment"
+            hx-target="closest div"
+            hx-swap="outerHTML">Refresh</button>
+</div>
+```
+
+**Fix (keep the wrapper — add `:inherited` to parent attributes):**
+
+```html
+<div hx-target:inherited="this" hx-swap:inherited="outerHTML">
+    <button hx-get="/fragment">Refresh</button>
+</div>
 ```
 
 ### Preload extension not working

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2879,7 +2879,12 @@ hx-vals='js:{"token": getToken()}'
 
 #### Attribute Inheritance Requires `:inherited`
 
-In v4, inheritance must be explicitly opted into:
+In v4, inheritance must be explicitly opted into — every element must carry its own
+`hx-target`, `hx-swap`, `hx-trigger`, etc. Without them, htmx falls back to its
+defaults (target: the element itself; swap: `innerHTML`) silently, with no console
+error. The `<div hx-target="this" hx-swap="outerHTML">` wrapper pattern is the
+common casualty: clicks nest the response inside the child instead of replacing
+the fragment.
 
 ```html
 <!-- Before: <div hx-target="#results"> -->

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -125,6 +125,13 @@ longer exists. Use `event.detail.ctx.response` instead:
 **Events do not bubble** to `document.body` in v4. Attach listeners
 directly to elements or use `hx-on` attributes.
 
+**Attribute inheritance is explicit.** htmx 4 does not inherit `hx-target`,
+`hx-swap`, `hx-trigger`, or any other attribute from ancestors. Every element must
+carry its own attributes. Without them, htmx falls back to its defaults (target:
+the element itself; swap: `innerHTML`) with no console error. To share attributes
+across children, add `:inherited` to the parent attribute (e.g.,
+`hx-target:inherited="this" hx-swap:inherited="outerHTML"`).
+
 See the [HTMX migration guide](https://vibetuner.alltuner.com/htmx-migration/)
 for full details.
 


### PR DESCRIPTION
## Summary

- Adds a `!!! warning "Silent failure: no console error"` admonition to the
  **Attribute Inheritance Requires `:inherited`** section of `htmx-migration.md`,
  calling out that htmx 4 falls back to default target/swap silently and describing
  the classic `<div hx-target="this" hx-swap="outerHTML">` wrapper failure mode.
- Expands the **Common Migration Issues** entry for inheritance to show the concrete
  symptom (response nests inside the child, stale handlers stay armed) and provides
  two explicit fixes: per-element attributes and the `:inherited` wrapper pattern.
- Adds an **Attribute inheritance is explicit** bullet to
  `vibetuner-template/.claude/rules/frontend.md` so agent rules surface this
  constraint when writing htmx templates.
- Updates the `llms-full.txt` inheritance entry with the silent-failure context.

## Technical verification

Confirmed against the htmx 4 upstream docs (`four.htmx.org`): attribute
inheritance in v4 is **opt-in via the `:inherited` modifier** on the parent
attribute (e.g. `hx-target:inherited="this"`). The `hx-inherit` and
`hx-disinherit` attributes from htmx 2 were both removed. Without `:inherited`,
children use htmx defaults (target: the element itself; swap: `innerHTML`) with no
console warning. The existing `htmx-migration.md` had this right technically but
lacked the silent-failure symptom description that makes the bug diagnosable.

## Test plan

- [ ] `just lint-md` passes (pre-existing `README.md` violations are unrelated)
- [ ] Rendered docs at `https://vibetuner.alltuner.com/htmx-migration/` show the
  warning admonition and expanded Common Migration Issues entry
- [ ] `vibetuner-template/.claude/rules/frontend.md` htmx-4 section contains the
  inheritance bullet

Closes #2032

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTUrgbYEPjmUyFJfQRCfH