### PR TITLE
fix(htmx): don't swap 4xx/5xx error bodies into fragment targets

### DIFF
--- a/vibetuner-docs/docs/htmx-migration.md
+++ b/vibetuner-docs/docs/htmx-migration.md
@@ -37,12 +37,21 @@ In v2, `4xx` and `5xx` responses were not swapped. In v4, if your server
 returns HTML with a `422` or `500`, that HTML gets swapped into the target.
 This means your error responses need to produce valid swap content.
 
+**Vibetuner ships the v2 behavior by default.** The framework skeleton
+includes `<meta name="htmx-config" content='{"noSwap": [204, 304, "4xx",
+"5xx"]}'>`, so scaffolded apps drop error bodies instead of swapping them.
+A stray validation `422` never replaces an inline-edit fragment with an
+error page. Override the `htmx_config` block in `skeleton.html.jinja` to
+change this (keep `noSwap` unless you handle error swapping another way).
+
 **Options:**
 
-- Design error responses as HTML fragments suitable for swapping
+- Design error responses as HTML fragments suitable for swapping, then
+  opt a specific element back into swapping with `hx-status`
 - Use the new [`hx-status`](#per-status-code-swap-control) attribute for
-  fine-grained control
-- Revert globally: `htmx.config.noSwap = [204, 304, '4xx', '5xx']`
+  fine-grained control (it wins over the `4xx`/`5xx` wildcards)
+- The skeleton already reverts globally via
+  `noSwap: [204, 304, '4xx', '5xx']`
 
 ## Per-Status-Code Swap Control
 

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -2969,6 +2969,19 @@ the fragment.
 <div hx-target:inherited="#results">
 ```
 
+#### Error Responses (4xx/5xx) Do Not Swap by Default
+
+htmx 4 swaps every response into the target (only `204`/`304` are skipped),
+so a validation `422` would replace a fragment with whatever the error
+handler returns. The framework skeleton ships
+`<meta name="htmx-config" content='{"noSwap": [204, 304, "4xx", "5xx"]}'>`,
+restoring htmx 2 behavior: error bodies are dropped, not swapped. To swap an
+error fragment for a specific element use `hx-status:<code>` (wins over the
+`4xx`/`5xx` wildcards), e.g.
+`hx-status:422="swap:innerHTML target:#errors"`. Overriding the
+`htmx_config` block in `skeleton.html.jinja` replaces this default — keep
+`noSwap` unless you handle error swapping another way.
+
 #### JavaScript Import Changes
 
 ```javascript

--- a/vibetuner-docs/docs/llms.txt
+++ b/vibetuner-docs/docs/llms.txt
@@ -70,6 +70,12 @@ Important notes:
   `hx_push_url()`, `hx_reswap()`, `hx_retarget()`, `hx_refresh()`,
   `hx_replace_url()`. Handles JSON serialization internally. Import from
   `vibetuner.htmx`
+- **HTMX Error-Swap Default**: the skeleton ships
+  `<meta name="htmx-config" content='{"noSwap": [204, 304, "4xx", "5xx"]}'>`,
+  so 4xx/5xx response bodies are not swapped into the target (htmx 2 behavior)
+  — a stray `422` never replaces a fragment with an error page. Opt a specific
+  element back in with `hx-status:<code>` (wins over the wildcards). Override
+  the `htmx_config` block to customize; keep `noSwap`
 - **Built-in Template Globals**: `request`, `language`, `DEBUG`, `now`
   (UTC datetime), `today` (ISO date string), `project` (`settings.project`),
   `brand` (`settings.brand`), `csp_nonce`, and `hotreload` are available

--- a/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
+++ b/vibetuner-py/src/vibetuner/templates/frontend/base/skeleton.html.jinja
@@ -33,8 +33,17 @@
 
         {# Pre-script head hook. Anything here is parsed before the bundle
            below, so htmx reads a `<meta name="htmx-config">` placed here at
-           startup (it reads config when the script evaluates, not later). -#}
+           startup (it reads config when the script evaluates, not later).
+
+           The default restores htmx 2 error-swap behavior: 4xx/5xx response
+           bodies are not swapped into the target, so a validation 422 or a
+           500 never replaces a fragment with an error page. Per-element
+           `hx-status:<code>` attributes still win (exact codes are matched
+           before the 4xx/5xx wildcards). Override this block to customize
+           the htmx config; keep `noSwap` unless you handle error swapping
+           some other way. -#}
         {% block htmx_config %}
+            <meta name="htmx-config" content='{"noSwap": [204, 304, "4xx", "5xx"]}' />
         {% endblock htmx_config %}
         {% block scripts %}
             <script src="{{ url_for('js', path='bundle.js').path }}"></script>

--- a/vibetuner-py/tests/unit/test_skeleton_extension_points.py
+++ b/vibetuner-py/tests/unit/test_skeleton_extension_points.py
@@ -268,6 +268,45 @@ def test_before_main_and_after_main_wrap_body():
     assert pre < body < post
 
 
+# ── htmx config default ──────────────────────────────────────────────
+
+
+class TestHtmxConfigDefault:
+    def test_ships_a_default_htmx_config_meta(self):
+        """The skeleton ships an htmx-config meta tag out of the box."""
+        out = _render(_make_env())
+        flat = " ".join(out.split())
+        assert 'name="htmx-config"' in flat
+
+    def test_default_disables_error_response_swapping(self):
+        """4xx/5xx response bodies must not swap into the target by default
+        (htmx 2 behavior), so a stray 422 never replaces a fragment with an
+        error page. See issue #2033."""
+        out = _render(_make_env())
+        flat = " ".join(out.split())
+        assert "noSwap" in flat
+        assert '"4xx"' in flat
+        assert '"5xx"' in flat
+
+    def test_default_config_renders_before_bundle_js(self):
+        """htmx reads its meta config when the bundle evaluates, so the
+        default config must precede the bundle script."""
+        out = _render(_make_env())
+        assert out.index("htmx-config") < out.index("bundle.js")
+
+    def test_block_override_replaces_default(self):
+        """A child template overriding the block replaces the framework
+        default entirely."""
+        env = _make_env(
+            child_body=(
+                "{% block htmx_config %}<!-- CUSTOM -->{% endblock htmx_config %}"
+            )
+        )
+        out = _render(env)
+        assert "<!-- CUSTOM -->" in out
+        assert "noSwap" not in out
+
+
 # ── scrollbar gutter ─────────────────────────────────────────────────
 
 

--- a/vibetuner-template/.claude/rules/frontend.md
+++ b/vibetuner-template/.claude/rules/frontend.md
@@ -132,6 +132,17 @@ the element itself; swap: `innerHTML`) with no console error. To share attribute
 across children, add `:inherited` to the parent attribute (e.g.,
 `hx-target:inherited="this" hx-swap:inherited="outerHTML"`).
 
+**Error responses (4xx/5xx) do not swap by default.** htmx 4 swaps every
+response into the target (only `204`/`304` are skipped), so a validation
+`422` would otherwise replace a fragment with whatever the error handler
+returns. The framework skeleton ships
+`<meta name="htmx-config" content='{"noSwap": [204, 304, "4xx", "5xx"]}'>`
+to restore htmx 2 behavior: error bodies are dropped, not swapped. To swap
+an error fragment for a specific element, use `hx-status:<code>` (it wins
+over the `4xx`/`5xx` wildcards), e.g.
+`hx-status:422="swap:innerHTML target:#errors"`. If you override the
+`htmx_config` block in `skeleton.html.jinja`, keep the `noSwap` default.
+
 See the [HTMX migration guide](https://vibetuner.alltuner.com/htmx-migration/)
 for full details.
 


### PR DESCRIPTION
## What

Closes #2033.

htmx 4 swaps every response into the request's target by default — only `204`/`304` are exempt (`htmx.config.noSwap`). htmx 2 did **not** swap `4xx`/`5xx`. So under htmx 4 a validation `422` (e.g. an inline-edit `PUT` with an empty `Form(...)` field) or any `4xx`/`5xx` now lands the error body inside the fragment target, replacing a one-line form with a full error page mid-card.

## Fix

Ship the htmx 2 error-swap behavior as the framework default. The skeleton's `htmx_config` block now renders:

```html
<meta name="htmx-config" content='{"noSwap": [204, 304, "4xx", "5xx"]}' />
```

`#handleStatusCodes` in htmx sets `swap: "none"` whenever the status matches a `noSwap` entry, so `4xx`/`5xx` bodies are dropped rather than swapped. Per-element `hx-status:<code>` overrides still win — exact codes (`422`) and single-digit wildcards (`42x`) are matched **before** the `4xx`/`5xx` range wildcards — so an app that wants to swap a validation fragment can still opt in:

```html
<form hx-post="/save" hx-status:422="swap:innerHTML target:#errors">
```

This is exactly the documented revert (htmx-migration guide), now shipped by default so scaffolded apps get sane behavior out of the box.

## Changes

- `skeleton.html.jinja`: default `htmx-config` meta with `noSwap` in the existing `htmx_config` block (overridable; comment tells overriders to keep `noSwap`)
- Tests: `test_skeleton_extension_points.py` pins the default meta, the `noSwap` 4xx/5xx contents, its position before `bundle.js`, and that a block override replaces it
- Docs: htmx-migration guide, `llms.txt`, `llms-full.txt`, and the template's `.claude/rules/frontend.md`

## Test

`1076 passed` in `vibetuner-py/tests/unit/`; jinja + markdown lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019udhTzNg2ob2sExB3Pauqd