### PR TITLE
feat(site): publish through the fleet's registry instead of GitHub Pages

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,52 @@
+# ABOUTME: Builds the vibetuner docs and attaches them to the release as site.tar.gz.
+# ABOUTME: The fleet's site publisher places it; nothing here touches storage.
+name: publish-site
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-site
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@v9.0.0
+
+      - name: Build docs
+        working-directory: vibetuner-docs
+        run: uvx --with mkdocs-material mkdocs build --strict --site-dir site
+
+      - name: Package the site
+        run: tar -czf site.tar.gz -C vibetuner-docs/site .
+
+      # sites.yaml in alltuner/infrastructure decides which bucket this lands
+      # in, and the publisher there polls for this asset. Nothing here holds a
+      # storage credential and no self-hosted runner is involved.
+      #
+      # It attaches to whichever release is current, so a repo that versions
+      # itself carries the site with its version. A repo with no releases gets
+      # one rolling `site` release whose asset is replaced in place.
+      - name: Attach it to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="$(gh release view --json tagName -q .tagName 2>/dev/null || true)"
+          if [ -z "$tag" ]; then
+            gh release create site \
+              --title "Site" \
+              --notes "Rolling release carrying the current build of the site." >/dev/null
+            tag=site
+          fi
+          gh release upload "$tag" site.tar.gz --clobber


### PR DESCRIPTION
Builds the same site, then attaches it to the release as `site.tar.gz` instead of deploying to GitHub Pages.

The site publisher in `alltuner/infrastructure` polls for that asset and syncs it into the bucket `sites.yaml` names for this hostname, writing from inside the fleet. So this repo keeps no storage credential and needs no self-hosted runner.

**The Pages workflow stays for now**, deliberately. The bucket has to be filled and verified before DNS moves, and until then the live site is still the Pages one — so both publish during the changeover. Retiring Pages is the last step, not the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmbxWdLwrqjTqvw2ECuoEa