### PR TITLE
ci: add test, lint, and type-check workflow for PRs and pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Unit tests run on a Python version matrix; lint and type-check use the
+# project's primary Python version (from root .python-version).
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache-dependency-glob: "vibetuner-py/uv.lock"
+
+      - name: Run unit tests
+        working-directory: vibetuner-py
+        run: uv run --frozen --extra dev python -m pytest tests/unit/ -v
+
+  lint-and-type-check:
+    name: Lint and type check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          cache-dependency-glob: "vibetuner-py/uv.lock"
+
+      - name: Ruff lint
+        working-directory: vibetuner-py
+        run: uv run --frozen --extra dev ruff check .
+
+      - name: Type check
+        working-directory: vibetuner-py
+        run: uv run --frozen --extra dev ty check .


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` — an **informational** workflow (no required status checks
configured; that's a separate GitHub settings decision for David). Runs automatically on all PRs
and pushes to `main`.

### What runs

**Job: `test` (matrix: Python 3.11 / 3.12 / 3.13 / 3.14)**
- `uv run --frozen --extra dev python -m pytest tests/unit/ -v`
- 1039 unit tests, confirmed passing on current main with all four Python versions via uv's
  managed Python distributions
- Integration tests (`tests/integration/`) are intentionally excluded: they require MongoDB and
  Redis services and testcontainers/Docker, making them unsuitable for a lightweight CI job

**Job: `lint-and-type-check` (Python 3.14 — project primary)**
- `uv run --frozen --extra dev ruff check .` — Python lint (passes on main)
- `uv run --frozen --extra dev ty check .` — type checking (passes on main)

### Pre-existing breakage on main (scoped out, reported for David to decide)

1. **`pre-commit run --all-files` is broken** — pre-commit 4.5.1 raises
   `InvalidConfigError: Missing required key: rev` on the `builtin` repo entry in
   `.pre-commit-config.yaml`. The workflow falls back to the individual `ruff check` /
   `ty check` equivalents instead.

2. **`ruff format --check` fails** — 7 test files in `vibetuner-py/tests/unit/` would be
   reformatted. Excluded from CI to avoid a red-from-day-one workflow. Included only `ruff check`
   (the linter), which is green.

3. **`actionlint .github/workflows/*.yml` has a pre-existing SC2010 warning** in `release.yml`
   (ls | grep). The new `ci.yml` is clean; `actionlint ci.yml` exits 0.

### Conventions matched

- `actions/checkout@v7` (matches `release.yml`)
- `astral-sh/setup-uv@v8.2.0` (matches `release.yml`)
- `cache-dependency-glob: "vibetuner-py/uv.lock"` for uv layer caching
- `fail-fast: false` on the matrix so one Python failure doesn't abort the others
- `--frozen` throughout (reads the lockfile, never updates it)
- `--extra dev` (the only optional-dependency group; the justfile's `--extra test` is a bug —
  that extra doesn't exist)

### Local verification

| Check | Result |
|---|---|
| `pytest tests/unit/` (Python 3.14) | 1039 passed, 40 warnings |
| `ruff check .` | All checks passed |
| `ty check .` | All checks passed |
| `actionlint ci.yml` | Clean (exit 0) |
| `dprint check ci.yml` (YAML formatter) | Clean (exit 0) |
| `pre-commit run --all-files` | FAILED — pre-existing config error (scoped out) |
| `ruff format --check .` | FAILED — 7 test files (pre-existing, scoped out) |

Closes #2022

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTUrgbYEPjmUyFJfQRCfH