### PR TITLE
ci: fix lint job failing on no-commit-to-branch and lint-po

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
           cache-dependency-glob: "vibetuner-py/uv.lock"
 
       - name: Pre-commit (lint suite)
+        # no-commit-to-branch is a local guard against committing to main; it
+        # has no meaning in CI and fails on push-to-main runs.
+        env:
+          SKIP: no-commit-to-branch
         run: uvx pre-commit run --all-files --show-diff-on-failure
 
       - name: Ruff format check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,6 @@ vibetuner = { path = "vibetuner-py" }
 
 [dependency-groups]
 dev = [
+    "lint-po>=0.1.5",
     "vibetuner[dev]",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1597,6 +1597,15 @@ wheels = [
 ]
 
 [[package]]
+name = "lint-po"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/4b/31ee4d62c31262d6d891381882df2bfd64cf8473c7deca40d41881fe9b49/lint_po-0.1.5.tar.gz", hash = "sha256:3e67ed31568163a9a9e1770dce7ce543dc120a576da17e8343a478763b732213", size = 7913, upload-time = "2026-05-05T17:10:56.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/20/9a3127fb08285c7a4fc7a8abf8910ea3cca6f926dab634f9f4f75f45e894/lint_po-0.1.5-py3-none-any.whl", hash = "sha256:bc5b316104c2a61e54c5132e1ab2f20f9452886d69548719eb37d87570661806", size = 8418, upload-time = "2026-05-05T17:10:54.904Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3259,13 +3268,17 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "lint-po" },
     { name = "vibetuner", extra = ["dev"] },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "vibetuner", extras = ["dev"], directory = "vibetuner-py" }]
+dev = [
+    { name = "lint-po", specifier = ">=0.1.5" },
+    { name = "vibetuner", extras = ["dev"], directory = "vibetuner-py" },
+]
 
 [[package]]
 name = "watchfiles"


### PR DESCRIPTION
## What

The CI **Lint and type check** job (`uvx pre-commit run --all-files`) has been red on `main` since it was added (#2077/#2078), on two hooks unrelated to any source change.

### `no-commit-to-branch`
This is a *local* guard against committing to `main`. On the push-to-`main` CI run it fails by design. Skip it in CI via the `SKIP` env on the pre-commit step. (On PR runs it passes anyway since the checkout isn't `main`; the skip is what keeps post-merge `main` runs green.)

### `lint-po`
The hook runs `uv run --frozen lint-po`, but `lint-po` was not declared as a dependency anywhere — it only resolved on machines with a global `uv tool install lint-po`. CI has no such tool, so it failed with `Failed to spawn: lint-po`. Declared `lint-po>=0.1.5` in the root `dev` dependency group so CI (and any contributor) resolves it reproducibly from the lockfile.

## Verification

`SKIP=uv-lock uvx pre-commit run --all-files` → all hooks pass, including `lint-po`. (`uv-lock` is skipped locally only because a machine-local `exclude-newer` config churns it; CI resolves the same lock, since `lint-po` 0.1.5 is the latest release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)