### PR TITLE
test: make integration tests find Docker Desktop's socket and stop env leak

### DIFF
--- a/vibetuner-py/tests/integration/conftest.py
+++ b/vibetuner-py/tests/integration/conftest.py
@@ -1,0 +1,30 @@
+# ABOUTME: Integration-test fixtures that prepare the Docker environment.
+# ABOUTME: Resolves the active Docker socket so testcontainers works on Docker Desktop.
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def docker_host() -> None:
+    """Point testcontainers at the active Docker socket.
+
+    docker-py (and therefore testcontainers) defaults to
+    ``unix:///var/run/docker.sock``, which Docker Desktop on macOS does not
+    create; the daemon listens on the socket named by the current Docker
+    context instead. When ``DOCKER_HOST`` is unset and the default socket is
+    missing, resolve the context's host and export it so the container fixtures
+    can reach the daemon. On Linux/CI, where the default socket exists, this is
+    a no-op.
+    """
+    if os.environ.get("DOCKER_HOST"):
+        return
+    if Path("/var/run/docker.sock").exists():
+        return
+
+    from docker.context import ContextAPI
+
+    host = ContextAPI.get_current_context().Host
+    if host:
+        os.environ["DOCKER_HOST"] = host

--- a/vibetuner-py/tests/integration/test_vibetuner_db_real.py
+++ b/vibetuner-py/tests/integration/test_vibetuner_db_real.py
@@ -1,8 +1,6 @@
 # ABOUTME: Integration test for vibetuner_db against a Dockerised MongoDB.
 # ABOUTME: Verifies cross-test isolation, session DB reuse, and index persistence.
 # ruff: noqa: S101
-import os
-
 import pytest
 import vibetuner.mongo as mongo_mod
 from beanie import Document
@@ -34,7 +32,7 @@ def _patched_get_all_models() -> list[type]:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def mongo_container():
+def mongo_container(docker_host):
     """Spin up a MongoDB container for the test session."""
     from pydantic import MongoDsn
 
@@ -42,8 +40,6 @@ def mongo_container():
         url = container.get_connection_url()
         original_url = settings.mongodb_url
         settings.mongodb_url = MongoDsn(url)
-        original_env = os.environ.get("MONGODB_URL")
-        os.environ["MONGODB_URL"] = url
         # Patch model registry to include our probe.
         mongo_mod.get_all_models = _patched_get_all_models
         try:
@@ -51,10 +47,6 @@ def mongo_container():
         finally:
             mongo_mod.get_all_models = _original_get_all_models
             settings.mongodb_url = original_url
-            if original_env is None:
-                os.environ.pop("MONGODB_URL", None)
-            else:
-                os.environ["MONGODB_URL"] = original_env
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## What

Two fixes so the full test suite (`just test`) passes locally with Docker running, not just the unit subset CI runs.

### Socket discovery
`tests/integration/conftest.py` now resolves the active Docker socket from the current Docker context (via docker-py's `ContextAPI`) when `DOCKER_HOST` is unset and `/var/run/docker.sock` is missing. Docker Desktop on macOS listens on the context socket (`~/.docker/run/docker.sock`), which testcontainers/docker-py don't find by default. No-op on Linux/CI where the default socket exists, and respects an explicit `DOCKER_HOST` override.

### Env-pollution fix
Dropped the redundant `os.environ["MONGODB_URL"]` mutation from the `mongo_container` fixture. The fixtures consume `settings.mongodb_url` (via `resolved_test_mongodb_url`), so the env write was unnecessary — and it leaked the container URL into the whole session, breaking `test_config.py::test_is_none_when_neither_set` whenever the integration tests ran before it. This was a latent bug masked only by Docker being unreachable.

## Verification

Full suite from the worktree with **no `DOCKER_HOST` set**:

- `pytest` → **1079 passed** (1076 unit + 3 integration), 0 failures
- `ruff check`, `ruff format --check`, `ty check .` → all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)