### PR TITLE
docs: the docs site publishes from a release asset, not GitHub Pages

### DIFF
--- a/vibetuner-docs/docs/development.md
+++ b/vibetuner-docs/docs/development.md
@@ -132,11 +132,15 @@ uvx git+https://github.com/alltuner/vibetuner@BRANCH_NAME#subdirectory=vibetuner
 just docs-serve
 # Build docs
 just docs-build
-# Deploy docs to GitHub Pages
-just docs-deploy
 ```
 
 Visit [localhost:8000](http://localhost:8000) to view the documentation site.
+
+There is no deploy recipe. Merging to `main` runs `publish-site.yml`, which
+builds the docs and attaches them to the current GitHub Release as
+`site.tar.gz`. The fleet's site publisher syncs that asset into the bucket
+serving vibetuner.alltuner.com; nothing in this repo holds a storage
+credential.
 
 ### Adding New Features
 
@@ -207,7 +211,6 @@ When you push a tag (e.g., `v0.0.2`), GitHub Actions will:
 1. Build both Python and JavaScript packages
 2. Publish `vibetuner` to PyPI
 3. Publish `@alltuner/vibetuner` to npm
-4. Deploy documentation to GitHub Pages
 
 The workflow is in `.github/workflows/publish.yml`.
 
@@ -344,7 +347,6 @@ just clean               # Clean test artifacts
 # Documentation
 just docs-serve          # Serve docs with live reload
 just docs-build          # Build docs
-just docs-deploy         # Deploy docs to GitHub Pages
 # Releases
 just bump-patch          # Bump patch version
 just bump-minor          # Bump minor version

--- a/vibetuner-docs/docs/llms-full.txt
+++ b/vibetuner-docs/docs/llms-full.txt
@@ -3664,7 +3664,8 @@ just dev  # Should start without errors
 ### Internal Documentation
 
 The `vibetuner-docs/docs/` directory contains the source files for all documentation. These are built using MkDocs and
-deployed to GitHub Pages.
+attached to the current GitHub Release as `site.tar.gz`, which the fleet's site publisher syncs into the bucket serving
+vibetuner.alltuner.com.
 
 **Documentation Structure**:
 


### PR DESCRIPTION
`vibetuner-docs/docs/development.md` still told contributors to deploy the docs to **GitHub Pages** with `just docs-deploy`, in three places. Two problems:

- Pages is disabled on this repo and the Pages workflow is gone. `vibetuner.alltuner.com` is served from the fleet's object storage.
- `docs-deploy` is not a recipe. `.justfiles/docs.justfile` has only `docs-serve` and `docs-build`, so anyone following the docs gets a `just` error and concludes their checkout is broken.

What actually happens now: merging to `main` runs `publish-site.yml`, which builds the mkdocs site and attaches it to the current GitHub Release as `site.tar.gz`. The fleet's site publisher syncs that asset into the bucket serving `vibetuner.alltuner.com`. Nothing in this repo holds a storage credential.

Also fixed the same stale claim in `vibetuner-docs/docs/llms-full.txt`, and dropped "Deploy documentation to GitHub Pages" from the tag-push release list, since a tag push does not do that.

Docs-only change. No workflow, justfile or lockfile changes.

## Left alone, but you may want to look

The **Publishing** section of `development.md` still says a tag push drives packaging and that "the workflow is in `.github/workflows/publish.yml`". That file does not exist — releases go through `release.yml` and Release Please. That is package-release staleness rather than site staleness, so it is out of scope for this sweep and I did not want to guess at the details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195RAs4FJBDCrb8mz6Ffhw3