### PR TITLE
feat(template): optional fnox-encrypted production secrets

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -87,6 +87,15 @@ docker_registry:
   default: "localhost:5050"
   when: "{{ fqdn }}"
 
+age_recipient:
+  type: str
+  help: |
+    age public key that production secrets are encrypted to, for fnox.
+    Leave blank to keep secrets in a plaintext .env instead.
+  placeholder: age1...
+  default: ""
+  when: "{{ fqdn }}"
+
 use_self_hosted_runner:
   type: bool
   help: Include a GitHub Actions workflow for building Docker images on a self-hosted runner?

--- a/vibetuner-docs/docs/development-guide.md
+++ b/vibetuner-docs/docs/development-guide.md
@@ -141,6 +141,31 @@ just release                 # Build and release production image
 just deploy-latest HOST      # Deploy to remote host
 ```
 
+### Production Secrets
+
+Answer `age_recipient` at generation time to keep production secrets in an
+age-encrypted `fnox.toml`, which is safe to commit. `deploy-latest` then runs
+Compose under `fnox exec`, so values are decrypted on the deploying machine and
+never reach the host or a plaintext file. Leave the answer blank to keep the
+plaintext `.env` flow instead.
+
+Secrets live in `compose.secrets.yml`, an overlay applied only at deploy —
+**not** in `compose.prod.yml`. CI builds the image with
+`docker buildx bake -f compose.prod.yml`, which interpolates that entire file
+rather than only its build sections, so a `${VAR:?}` guard there fails every
+build with no secrets set.
+
+Adding a secret means two places:
+
+```bash
+fnox set SOME_KEY            # prompts; the value is encrypted into fnox.toml
+# then declare SOME_KEY in the x-secrets map in compose.secrets.yml
+```
+
+The deploy passes `--env-file /dev/null` so Compose never interpolates a local
+`.env`. A deploy outside `fnox exec` therefore fails loudly instead of starting
+the app with blank credentials or stale file values.
+
 ### Scaffolding Updates
 
 ```bash

--- a/vibetuner-template/.justfiles/cicd.justfile.j2
+++ b/vibetuner-template/.justfiles/cicd.justfile.j2
@@ -41,10 +41,24 @@ release: _check-clean _check-last-commit-tagged
     ENVIRONMENT=prod docker buildx bake -f compose.prod.yml --push
 
 # Deploys to a remote host, pulling from the configured registry.
+{%- if age_recipient %}
+# Secrets are decrypted here, at deploy time, and never reach the host or a
+# plaintext file. --env-file /dev/null stops Compose interpolating a local
+# .env, so a deploy outside `fnox exec` fails loudly rather than using stale
+# values. They live in compose.secrets.yml and not compose.prod.yml because
+# `buildx bake` interpolates the whole file it builds from, with no secrets set.
+{%- endif %}
 [group('CI/CD')]
 deploy-latest HOST:
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(just _project-vars)"
-    DOCKER_HOST="ssh://{{ HOST }}" ENVIRONMENT=prod \
+{%- if age_recipient %}
+    DOCKER_HOST="ssh://{{ '{{ HOST }}' }}" ENVIRONMENT=prod \
+    fnox exec -- docker compose --env-file /dev/null \
+      -f compose.prod.yml -f compose.secrets.yml \
+      up -d --remove-orphans --pull always
+{%- else %}
+    DOCKER_HOST="ssh://{{ '{{ HOST }}' }}" ENVIRONMENT=prod \
     docker compose -f compose.prod.yml up -d --remove-orphans --pull always
+{%- endif %}

--- a/vibetuner-template/compose.prod.yml.j2
+++ b/vibetuner-template/compose.prod.yml.j2
@@ -2,9 +2,11 @@ services:
   worker:
     image: ${DOCKER_REGISTRY:-localhost:5050}/${COMPOSE_PROJECT_NAME}:${VERSION:-latest}
     restart: unless-stopped
+{%- if not age_recipient %}
     env_file:
       - path: .env
         required: false
+{%- endif %}
     command: ["prod", "worker"]
     healthcheck:
       test: ["CMD", "vibetuner", "worker-health"]
@@ -45,9 +47,11 @@ services:
       retries: 3
       start_period: 5s
     restart: unless-stopped
+{%- if not age_recipient %}
     env_file:
       - path: .env
         required: false
+{%- endif %}
     labels:
       com.centurylinklabs.watchtower.enable: "${ENABLE_WATCHTOWER:-false}"
 

--- a/vibetuner-template/{% if age_recipient %}compose.secrets.yml{% endif %}.j2
+++ b/vibetuner-template/{% if age_recipient %}compose.secrets.yml{% endif %}.j2
@@ -1,0 +1,16 @@
+# ABOUTME: Deploy-only overlay carrying the secret environment for both services.
+# ABOUTME: Kept out of compose.prod.yml because CI bakes that file without secrets.
+#
+# `docker buildx bake -f compose.prod.yml` interpolates the entire file, not
+# just its build sections, so a `${VAR:?}` guard there fails every CI build.
+# Anchors do not cross files, so the map is defined here and applied to both
+# services. Add new secrets in both this file and fnox.toml.
+
+x-secrets: &secrets
+  SESSION_KEY: ${SESSION_KEY:?missing — run via `fnox exec`}
+
+services:
+  worker:
+    environment: *secrets
+  frontend:
+    environment: *secrets

--- a/vibetuner-template/{% if age_recipient %}fnox.toml{% endif %}.j2
+++ b/vibetuner-template/{% if age_recipient %}fnox.toml{% endif %}.j2
@@ -1,0 +1,13 @@
+# ABOUTME: fnox secrets for this project; age-encrypted values are safe to commit.
+# ABOUTME: Decrypted at deploy time by `fnox exec` — see .justfiles/cicd.justfile.
+
+default_provider = "age"
+
+[providers.age]
+type = "age"
+recipients = ["{{ age_recipient }}"]
+
+# Add secrets with `fnox set NAME`, then declare them in compose.secrets.yml.
+# Never paste a decrypted value into a shell argument — prefer stdin or the
+# interactive prompt.
+[secrets]


### PR DESCRIPTION
Carries back what a downstream project (`alltuner/radio`) hit while migrating its secrets, so the next project generated from this template does not repeat it.

## What

A new `age_recipient` answer. Provide one and the project scaffolds:

- `fnox.toml` — age-encrypted secrets, safe to commit
- `compose.secrets.yml` — deploy-only overlay declaring the secret environment
- `deploy-latest` running under `fnox exec`

Leave it blank and the existing plaintext `.env` flow is generated unchanged.

## The trap this encodes

Secrets go in the overlay, **not** `compose.prod.yml`, because CI builds with:

```
docker buildx bake -f compose.prod.yml --push
```

Bake interpolates the **entire** file, not only its `build:` sections. A `${VAR:?}` guard there fails every CI build, since a runner has no secrets. Downstream this tagged a release that was then never built, and it is invisible locally because the bake step only runs on release.

The deploy also passes `--env-file /dev/null`, so Compose cannot quietly interpolate a local `.env`. Without that the guards are satisfied by whatever file happens to be lying around, and a deploy outside `fnox exec` silently uses stale values instead of failing.

## Mechanics

`compose.prod.yml` and `.justfiles/cicd.justfile` become `.j2` so they can vary on the answer. The single `{{ HOST }}` in the recipe is escaped, since that is just syntax rather than copier's.

## Verified

Generated a project both ways:

| | with `age_recipient` | without |
|---|---|---|
| `fnox.toml`, `compose.secrets.yml` | present | absent |
| `env_file` in `compose.prod.yml` | absent | present (×2) |
| `bake` with no secrets | exit 0 | exit 0 |
| deploy with unset secret | fails loudly | n/a |
| deploy with secret set | exit 0 | n/a |

No stray Jinja in either output.